### PR TITLE
feat(curried) Add curried functions

### DIFF
--- a/snuba_sdk/conditions.py
+++ b/snuba_sdk/conditions.py
@@ -4,6 +4,7 @@ from typing import Union
 
 from snuba_sdk.expressions import (
     Column,
+    CurriedFunction,
     Expression,
     Function,
     InvalidExpression,
@@ -27,18 +28,20 @@ class Op(Enum):
 
 @dataclass(frozen=True)
 class Condition(Expression):
-    lhs: Union[Column, Function]
+    lhs: Union[Column, CurriedFunction, Function]
     op: Op
-    rhs: Union[Column, Function, ScalarType]
+    rhs: Union[Column, CurriedFunction, Function, ScalarType]
 
     def validate(self) -> None:
-        if not isinstance(self.lhs, (Column, Function)):
+        if not isinstance(self.lhs, (Column, CurriedFunction, Function)):
             raise InvalidExpression(
-                f"invalid condition: LHS of a condition must be a Column or Function, not {type(self.lhs)}"
+                f"invalid condition: LHS of a condition must be a Column, CurriedFunction or Function, not {type(self.lhs)}"
             )
-        if not isinstance(self.rhs, (Column, Function)) and not is_scalar(self.rhs):
+        if not isinstance(
+            self.rhs, (Column, CurriedFunction, Function)
+        ) and not is_scalar(self.rhs):
             raise InvalidExpression(
-                f"invalid condition: RHS of a condition must be a Column, Function or Scalar not {type(self.rhs)}"
+                f"invalid condition: RHS of a condition must be a Column, CurriedFunction, Function or Scalar not {type(self.rhs)}"
             )
         if not isinstance(self.op, Op):
             raise InvalidExpression(

--- a/snuba_sdk/expressions.py
+++ b/snuba_sdk/expressions.py
@@ -50,11 +50,16 @@ class InvalidArray(Exception):
         )
 
 
-def is_scalar(value: Any, literal: bool = False) -> bool:
+def is_literal(value: Any) -> bool:
+    """
+    Allow simple scalar types but not lists/tuples.
+    """
+    return isinstance(value, tuple(Scalar))
+
+
+def is_scalar(value: Any) -> bool:
     if isinstance(value, tuple(Scalar)):
         return True
-    elif literal:  # Bail if we don't include arrays/tuples
-        return False
     elif isinstance(value, tuple):
         if not all(is_scalar(v) for v in value):
             raise InvalidExpression("tuple must contain only scalar values")
@@ -203,7 +208,7 @@ class CurriedFunction(Expression):
                     f"initializers of function {self.function} must be a Sequence"
                 )
             elif not all(
-                isinstance(param, Column) or is_scalar(param, True)
+                isinstance(param, Column) or is_literal(param)
                 for param in self.initializers
             ):
                 raise InvalidExpression(

--- a/snuba_sdk/query.py
+++ b/snuba_sdk/query.py
@@ -6,6 +6,7 @@ from snuba_sdk.entity import Entity
 from snuba_sdk.expressions import (
     Column,
     Consistent,
+    CurriedFunction,
     Debug,
     Function,
     Granularity,
@@ -44,8 +45,8 @@ class Query:
     # These must be listed in the order that they must appear in the SnQL query.
     dataset: str
     match: Entity
-    select: Optional[List[Union[Column, Function]]] = None
-    groupby: Optional[List[Union[Column, Function]]] = None
+    select: Optional[List[Union[Column, CurriedFunction, Function]]] = None
+    groupby: Optional[List[Union[Column, CurriedFunction, Function]]] = None
     where: Optional[List[Condition]] = None
     having: Optional[List[Condition]] = None
     orderby: Optional[List[OrderBy]] = None
@@ -86,15 +87,19 @@ class Query:
             raise InvalidQuery(f"{match} must be a valid Entity")
         return self._replace("match", match)
 
-    def set_select(self, select: Sequence[Union[Column, Function]]) -> "Query":
-        if not list_type(select, (Column, Function)) or not select:
+    def set_select(
+        self, select: Sequence[Union[Column, CurriedFunction, Function]]
+    ) -> "Query":
+        if not list_type(select, (Column, CurriedFunction, Function)) or not select:
             raise InvalidQuery(
                 "select clause must be a non-empty list of Column and/or Function"
             )
         return self._replace("select", select)
 
-    def set_groupby(self, groupby: Sequence[Union[Column, Function]]) -> "Query":
-        if not list_type(groupby, (Column, Function)):
+    def set_groupby(
+        self, groupby: Sequence[Union[Column, CurriedFunction, Function]]
+    ) -> "Query":
+        if not list_type(groupby, (Column, CurriedFunction, Function)):
             raise InvalidQuery(
                 "groupby clause must be a list of Column and/or Function"
             )

--- a/tests/test_condition.py
+++ b/tests/test_condition.py
@@ -48,7 +48,7 @@ tests = [
         None,
         "",
         InvalidExpression(
-            "invalid condition: LHS of a condition must be a Column or Function, not <class 'str'>"
+            "invalid condition: LHS of a condition must be a Column, CurriedFunction or Function, not <class 'str'>"
         ),
         id="lhs invalid type",
     ),
@@ -64,7 +64,7 @@ tests = [
         None,
         "",
         InvalidExpression(
-            "invalid condition: RHS of a condition must be a Column, Function or Scalar not <enum 'Op'>"
+            "invalid condition: RHS of a condition must be a Column, CurriedFunction, Function or Scalar not <enum 'Op'>"
         ),
         id="rhs invalid type",
     ),

--- a/tests/test_expression.py
+++ b/tests/test_expression.py
@@ -81,7 +81,9 @@ orderby_tests = [
     pytest.param(
         0,
         Direction.DESC,
-        InvalidExpression("OrderBy expression must be a Column or Function"),
+        InvalidExpression(
+            "OrderBy expression must be a Column, CurriedFunction or Function"
+        ),
     ),
     pytest.param(
         Column("foo"), "ASC", InvalidExpression("OrderBy direction must be a Direction")

--- a/tests/test_function.py
+++ b/tests/test_function.py
@@ -4,12 +4,13 @@ from typing import Any, Callable, Optional
 
 from snuba_sdk.conditions import Op
 from snuba_sdk.expressions import (
-    Function,
     Column,
+    CurriedFunction,
+    Function,
     InvalidExpression,
 )
 from snuba_sdk.visitors import Translation
-from tests import col, func
+from tests import col, func, cur_func
 
 
 tests = [
@@ -123,7 +124,92 @@ TRANSLATOR = Translation()
 @pytest.mark.parametrize("func_wrapper, valid, translated, exception", tests)
 def test_functions(
     func_wrapper: Callable[[], Any],
-    valid: Function,
+    valid: Optional[Function],
+    translated: str,
+    exception: Optional[Exception],
+) -> None:
+    def verify() -> None:
+        exp = func_wrapper()
+        assert exp == valid
+        assert TRANSLATOR.visit(exp) == translated
+
+    if exception is not None:
+        with pytest.raises(type(exception), match=re.escape(str(exception))):
+            verify()
+    else:
+        verify()
+
+
+curried_tests = [
+    pytest.param(
+        cur_func(
+            "someFunc",
+            [Column("event_id"), None, "stuff"],
+            [
+                Column("event_id"),
+                None,
+                "stuff",
+                [1, 2, 3],
+                func("toString", [Column("event_id")], "event_id_str"),
+                cur_func("quantile", [0.5], [Column("duration")], "cur_str"),
+            ],
+            "someFunc",
+        ),
+        CurriedFunction(
+            "someFunc",
+            [Column("event_id"), None, "stuff"],
+            [
+                Column("event_id"),
+                None,
+                "stuff",
+                [1, 2, 3],
+                Function("toString", [Column("event_id")], "event_id_str"),
+                CurriedFunction("quantile", [0.5], [Column("duration")], "cur_str"),
+            ],
+            "someFunc",
+        ),
+        "someFunc(event_id, NULL, 'stuff')(event_id, NULL, 'stuff', array(1, 2, 3), toString(event_id) AS event_id_str, quantile(0.5)(duration) AS cur_str) AS someFunc",
+        None,
+        id="all curried possible parameter types",
+    ),
+    pytest.param(
+        cur_func("someFunc", [], [Column("event_id")], "someFunc"),
+        CurriedFunction(
+            "someFunc",
+            [],
+            [Column("event_id")],
+            "someFunc",
+        ),
+        "someFunc()(event_id) AS someFunc",
+        None,
+        id="zero length initializers",
+    ),
+    pytest.param(
+        cur_func("someFunc", None, [Column("event_id")], "someFunc"),
+        CurriedFunction(
+            "someFunc",
+            None,
+            [Column("event_id")],
+            "someFunc",
+        ),
+        "someFunc(event_id) AS someFunc",
+        None,
+        id="None initializers",
+    ),
+    pytest.param(
+        cur_func("foo", [[1, 2, 3]], ["foo"], "invalid"),
+        None,
+        "",
+        InvalidExpression("initializers to function foo must be a scalar or column"),
+        id="invalid initializers",
+    ),
+]
+
+
+@pytest.mark.parametrize("func_wrapper, valid, translated, exception", curried_tests)
+def test_curried_functions(
+    func_wrapper: Callable[[], Any],
+    valid: Optional[CurriedFunction],
     translated: str,
     exception: Optional[Exception],
 ) -> None:

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -7,6 +7,7 @@ from snuba_sdk.conditions import Condition, Op
 from snuba_sdk.entity import Entity
 from snuba_sdk.expressions import (
     Column,
+    CurriedFunction,
     Debug,
     Direction,
     Function,
@@ -74,7 +75,11 @@ tests = [
     pytest.param(
         Query("discover", Entity("events"))
         .set_select(
-            [Column("title"), Function("uniq", [Column("event_id")], "uniq_events")]
+            [
+                Column("title"),
+                Function("uniq", [Column("event_id")], "uniq_events"),
+                CurriedFunction("quantile", [0.5], [Column("duration")], "p50"),
+            ]
         )
         .set_groupby([Column("title")])
         .set_where(
@@ -167,7 +172,7 @@ tests = [
             granularity=Granularity(3600),
         ),
         InvalidQuery(
-            "Function(function='count', parameters=[], alias=None) must have an alias in the select"
+            "Function(function='count', initializers=None, parameters=[], alias=None) must have an alias in the select"
         ),
         id="functions in the select must have an alias",
     ),

--- a/tests/test_query_visitors.py
+++ b/tests/test_query_visitors.py
@@ -7,6 +7,7 @@ from snuba_sdk.conditions import Condition, Op
 from snuba_sdk.entity import Entity
 from snuba_sdk.expressions import (
     Column,
+    CurriedFunction,
     Direction,
     Function,
     Granularity,
@@ -46,6 +47,7 @@ tests = [
             select=[
                 Column("title"),
                 Function("uniq", [Column("event_id")], "uniq_events"),
+                CurriedFunction("quantile", [0.5], [Column("duration")], "p50"),
             ],
             groupby=[Column("title")],
             where=[
@@ -63,7 +65,7 @@ tests = [
         ),
         (
             "MATCH (events SAMPLE 1000)",
-            "SELECT title, uniq(event_id) AS uniq_events",
+            "SELECT title, uniq(event_id) AS uniq_events, quantile(0.5)(duration) AS p50",
             "BY title",
             (
                 "WHERE timestamp > toDateTime('2021-01-02T03:04:05.000006') "


### PR DESCRIPTION
Add CurriedFunctions, which initializers as well as parameters, and are
formatted as `function(initializers)(parameters)`. These are accepted all the
same places a Function is allowed. A Function is now a CurriedFunction with no
initializers. This also makes the parameters optional, which is reflected by not
encoding the parameters if they are None.

There is a chunk of tech debt added here: the legacy API doesn't support curried
functions, they are sent as raw strings e.g. ["quantile(0.5)", "duration", None]
On top of this some users of the legacy API are sending functions in this form
as well e.g. ["apdex(300, duration)", None, None]. Snuba uses a regex grammar to
parse these strings, and it seemed overkill to port that to this SDK just for
this legacy use case. So instead the raw strings are passed through as is. Once
the legacy code is deprecated we can restrict this again.