### PR TITLE
feat(query) Create Query visitor, add missing clauses

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,11 @@
 
 ## 0.0.2
 
-- No documented changes.
+- It is now possible to create a functioning Query, with basic validation. Also CI and release tools have all been set up.
+
+## 0.0.1
+
+- Created blank repo with basic bootstrapping
 
 ## Versioning Policy
 
@@ -23,7 +27,3 @@ snuba-sdk==0.10.1
 ```
 
 A major release `N` implies the previous release `N-1` will no longer receive updates. We generally do not backport bugfixes to older versions unless they are security relevant. However, feel free to ask for backports of specific commits on the bugtracker.
-
-## 0.0.1
-
-- Created blank repo with basic bootstrapping

--- a/README.md
+++ b/README.md
@@ -10,14 +10,81 @@
 [![Discord](https://img.shields.io/discord/621778831602221064)](https://discord.gg/cWnMQeA)
 [![Tests](https://github.com/getsentry/snuba-sdk/workflows/tests/badge.svg)](https://github.com/getsentry/snuba-sdk/actions)
 
+# Examples
+
+Snuba SDK is a tool that allows SnQL queries (the language that Snuba uses) to be built programatically. A SnQL query is represented by a Query object, and has a number of attributes corresponding to different parts of the query.
+
+Queries can be created directly:
+
+```python
+query = Query(
+    dataset="discover",
+    match=Entity("events"),
+    select=[
+        Column("title"),
+        Function("uniq", [Column("event_id")], "uniq_events"),
+    ],
+    groupby=[Column("title")],
+    where=[
+        Condition(Column("timestamp"), Op.GT, datetime.datetime.(2021, 1, 1)),
+        Condition(Column("project_id"), Op.IN, Function("tuple", [1, 2, 3])),
+    ],
+    limit=Limit(10),
+    offset=Offset(0),
+    granularity=Granularity(3600),
+)
+```
+
+Queries can also be built incrementally:
+
+```python
+query = Query("discover", Entity("events"))
+    .set_select(
+        [Column("title"), Function("uniq", [Column("event_id")], "uniq_events")]
+    )
+    .set_groupby([Column("title")])
+    .set_where(
+        [
+            Condition(Column("timestamp"), Op.GT, datetime.datetime.(2021, 1, 1)),
+            Condition(Column("project_id"), Op.IN, Function("tuple", [1, 2, 3])),
+        ]
+    )
+    .set_limit(10)
+    .set_offset(0)
+    .set_granularity(3600)
+```
+
+Once the query is built, it can be translated into a SnQL query that can be sent to Snuba or a human readable query.
+
+```python
+# Outputs a formatted SnQL query
+print(query.print())
+```
+
+This outputs:
+
+```sql
+MATCH (events)
+SELECT title, uniq(event_id) AS uniq_events
+BY title
+WHERE timestamp > toDateTime('2021-01-01T00:00:00.000000')
+AND project_id IN tuple(1, 2, 3)
+LIMIT 10
+OFFSET 0
+GRANULARITY 3600
+```
+
+If an expression in the query is invalid (e.g. `Column(1)`) then an `InvalidExpression` exception will be thrown. If there is a problem with a query, it will throw an `InvalidQuery` exception when `.validate()` or `.translate()` is called.
+
 # TODO List
 
-- ~~Update build/dev tooling to use github actions~~
-- Add missing clauses: having, orderby, limitby, totals
+- ~~Add missing clauses: having, orderby, limitby~~
+- Handle array/tuple literals by converting to `array(...)` and `tuple(...)` functions implicitly
+- Add a utility to convert the old JSON Snuba query format to the new SnQL format
+- Sample support in Entity
 - Subscriptable support (measurements\[fcp.first\])
 - Curried function calls
 - unary conditions
-- Handle array/tuple literals by converting to `array(...)` and `tuple(...)` functions implicitly
 - Complex boolean conditions (AND/OR)
 - Join support
 - Have the Entity object take a set of columns
@@ -30,4 +97,4 @@ Please refer to [CONTRIBUTING.md](https://github.com/getsentry/snuba-sdk/blob/ma
 
 # License
 
-Licensed under BSL with Apache-2.0 conversion in 36 months, see [`LICENSE`](https://github.com/getsentry/snuba-sdk/blob/master/LICENSE)
+Licensed under MIT, see [`LICENSE`](https://github.com/getsentry/snuba-sdk/blob/master/LICENSE)

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 # snuba-sdk - SDK for generating SnQL queries for Snuba
 
-[![PyPi page link -- version](https://img.shields.io/pypi/v/sentry-sdk.svg)](https://pypi.python.org/pypi/sentry-sdk)
+[![PyPi page link -- version](https://img.shields.io/pypi/v/snuba-sdk.svg)](https://pypi.python.org/pypi/snuba-sdk)
 [![Discord](https://img.shields.io/discord/621778831602221064)](https://discord.gg/cWnMQeA)
 [![Tests](https://github.com/getsentry/snuba-sdk/workflows/tests/badge.svg)](https://github.com/getsentry/snuba-sdk/actions)
 

--- a/snuba_sdk/expressions.py
+++ b/snuba_sdk/expressions.py
@@ -5,7 +5,7 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from datetime import date, datetime
 from enum import Enum
-from typing import List, Optional, Set, Union
+from typing import Any, List, Optional, Sequence, Set, Union
 
 from snuba_sdk.snuba import check_array_type, is_aggregation_function
 

--- a/snuba_sdk/expressions.py
+++ b/snuba_sdk/expressions.py
@@ -136,7 +136,14 @@ class Function(Expression):
     alias: Optional[str] = None
 
     def is_aggregate(self) -> bool:
-        return is_aggregation_function(self.function)
+        if is_aggregation_function(self.function):
+            return True
+
+        for param in self.parameters:
+            if isinstance(param, Function) and param.is_aggregate():
+                return True
+
+        return False
 
     def validate(self) -> None:
         if not isinstance(self.function, str):

--- a/snuba_sdk/expressions.py
+++ b/snuba_sdk/expressions.py
@@ -4,7 +4,8 @@ import re
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from datetime import date, datetime
-from typing import Any, List, Optional, Sequence, Set, Union
+from enum import Enum
+from typing import List, Optional, Set, Union
 
 from snuba_sdk.snuba import check_array_type, is_aggregation_function
 
@@ -106,6 +107,15 @@ class Granularity(Expression):
 
 
 @dataclass(frozen=True)
+class Totals(Expression):
+    totals: bool = False
+
+    def validate(self) -> None:
+        if not isinstance(self.totals, bool):
+            raise InvalidExpression("totals must be a boolean")
+
+
+@dataclass(frozen=True)
 class Column(Expression):
     name: str
 
@@ -156,3 +166,41 @@ class Function(Expression):
                 raise InvalidExpression(
                     f"parameter '{param}' of function {self.function} is an invalid type"
                 )
+
+    def __eq__(self, other: object) -> bool:
+        # Don't use the alias to compare equality
+        if not isinstance(other, Function):
+            return False
+
+        return self.function == other.function and self.parameters == other.parameters
+
+
+class Direction(Enum):
+    ASC = "ASC"
+    DESC = "DESC"
+
+
+@dataclass(frozen=True)
+class OrderBy(Expression):
+    exp: Union[Column, Function]
+    direction: Direction
+
+    def validate(self) -> None:
+        if not isinstance(self.exp, (Column, Function)):
+            raise InvalidExpression("OrderBy expression must be a Column or Function")
+        if not isinstance(self.direction, Direction):
+            raise InvalidExpression("OrderBy direction must be a Direction")
+
+
+@dataclass(frozen=True)
+class LimitBy(Expression):
+    column: Column
+    count: int
+
+    def validate(self) -> None:
+        if not isinstance(self.column, Column):
+            raise InvalidExpression("LimitBy can only be used on a Column")
+        if not isinstance(self.count, int) or self.count <= 0 or self.count > 10000:
+            raise InvalidExpression(
+                "LimitBy count must be a positive integer (max 10,000)"
+            )

--- a/snuba_sdk/query_visitors.py
+++ b/snuba_sdk/query_visitors.py
@@ -1,0 +1,321 @@
+from __future__ import annotations
+
+import json
+from abc import ABC, abstractmethod
+from typing import (
+    Generic,
+    List,
+    MutableMapping,
+    Optional,
+    TypeVar,
+    TYPE_CHECKING,
+    Union,
+)
+
+from snuba_sdk.entity import Entity
+from snuba_sdk.conditions import Condition
+from snuba_sdk.expressions import (
+    Column,
+    Function,
+    Granularity,
+    Limit,
+    LimitBy,
+    Offset,
+    OrderBy,
+    Totals,
+)
+from snuba_sdk.visitors import Translation
+
+if TYPE_CHECKING:
+    from snuba_sdk.query import Query
+
+
+class InvalidQuery(Exception):
+    pass
+
+
+QVisited = TypeVar("QVisited")
+
+
+class QueryVisitor(ABC, Generic[QVisited]):
+    def visit(self, query: Query) -> QVisited:
+        returns = {
+            "dataset": self._visit_dataset(query.dataset),
+            "match": self._visit_match(query.match),
+            "select": self._visit_select(query.select),
+            "groupby": self._visit_groupby(query.groupby),
+            "where": self._visit_where(query.where),
+            "having": self._visit_having(query.having),
+            "orderby": self._visit_orderby(query.orderby),
+            "limitby": self._visit_limitby(query.limitby),
+            "limit": self._visit_limit(query.limit),
+            "offset": self._visit_offset(query.offset),
+            "granularity": self._visit_granularity(query.granularity),
+            "totals": self._visit_totals(query.totals),
+        }
+
+        return self._combine(query, returns)
+
+    @abstractmethod
+    def _combine(
+        self,
+        query: Query,
+        returns: MutableMapping[str, QVisited],
+    ) -> QVisited:
+        raise NotImplementedError
+
+    @abstractmethod
+    def _visit_dataset(self, dataset: str) -> QVisited:
+        raise NotImplementedError
+
+    @abstractmethod
+    def _visit_match(self, match: Entity) -> QVisited:
+        raise NotImplementedError
+
+    @abstractmethod
+    def _visit_select(
+        self, select: Optional[List[Union[Column, Function]]]
+    ) -> QVisited:
+        raise NotImplementedError
+
+    @abstractmethod
+    def _visit_groupby(
+        self, groupby: Optional[List[Union[Column, Function]]]
+    ) -> QVisited:
+        raise NotImplementedError
+
+    @abstractmethod
+    def _visit_where(self, where: Optional[List[Condition]]) -> QVisited:
+        raise NotImplementedError
+
+    @abstractmethod
+    def _visit_having(self, having: Optional[List[Condition]]) -> QVisited:
+        raise NotImplementedError
+
+    @abstractmethod
+    def _visit_orderby(self, orderby: Optional[List[OrderBy]]) -> QVisited:
+        raise NotImplementedError
+
+    @abstractmethod
+    def _visit_limitby(self, limitby: Optional[LimitBy]) -> QVisited:
+        raise NotImplementedError
+
+    @abstractmethod
+    def _visit_limit(self, limit: Optional[Limit]) -> QVisited:
+        raise NotImplementedError
+
+    @abstractmethod
+    def _visit_offset(self, offset: Optional[Offset]) -> QVisited:
+        raise NotImplementedError
+
+    @abstractmethod
+    def _visit_granularity(self, granularity: Optional[Granularity]) -> QVisited:
+        raise NotImplementedError
+
+    @abstractmethod
+    def _visit_totals(self, granularity: Optional[Totals]) -> QVisited:
+        raise NotImplementedError
+
+
+class Printer(QueryVisitor[str]):
+    def __init__(self, pretty: bool = False) -> None:
+        self.translator = Translation()
+        self.pretty = pretty
+
+    def _combine(self, query: Query, returns: MutableMapping[str, str]) -> str:
+        clauses = [
+            "match",
+            "select",
+            "groupby",
+            "where",
+            "having",
+            "orderby",
+            "limitby",
+            "limit",
+            "offset",
+            "granularity",
+            "totals",
+        ]
+        separator = "\n" if self.pretty else " "
+        formatted = separator.join([returns[c] for c in clauses if returns[c]])
+        if self.pretty:
+            formatted = f"-- DATASET: {returns['dataset']}\n{formatted}"
+
+        return formatted
+
+    def _visit_dataset(self, dataset: str) -> str:
+        return dataset
+
+    def _visit_match(self, match: Entity) -> str:
+        return f"MATCH {self.translator.visit(match)}"
+
+    def _visit_select(self, select: Optional[List[Union[Column, Function]]]) -> str:
+        if select is not None:
+            return f"SELECT {', '.join(self.translator.visit(s) for s in select)}"
+        return ""
+
+    def _visit_groupby(self, groupby: Optional[List[Union[Column, Function]]]) -> str:
+        if groupby is not None:
+            return f"BY {', '.join(self.translator.visit(g) for g in groupby)}"
+        return ""
+
+    def _visit_where(self, where: Optional[List[Condition]]) -> str:
+        if where is not None:
+            return f"WHERE {' AND '.join(self.translator.visit(w) for w in where)}"
+        return ""
+
+    def _visit_having(self, having: Optional[List[Condition]]) -> str:
+        if having is not None:
+            return f"HAVING {', '.join(self.translator.visit(h) for h in having)}"
+        return ""
+
+    def _visit_orderby(self, orderby: Optional[List[OrderBy]]) -> str:
+        if orderby is not None:
+            return f"ORDER BY {', '.join(self.translator.visit(o) for o in orderby)}"
+        return ""
+
+    def _visit_limitby(self, limitby: Optional[LimitBy]) -> str:
+        if limitby is not None:
+            return f"LIMIT {self.translator.visit(limitby)}"
+        return ""
+
+    def _visit_limit(self, limit: Optional[Limit]) -> str:
+        if limit is not None:
+            return f"LIMIT {self.translator.visit(limit)}"
+        return ""
+
+    def _visit_offset(self, offset: Optional[Offset]) -> str:
+        if offset is not None:
+            return f"OFFSET {self.translator.visit(offset)}"
+        return ""
+
+    def _visit_granularity(self, granularity: Optional[Granularity]) -> str:
+        if granularity is not None:
+            return f"GRANULARITY {self.translator.visit(granularity)}"
+        return ""
+
+    def _visit_totals(self, totals: Optional[Totals]) -> str:
+        if totals is not None:
+            return f"TOTALS {self.translator.visit(totals)}"
+        return ""
+
+
+class Translator(Printer):
+    def __init__(self) -> None:
+        super().__init__(False)
+
+    def _combine(self, query: Query, returns: MutableMapping[str, str]) -> str:
+        formatted_query = super()._combine(query, returns)
+        body = {"dataset": query.dataset, "query": formatted_query}
+
+        return json.dumps(body)
+
+
+class Validator(QueryVisitor[None]):
+    def _combine(self, query: Query, returns: MutableMapping[str, None]) -> None:
+        # TODO: Contextual validations:
+        # - Must have certain conditions (project, timestamp, organization etc.)
+
+        if query.select is None:
+            raise InvalidQuery("query must have at least one column in select")
+
+        # - Orderby must be a field in select
+        if query.orderby is not None:
+            for o in query.orderby:
+                found = False
+                for s in query.select:
+                    if s == o.exp:
+                        found = True
+                        break
+
+                if not found:
+                    raise InvalidQuery(
+                        f"{o.exp} in orderby clause is missing from select clause"
+                    )
+
+        # - limit by must be a field in select
+        if query.limitby is not None:
+            found = False
+            for s in query.select:
+                if s == query.limitby.column:
+                    found = True
+                    break
+
+            if not found:
+                raise InvalidQuery(
+                    f"{query.limitby.column} in limitby clause is missing from select clause"
+                )
+
+        # Top level functions in the select clause must have an alias
+        non_aggregates = []
+        has_aggregates = False
+        for exp in query.select:
+            if isinstance(exp, Function) and not exp.alias:
+                raise InvalidQuery(f"{exp} must have an alias in the select")
+
+            if not isinstance(exp, Function) or not exp.is_aggregate():
+                non_aggregates.append(exp)
+            else:
+                has_aggregates = True
+
+        # Non-aggregate expressions must be in the groupby if there is an aggregate
+        if has_aggregates and len(non_aggregates) > 0:
+            if not query.groupby or len(query.groupby) == 0:
+                raise InvalidQuery(
+                    "groupby must be included if there are aggregations in the select"
+                )
+
+            for group_exp in non_aggregates:
+                if group_exp not in query.groupby:
+                    raise InvalidQuery(f"{group_exp} missing from the groupby")
+
+    def _visit_dataset(self, dataset: str) -> None:
+        pass
+
+    def _visit_match(self, match: Entity) -> None:
+        match.validate()
+
+    def _visit_select(self, select: Optional[List[Union[Column, Function]]]) -> None:
+        if select is not None:
+            for s in select:
+                s.validate()
+
+    def _visit_groupby(self, groupby: Optional[List[Union[Column, Function]]]) -> None:
+        if groupby is not None:
+            for g in groupby:
+                g.validate()
+
+    def _visit_where(self, where: Optional[List[Condition]]) -> None:
+        if where is not None:
+            for w in where:
+                w.validate()
+
+    def _visit_having(self, having: Optional[List[Condition]]) -> None:
+        if having is not None:
+            for h in having:
+                h.validate()
+
+    def _visit_orderby(self, orderby: Optional[List[OrderBy]]) -> None:
+        if orderby is not None:
+            for o in orderby:
+                o.validate()
+
+    def _visit_limitby(self, limitby: Optional[LimitBy]) -> None:
+        if limitby is not None:
+            limitby.validate()
+
+    def _visit_limit(self, limit: Optional[Limit]) -> None:
+        if limit is not None:
+            limit.validate()
+
+    def _visit_offset(self, offset: Optional[Offset]) -> None:
+        if offset is not None:
+            offset.validate()
+
+    def _visit_granularity(self, granularity: Optional[Granularity]) -> None:
+        if granularity is not None:
+            granularity.validate()
+
+    def _visit_totals(self, totals: Optional[Totals]) -> None:
+        if totals is not None:
+            totals.validate()

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -180,6 +180,27 @@ tests = [
         Query(
             dataset="discover",
             match=Entity("events"),
+            select=[
+                Column("title"),
+                Function(
+                    "plus", [Function("count", []), Function("count", [])], "added"
+                ),
+            ],
+            groupby=None,
+            where=[Condition(Column("timestamp"), Op.GT, NOW)],
+            limit=Limit(10),
+            offset=Offset(1),
+            granularity=Granularity(3600),
+        ),
+        InvalidQuery(
+            "groupby must be included if there are aggregations in the select"
+        ),
+        id="groupby can't be None with nested aggregate",
+    ),
+    pytest.param(
+        Query(
+            dataset="discover",
+            match=Entity("events"),
             select=[Column("title"), Function("count", [], "count")],
             groupby=[Column("day")],
             where=[Condition(Column("timestamp"), Op.GT, NOW)],
@@ -189,27 +210,6 @@ tests = [
         ),
         InvalidQuery("Column(name='title') missing from the groupby"),
         id="groupby must include all non aggregates",
-    ),
-    pytest.param(
-        Query(
-            dataset="discover",
-            match=Entity("events"),
-            select=[Column("title"), Function("count", [], "count")],
-            groupby=[Column("day")],
-            where=[Condition(Column("timestamp"), Op.GT, NOW)],
-            orderby=[
-                OrderBy(Column("title"), Direction.ASC),
-                OrderBy(Function("count", []), Direction.DESC),
-                OrderBy(Column("event_id"), Direction.ASC),
-            ],
-            limit=Limit(10),
-            offset=Offset(1),
-            granularity=Granularity(3600),
-        ),
-        InvalidQuery(
-            "Column(name='event_id') in orderby clause is missing from select clause"
-        ),
-        id="All OrderBy must be in the select",
     ),
     pytest.param(
         Query(

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -7,12 +7,16 @@ from snuba_sdk.conditions import Condition, Op
 from snuba_sdk.entity import Entity
 from snuba_sdk.expressions import (
     Column,
+    Direction,
     Function,
     Granularity,
     Limit,
+    LimitBy,
     Offset,
+    OrderBy,
 )
-from snuba_sdk.query import Query, InvalidQuery
+from snuba_sdk.query import Query
+from snuba_sdk.query_visitors import InvalidQuery
 
 
 NOW = datetime(2021, 1, 2, 3, 4, 5, 6, timezone.utc)
@@ -29,14 +33,6 @@ tests = [
             granularity=Granularity(3600),
         ),
         None,
-        (
-            "MATCH (events) "
-            "SELECT event_id "
-            "WHERE timestamp > toDateTime('2021-01-02T03:04:05.000006') "
-            "LIMIT 10 "
-            "OFFSET 1 "
-            "GRANULARITY 3600"
-        ),
         id="basic query",
     ),
     pytest.param(
@@ -53,22 +49,14 @@ tests = [
                 Condition(Function("toHour", [Column("timestamp")]), Op.LTE, NOW),
                 Condition(Column("project_id"), Op.IN, Function("tuple", [1, 2, 3])),
             ],
+            having=[Condition(Function("uniq", [Column("event_id")]), Op.GT, 1)],
+            orderby=[OrderBy(Column("title"), Direction.ASC)],
+            limitby=LimitBy(Column("title"), 5),
             limit=Limit(10),
             offset=Offset(1),
             granularity=Granularity(3600),
         ),
         None,
-        (
-            "MATCH (events) "
-            "SELECT title, uniq(event_id) AS uniq_events "
-            "BY title "
-            "WHERE timestamp > toDateTime('2021-01-02T03:04:05.000006') "
-            "AND toHour(timestamp) <= toDateTime('2021-01-02T03:04:05.000006') "
-            "AND project_id IN tuple(1, 2, 3) "
-            "LIMIT 10 "
-            "OFFSET 1 "
-            "GRANULARITY 3600"
-        ),
         id="complex query",
     ),
     pytest.param(
@@ -79,14 +67,6 @@ tests = [
         .set_offset(1)
         .set_granularity(3600),
         None,
-        (
-            "MATCH (events) "
-            "SELECT event_id "
-            "WHERE timestamp > toDateTime('2021-01-02T03:04:05.000006') "
-            "LIMIT 10 "
-            "OFFSET 1 "
-            "GRANULARITY 3600"
-        ),
         id="basic query with replace",
     ),
     pytest.param(
@@ -102,21 +82,13 @@ tests = [
                 Condition(Column("project_id"), Op.IN, Function("tuple", [1, 2, 3])),
             ]
         )
+        .set_having([Condition(Function("uniq", [Column("event_id")]), Op.GT, 1)])
+        .set_orderby([OrderBy(Column("title"), Direction.ASC)])
+        .set_limitby(LimitBy(Column("title"), 5))
         .set_limit(10)
         .set_offset(1)
         .set_granularity(3600),
         None,
-        (
-            "MATCH (events) "
-            "SELECT title, uniq(event_id) AS uniq_events "
-            "BY title "
-            "WHERE timestamp > toDateTime('2021-01-02T03:04:05.000006') "
-            "AND toHour(timestamp) <= toDateTime('2021-01-02T03:04:05.000006') "
-            "AND project_id IN tuple(1, 2, 3) "
-            "LIMIT 10 "
-            "OFFSET 1 "
-            "GRANULARITY 3600"
-        ),
         id="complex query with replace",
     ),
     pytest.param(
@@ -143,6 +115,22 @@ tests = [
         id="lists and tuples are allowed",
     ),
     pytest.param(
+        Query("discover", Entity("events"))
+        .set_select([Column("event_id"), Column("title")])
+        .set_where([Condition(Column("timestamp"), Op.GT, NOW)])
+        .set_orderby(
+            [
+                OrderBy(Column("event_id"), Direction.ASC),
+                OrderBy(Column("title"), Direction.DESC),
+            ]
+        )
+        .set_limit(10)
+        .set_offset(1)
+        .set_granularity(3600),
+        None,
+        id="multiple ORDER BY",
+    ),
+    pytest.param(
         Query(
             dataset="discover",
             match=Entity("events"),
@@ -154,7 +142,6 @@ tests = [
             granularity=Granularity(3600),
         ),
         InvalidQuery("query must have at least one column in select"),
-        None,
         id="missing select",
     ),
     pytest.param(
@@ -168,23 +155,25 @@ tests = [
             offset=Offset(1),
             granularity=Granularity(3600),
         ),
-        InvalidQuery("count() must have an alias in the select"),
-        None,
-        id="functions must have alias",
+        InvalidQuery(
+            "Function(function='count', parameters=[], alias=None) must have an alias in the select"
+        ),
+        id="functions in the select must have an alias",
     ),
     pytest.param(
         Query(
             dataset="discover",
             match=Entity("events"),
-            select=[Column("title"), Function("count", [])],
+            select=[Column("title"), Function("count", [], "count")],
             groupby=None,
             where=[Condition(Column("timestamp"), Op.GT, NOW)],
             limit=Limit(10),
             offset=Offset(1),
             granularity=Granularity(3600),
         ),
-        InvalidQuery("count() must have an alias in the select"),
-        None,
+        InvalidQuery(
+            "groupby must be included if there are aggregations in the select"
+        ),
         id="groupby can't be None with aggregate",
     ),
     pytest.param(
@@ -198,20 +187,55 @@ tests = [
             offset=Offset(1),
             granularity=Granularity(3600),
         ),
-        InvalidQuery("title missing from the groupby"),
-        None,
+        InvalidQuery("Column(name='title') missing from the groupby"),
         id="groupby must include all non aggregates",
+    ),
+    pytest.param(
+        Query(
+            dataset="discover",
+            match=Entity("events"),
+            select=[Column("title"), Function("count", [], "count")],
+            groupby=[Column("day")],
+            where=[Condition(Column("timestamp"), Op.GT, NOW)],
+            orderby=[
+                OrderBy(Column("title"), Direction.ASC),
+                OrderBy(Function("count", []), Direction.DESC),
+                OrderBy(Column("event_id"), Direction.ASC),
+            ],
+            limit=Limit(10),
+            offset=Offset(1),
+            granularity=Granularity(3600),
+        ),
+        InvalidQuery(
+            "Column(name='event_id') in orderby clause is missing from select clause"
+        ),
+        id="All OrderBy must be in the select",
+    ),
+    pytest.param(
+        Query(
+            dataset="discover",
+            match=Entity("events"),
+            select=[Column("title"), Function("count", [], "count")],
+            groupby=[Column("day")],
+            where=[Condition(Column("timestamp"), Op.GT, NOW)],
+            limitby=LimitBy(Column("event_id"), 5),
+            limit=Limit(10),
+            offset=Offset(1),
+            granularity=Granularity(3600),
+        ),
+        InvalidQuery(
+            "Column(name='event_id') in limitby clause is missing from select clause"
+        ),
+        id="LimitBy must be in the select",
     ),
 ]
 
 
-@pytest.mark.parametrize("query, exception, expected", tests)
-def test_query(
-    query: Query, exception: Optional[Exception], expected: Optional[str]
-) -> None:
+@pytest.mark.parametrize("query, exception", tests)
+def test_query(query: Query, exception: Optional[Exception]) -> None:
     if exception is not None:
         with pytest.raises(type(exception), match=re.escape(str(exception))):
-            query.translate()
+            query.validate()
         return
 
-    assert query.translate() == expected
+    query.validate()

--- a/tests/test_query_visitors.py
+++ b/tests/test_query_visitors.py
@@ -103,6 +103,37 @@ tests = [
         ),
         id="multiple ORDER BY",
     ),
+    pytest.param(
+        Query("discover", Entity("events"))
+        .set_select([Column("event_id"), Column("title")])
+        .set_where([Condition(Column("timestamp"), Op.GT, NOW)])
+        .set_having(
+            [
+                Condition(Function("uniq", [Column("users")]), Op.GT, 1),
+                Condition(Function("count", []), Op.LTE, 1000),
+            ]
+        )
+        .set_orderby(
+            [
+                OrderBy(Column("event_id"), Direction.ASC),
+                OrderBy(Column("title"), Direction.DESC),
+            ]
+        )
+        .set_limit(10)
+        .set_offset(1)
+        .set_granularity(3600),
+        (
+            "MATCH (events)",
+            "SELECT event_id, title",
+            "WHERE timestamp > toDateTime('2021-01-02T03:04:05.000006')",
+            "HAVING uniq(users) > 1 AND count() <= 1000",
+            "ORDER BY event_id ASC, title DESC",
+            "LIMIT 10",
+            "OFFSET 1",
+            "GRANULARITY 3600",
+        ),
+        id="multiple HAVING",
+    ),
 ]
 
 

--- a/tests/test_query_visitors.py
+++ b/tests/test_query_visitors.py
@@ -1,0 +1,126 @@
+import json
+import pytest
+from datetime import datetime, timezone
+from typing import Sequence
+
+from snuba_sdk.conditions import Condition, Op
+from snuba_sdk.entity import Entity
+from snuba_sdk.expressions import (
+    Column,
+    Direction,
+    Function,
+    Granularity,
+    Limit,
+    LimitBy,
+    Offset,
+    OrderBy,
+    Totals,
+)
+from snuba_sdk.query import Query
+
+
+NOW = datetime(2021, 1, 2, 3, 4, 5, 6, timezone.utc)
+tests = [
+    pytest.param(
+        Query("discover", Entity("events"))
+        .set_select([Column("event_id")])
+        .set_where([Condition(Column("timestamp"), Op.GT, NOW)])
+        .set_limit(10)
+        .set_offset(1)
+        .set_granularity(3600),
+        (
+            "MATCH (events)",
+            "SELECT event_id",
+            "WHERE timestamp > toDateTime('2021-01-02T03:04:05.000006')",
+            "LIMIT 10",
+            "OFFSET 1",
+            "GRANULARITY 3600",
+        ),
+        id="basic query",
+    ),
+    pytest.param(
+        Query(
+            dataset="discover",
+            match=Entity("events"),
+            select=[
+                Column("title"),
+                Function("uniq", [Column("event_id")], "uniq_events"),
+            ],
+            groupby=[Column("title")],
+            where=[
+                Condition(Column("timestamp"), Op.GT, NOW),
+                Condition(Function("toHour", [Column("timestamp")]), Op.LTE, NOW),
+                Condition(Column("project_id"), Op.IN, Function("tuple", [1, 2, 3])),
+            ],
+            having=[Condition(Function("uniq", [Column("event_id")]), Op.GT, 1)],
+            orderby=[OrderBy(Column("title"), Direction.ASC)],
+            limitby=LimitBy(Column("title"), 5),
+            limit=Limit(10),
+            offset=Offset(1),
+            granularity=Granularity(3600),
+            totals=Totals(True),
+        ),
+        (
+            "MATCH (events)",
+            "SELECT title, uniq(event_id) AS uniq_events",
+            "BY title",
+            (
+                "WHERE timestamp > toDateTime('2021-01-02T03:04:05.000006') "
+                "AND toHour(timestamp) <= toDateTime('2021-01-02T03:04:05.000006') "
+                "AND project_id IN tuple(1, 2, 3)"
+            ),
+            "HAVING uniq(event_id) > 1",
+            "ORDER BY title ASC",
+            "LIMIT 5 BY title",
+            "LIMIT 10",
+            "OFFSET 1",
+            "GRANULARITY 3600",
+            "TOTALS True",
+        ),
+        id="query with all clauses",
+    ),
+    pytest.param(
+        Query("discover", Entity("events"))
+        .set_select([Column("event_id"), Column("title")])
+        .set_where([Condition(Column("timestamp"), Op.GT, NOW)])
+        .set_orderby(
+            [
+                OrderBy(Column("event_id"), Direction.ASC),
+                OrderBy(Column("title"), Direction.DESC),
+            ]
+        )
+        .set_limit(10)
+        .set_offset(1)
+        .set_granularity(3600),
+        (
+            "MATCH (events)",
+            "SELECT event_id, title",
+            "WHERE timestamp > toDateTime('2021-01-02T03:04:05.000006')",
+            "ORDER BY event_id ASC, title DESC",
+            "LIMIT 10",
+            "OFFSET 1",
+            "GRANULARITY 3600",
+        ),
+        id="multiple ORDER BY",
+    ),
+]
+
+
+@pytest.mark.parametrize("query, clauses", tests)
+def test_print_query(query: Query, clauses: Sequence[str]) -> None:
+    expected = " ".join(clauses)
+    assert str(query) == expected
+
+
+@pytest.mark.parametrize("query, clauses", tests)
+def test_pretty_print_query(query: Query, clauses: Sequence[str]) -> None:
+    joined = "\n".join(clauses)
+    expected = f"-- DATASET: discover\n{joined}"
+    assert query.print() == expected
+
+
+@pytest.mark.parametrize("query, clauses", tests)
+def test_translate_query(query: Query, clauses: Sequence[str]) -> None:
+    joined = " ".join(clauses)
+    body = {"dataset": "discover", "query": joined}
+    assert query.snuba() == json.dumps(body)


### PR DESCRIPTION
- Add the last few missing clauses: having, orderby, limitby, totals.
- I realized that the query needed to be translated into a JSON blob, since
that's what Snuba ultimately expects. That prompted the realization that it
was time to create a QueryVisitor class.
- Add a pretty print and snuba query visitor.