### PR TITLE
fix(subscriptables) Allow subscriptables in the columns

### DIFF
--- a/snuba_sdk/expressions.py
+++ b/snuba_sdk/expressions.py
@@ -173,7 +173,7 @@ class Column(Expression):
     """
 
     name: str
-    column: Optional[str] = field(init=False, default=None)
+    subscriptable: Optional[str] = field(init=False, default=None)
     key: Optional[str] = field(init=False, default=None)
 
     def validate(self) -> None:
@@ -188,9 +188,9 @@ class Column(Expression):
         # If this is a subscriptable set these values to help with debugging etc.
         # Because this is frozen we can't set the value directly.
         if "[" in self.name:
-            column, key = self.name.split("[", 1)
+            subscriptable, key = self.name.split("[", 1)
             key = key.strip("]")
-            super().__setattr__("column", column)
+            super().__setattr__("subscriptable", subscriptable)
             super().__setattr__("key", key)
 
 

--- a/snuba_sdk/expressions.py
+++ b/snuba_sdk/expressions.py
@@ -73,7 +73,9 @@ def is_scalar(value: Any) -> bool:
     return False
 
 
-column_name_re = re.compile(r"^[a-zA-Z](\w|\.)+$")
+alias_re = re.compile(r"^[a-zA-Z](\w|\.)+$")
+
+column_name_re = re.compile(r"^[a-zA-Z](\w|\.|:)*(\[([a-zA-Z](\w|\.|:)*)\])?$")
 # In theory the function matcher should be the same as the column one.
 # However legacy API sends curried functions as raw strings, and it
 # wasn't worth it to import an entire parsing grammar into the SDK
@@ -155,7 +157,24 @@ class Debug(BooleanFlag):
 
 @dataclass(frozen=True)
 class Column(Expression):
+    """
+    A representation of a single column in the database. Columns are
+    expected to be alpha-numeric, with '.', '_`, and `:` allowed as well.
+    If the column is subscriptable then you can specify the column in the
+    form `column[key]`. The `column` attribute will contain the outer
+    column and `key` will contain the inner key.
+
+    :param name: The column name.
+    :type name: str
+
+    :raises InvalidExpression: If the column name is not a string or has an
+        invalid format.
+
+    """
+
     name: str
+    column: Optional[str] = field(init=False, default=None)
+    key: Optional[str] = field(init=False, default=None)
 
     def validate(self) -> None:
         if not isinstance(self.name, str):
@@ -165,6 +184,14 @@ class Column(Expression):
             raise InvalidExpression(
                 f"column '{self.name}' is empty or contains invalid characters"
             )
+
+        # If this is a subscriptable set these values to help with debugging etc.
+        # Because this is frozen we can't set the value directly.
+        if "[" in self.name:
+            column, key = self.name.split("[", 1)
+            key = key.strip("]")
+            super().__setattr__("column", column)
+            super().__setattr__("key", key)
 
 
 @dataclass(frozen=True)
@@ -220,7 +247,7 @@ class CurriedFunction(Expression):
                 raise InvalidExpression(
                     f"alias '{self.alias}' of function {self.function} must be None or a non-empty string"
                 )
-            if not column_name_re.match(self.alias):
+            if not alias_re.match(self.alias):
                 raise InvalidExpression(
                     f"alias '{self.alias}' of function {self.function} contains invalid characters"
                 )

--- a/tests/test_column.py
+++ b/tests/test_column.py
@@ -103,7 +103,7 @@ def test_columns(
     def verify() -> None:
         exp = Column(column_name)
         assert exp.name == valid[0]
-        assert exp.column == valid[1]
+        assert exp.subscriptable == valid[1]
         assert exp.key == valid[2]
         assert TRANSLATOR.visit(exp) == translated
 

--- a/tests/test_column.py
+++ b/tests/test_column.py
@@ -1,24 +1,63 @@
 import pytest
-from typing import Optional
+import re
+from typing import Optional, Tuple
 
 from snuba_sdk.expressions import (
     Column,
-    Expression,
     InvalidExpression,
 )
 from snuba_sdk.visitors import Translation
 
 tests = [
-    pytest.param("valid", Column("valid"), "valid", None, id="basic column test"),
+    pytest.param("valid", ("valid", None, None), "valid", None, id="basic column test"),
     pytest.param(
-        "valid_", Column("valid_"), "valid_", None, id="underscore column test"
+        "valid_", ("valid_", None, None), "valid_", None, id="underscore column test"
     ),
     pytest.param(
         "va_lid.stuff",
-        Column("va_lid.stuff"),
+        ("va_lid.stuff", None, None),
         "va_lid.stuff",
         None,
         id="dot column test",
+    ),
+    pytest.param(
+        "va_lid:stuff",
+        ("va_lid:stuff", None, None),
+        "va_lid:stuff",
+        None,
+        id="colon column test",
+    ),
+    pytest.param(
+        "a[b]", ("a[b]", "a", "b"), "a[b]", None, id="single char subscriptable"
+    ),
+    pytest.param(
+        "a1[a1]", ("a1[a1]", "a1", "a1"), "a1[a1]", None, id="number subscriptable"
+    ),
+    pytest.param(
+        "a1[a.2]", ("a1[a.2]", "a1", "a.2"), "a1[a.2]", None, id="dot subscriptable"
+    ),
+    pytest.param(
+        "a1.2[a:bdsd]",
+        ("a1.2[a:bdsd]", "a1.2", "a:bdsd"),
+        "a1.2[a:bdsd]",
+        None,
+        id="colon subscriptable",
+    ),
+    pytest.param(
+        "a1[a:b][aasdc]",
+        None,
+        None,
+        InvalidExpression(
+            "column 'a1[a:b][aasdc]' is empty or contains invalid characters"
+        ),
+        id="only one subscriptable",
+    ),
+    pytest.param(
+        "a1[a?]",
+        None,
+        None,
+        InvalidExpression("column 'a1[a?]' is empty or contains invalid characters"),
+        id="invalid subscriptable",
     ),
     pytest.param(
         "_valid",
@@ -57,17 +96,19 @@ TRANSLATOR = Translation()
 @pytest.mark.parametrize("column_name, valid, translated, exception", tests)
 def test_columns(
     column_name: str,
-    valid: Expression,
+    valid: Tuple[str, Optional[str], Optional[str]],
     translated: str,
     exception: Optional[Exception],
 ) -> None:
     def verify() -> None:
         exp = Column(column_name)
-        assert exp == valid
+        assert exp.name == valid[0]
+        assert exp.column == valid[1]
+        assert exp.key == valid[2]
         assert TRANSLATOR.visit(exp) == translated
 
     if exception is not None:
-        with pytest.raises(type(exception), match=str(exception)):
+        with pytest.raises(type(exception), match=re.escape(str(exception))):
             verify()
     else:
         verify()

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -226,7 +226,7 @@ tests = [
             granularity=Granularity(3600),
         ),
         InvalidQuery(
-            "Column(name='title', column=None, key=None) missing from the groupby"
+            "Column(name='title', subscriptable=None, key=None) missing from the groupby"
         ),
         id="groupby must include all non aggregates",
     ),
@@ -243,7 +243,7 @@ tests = [
             granularity=Granularity(3600),
         ),
         InvalidQuery(
-            "Column(name='event_id', column=None, key=None) in limitby clause is missing from select clause"
+            "Column(name='event_id', subscriptable=None, key=None) in limitby clause is missing from select clause"
         ),
         id="LimitBy must be in the select",
     ),

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -43,9 +43,10 @@ tests = [
             match=Entity("events", 0.2),
             select=[
                 Column("title"),
+                Column("tags[release:1]"),
                 Function("uniq", [Column("event_id")], "uniq_events"),
             ],
-            groupby=[Column("title")],
+            groupby=[Column("title"), Column("tags[release:1]")],
             where=[
                 Condition(Column("timestamp"), Op.GT, NOW),
                 Condition(Function("toHour", [Column("timestamp")]), Op.LTE, NOW),
@@ -224,7 +225,9 @@ tests = [
             offset=Offset(1),
             granularity=Granularity(3600),
         ),
-        InvalidQuery("Column(name='title') missing from the groupby"),
+        InvalidQuery(
+            "Column(name='title', column=None, key=None) missing from the groupby"
+        ),
         id="groupby must include all non aggregates",
     ),
     pytest.param(
@@ -240,7 +243,7 @@ tests = [
             granularity=Granularity(3600),
         ),
         InvalidQuery(
-            "Column(name='event_id') in limitby clause is missing from select clause"
+            "Column(name='event_id', column=None, key=None) in limitby clause is missing from select clause"
         ),
         id="LimitBy must be in the select",
     ),


### PR DESCRIPTION
Allow subscriptables (column[key]) in the Column class. If a Column is a
subscriptable, also populate two helper fields column and key.