### PR TITLE
feat(column-entity) Add an alias to entity and column 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ dist: .venv
 format: .venv
 	$(VENV_PATH)/bin/flake8 tests examples snuba_sdk
 	$(VENV_PATH)/bin/black tests examples snuba_sdk
-	$(VENV_PATH)/bin/mypy --config-file mypy.ini tests examples snuba_sdk
+	$(VENV_PATH)/bin/mypy --config-file mypy.ini --strict tests examples snuba_sdk
 
 .PHONY: format
 

--- a/snuba_sdk/column.py
+++ b/snuba_sdk/column.py
@@ -1,0 +1,60 @@
+import re
+from dataclasses import dataclass, field
+from typing import Optional
+
+from snuba_sdk.entity import Entity
+from snuba_sdk.expressions import Expression, InvalidExpression
+
+
+class InvalidColumn(InvalidExpression):
+    pass
+
+
+column_name_re = re.compile(r"^[a-zA-Z](\w|\.|:)*(\[([a-zA-Z](\w|\.|:)*)\])?$")
+
+
+@dataclass(frozen=True)
+class Column(Expression):
+    """
+    A representation of a single column in the database. Columns are
+    expected to be alpha-numeric, with '.', '_`, and `:` allowed as well.
+    If the column is subscriptable then you can specify the column in the
+    form `column[key]`. The `column` attribute will contain the outer
+    column and `key` will contain the inner key.
+
+    :param name: The column name.
+    :type name: str
+
+    :raises InvalidColumn: If the column name is not a string or has an
+        invalid format.
+
+    """
+
+    name: str
+    entity: Optional[Entity] = None
+    subscriptable: Optional[str] = field(init=False, default=None)
+    key: Optional[str] = field(init=False, default=None)
+
+    def validate(self) -> None:
+        if not isinstance(self.name, str):
+            raise InvalidColumn(f"column '{self.name}' must be a string")
+            self.name = str(self.name)
+        if not column_name_re.match(self.name):
+            raise InvalidColumn(
+                f"column '{self.name}' is empty or contains invalid characters"
+            )
+        if self.entity is not None:
+            if not isinstance(self.entity, Entity):
+                raise InvalidColumn(f"column {self.name} expects an Entity")
+            if not self.entity.alias:
+                raise InvalidColumn(
+                    f"column {self.name} expects an Entity with an alias"
+                )
+
+        # If this is a subscriptable set these values to help with debugging etc.
+        # Because this is frozen we can't set the value directly.
+        if "[" in self.name:
+            subscriptable, key = self.name.split("[", 1)
+            key = key.strip("]")
+            super().__setattr__("subscriptable", subscriptable)
+            super().__setattr__("key", key)

--- a/snuba_sdk/entity.py
+++ b/snuba_sdk/entity.py
@@ -15,12 +15,13 @@ class InvalidEntity(Exception):
 @dataclass(frozen=True)
 class Entity(Expression):
     name: str
+    alias: Optional[str] = None
     sample: Optional[Union[int, float]] = None
 
     def validate(self) -> None:
         # TODO: There should be a whitelist of entity names at some point
         if not isinstance(self.name, str) or not entity_name_re.match(self.name):
-            raise InvalidEntity(f"{self.name} is not a valid entity name")
+            raise InvalidEntity(f"'{self.name}' is not a valid entity name")
 
         if self.sample is not None:
             if not isinstance(self.sample, (int, float)):
@@ -35,3 +36,7 @@ class Entity(Expression):
             elif isinstance(self.sample, int):
                 if self.sample < 1:
                     raise InvalidEntity("int samples must be at least 1 (# of rows)")
+
+        if self.alias is not None:
+            if not isinstance(self.alias, str) or not self.alias:
+                raise InvalidEntity(f"'{self.alias}' is not a valid alias")

--- a/snuba_sdk/expressions.py
+++ b/snuba_sdk/expressions.py
@@ -1,11 +1,9 @@
-import re
 from abc import ABC, abstractmethod
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from datetime import date, datetime
-from enum import Enum
 from typing import Any, List, Optional, Sequence, Set, Union
 
-from snuba_sdk.snuba import check_array_type, is_aggregation_function
+from snuba_sdk.snuba import check_array_type
 
 
 class InvalidExpression(Exception):
@@ -71,17 +69,6 @@ def is_scalar(value: Any) -> bool:
         return True
 
     return False
-
-
-alias_re = re.compile(r"^[a-zA-Z](\w|\.)+$")
-
-column_name_re = re.compile(r"^[a-zA-Z](\w|\.|:)*(\[([a-zA-Z](\w|\.|:)*)\])?$")
-# In theory the function matcher should be the same as the column one.
-# However legacy API sends curried functions as raw strings, and it
-# wasn't worth it to import an entire parsing grammar into the SDK
-# just to accomodate that one case. Instead, allow it for now and
-# once that use case is eliminated we can remove this.
-function_name_re = re.compile(r"^[a-zA-Z](\w|[().,]| |\[|\])+$")
 
 
 def _validate_int_literal(
@@ -153,166 +140,3 @@ class Turbo(BooleanFlag):
 @dataclass(frozen=True)
 class Debug(BooleanFlag):
     name: str = "debug"
-
-
-@dataclass(frozen=True)
-class Column(Expression):
-    """
-    A representation of a single column in the database. Columns are
-    expected to be alpha-numeric, with '.', '_`, and `:` allowed as well.
-    If the column is subscriptable then you can specify the column in the
-    form `column[key]`. The `column` attribute will contain the outer
-    column and `key` will contain the inner key.
-
-    :param name: The column name.
-    :type name: str
-
-    :raises InvalidExpression: If the column name is not a string or has an
-        invalid format.
-
-    """
-
-    name: str
-    subscriptable: Optional[str] = field(init=False, default=None)
-    key: Optional[str] = field(init=False, default=None)
-
-    def validate(self) -> None:
-        if not isinstance(self.name, str):
-            raise InvalidExpression(f"column '{self.name}' must be a string")
-            self.name = str(self.name)
-        if not column_name_re.match(self.name):
-            raise InvalidExpression(
-                f"column '{self.name}' is empty or contains invalid characters"
-            )
-
-        # If this is a subscriptable set these values to help with debugging etc.
-        # Because this is frozen we can't set the value directly.
-        if "[" in self.name:
-            subscriptable, key = self.name.split("[", 1)
-            key = key.strip("]")
-            super().__setattr__("subscriptable", subscriptable)
-            super().__setattr__("key", key)
-
-
-@dataclass(frozen=True)
-class CurriedFunction(Expression):
-    function: str
-    initializers: Optional[Sequence[Union[ScalarLiteralType, Column]]] = None
-    parameters: Optional[
-        Sequence[Union[ScalarType, Column, "CurriedFunction", "Function"]]
-    ] = None
-    alias: Optional[str] = None
-
-    def is_aggregate(self) -> bool:
-        if is_aggregation_function(self.function):
-            return True
-
-        if self.parameters is not None:
-            for param in self.parameters:
-                if (
-                    isinstance(param, (CurriedFunction, Function))
-                    and param.is_aggregate()
-                ):
-                    return True
-
-        return False
-
-    def validate(self) -> None:
-        if not isinstance(self.function, str):
-            raise InvalidExpression(f"function '{self.function}' must be a string")
-        if self.function == "":
-            # TODO: Have a whitelist of valid functions to check, maybe even with more
-            # specific parameter type checking
-            raise InvalidExpression("function cannot be empty")
-        if not function_name_re.match(self.function):
-            raise InvalidExpression(
-                f"function '{self.function}' contains invalid characters"
-            )
-
-        if self.initializers is not None:
-            if not isinstance(self.initializers, Sequence):
-                raise InvalidExpression(
-                    f"initializers of function {self.function} must be a Sequence"
-                )
-            elif not all(
-                isinstance(param, Column) or is_literal(param)
-                for param in self.initializers
-            ):
-                raise InvalidExpression(
-                    f"initializers to function {self.function} must be a scalar or column"
-                )
-
-        if self.alias is not None:
-            if not isinstance(self.alias, str) or self.alias == "":
-                raise InvalidExpression(
-                    f"alias '{self.alias}' of function {self.function} must be None or a non-empty string"
-                )
-            if not alias_re.match(self.alias):
-                raise InvalidExpression(
-                    f"alias '{self.alias}' of function {self.function} contains invalid characters"
-                )
-
-        if self.parameters is not None:
-            if not isinstance(self.parameters, Sequence):
-                raise InvalidExpression(
-                    f"parameters of function {self.function} must be a Sequence"
-                )
-            for param in self.parameters:
-                if not isinstance(
-                    param, (Column, CurriedFunction, Function)
-                ) and not is_scalar(param):
-                    assert not isinstance(param, bytes)  # mypy
-                    raise InvalidExpression(
-                        f"parameter '{param}' of function {self.function} is an invalid type"
-                    )
-
-    def __eq__(self, other: object) -> bool:
-        # Don't use the alias to compare equality
-        if not isinstance(other, CurriedFunction):
-            return False
-
-        return (
-            self.function == other.function
-            and self.initializers == other.initializers
-            and self.parameters == other.parameters
-        )
-
-
-@dataclass(frozen=True)
-class Function(CurriedFunction):
-    initializers: Optional[Sequence[Union[ScalarLiteralType, Column]]] = field(
-        init=False, default=None
-    )
-
-
-class Direction(Enum):
-    ASC = "ASC"
-    DESC = "DESC"
-
-
-@dataclass(frozen=True)
-class OrderBy(Expression):
-    exp: Union[Column, CurriedFunction, Function]
-    direction: Direction
-
-    def validate(self) -> None:
-        if not isinstance(self.exp, (Column, CurriedFunction, Function)):
-            raise InvalidExpression(
-                "OrderBy expression must be a Column, CurriedFunction or Function"
-            )
-        if not isinstance(self.direction, Direction):
-            raise InvalidExpression("OrderBy direction must be a Direction")
-
-
-@dataclass(frozen=True)
-class LimitBy(Expression):
-    column: Column
-    count: int
-
-    def validate(self) -> None:
-        if not isinstance(self.column, Column):
-            raise InvalidExpression("LimitBy can only be used on a Column")
-        if not isinstance(self.count, int) or self.count <= 0 or self.count > 10000:
-            raise InvalidExpression(
-                "LimitBy count must be a positive integer (max 10,000)"
-            )

--- a/snuba_sdk/function.py
+++ b/snuba_sdk/function.py
@@ -1,0 +1,118 @@
+import re
+from dataclasses import dataclass, field
+from typing import Optional, Sequence, Union
+
+from snuba_sdk.column import Column
+from snuba_sdk.expressions import (
+    Expression,
+    InvalidExpression,
+    is_literal,
+    is_scalar,
+    ScalarLiteralType,
+    ScalarType,
+)
+from snuba_sdk.snuba import is_aggregation_function
+
+
+class InvalidFunction(InvalidExpression):
+    pass
+
+
+alias_re = re.compile(r"^[a-zA-Z](\w|\.)+$")
+# In theory the function matcher should be the same as the column one.
+# However legacy API sends curried functions as raw strings, and it
+# wasn't worth it to import an entire parsing grammar into the SDK
+# just to accomodate that one case. Instead, allow it for now and
+# once that use case is eliminated we can remove this.
+function_name_re = re.compile(r"^[a-zA-Z](\w|[().,]| |\[|\])+$")
+
+
+@dataclass(frozen=True)
+class CurriedFunction(Expression):
+    function: str
+    initializers: Optional[Sequence[Union[ScalarLiteralType, Column]]] = None
+    parameters: Optional[
+        Sequence[Union[ScalarType, Column, "CurriedFunction", "Function"]]
+    ] = None
+    alias: Optional[str] = None
+
+    def is_aggregate(self) -> bool:
+        if is_aggregation_function(self.function):
+            return True
+
+        if self.parameters is not None:
+            for param in self.parameters:
+                if (
+                    isinstance(param, (CurriedFunction, Function))
+                    and param.is_aggregate()
+                ):
+                    return True
+
+        return False
+
+    def validate(self) -> None:
+        if not isinstance(self.function, str):
+            raise InvalidFunction(f"function '{self.function}' must be a string")
+        if self.function == "":
+            # TODO: Have a whitelist of valid functions to check, maybe even with more
+            # specific parameter type checking
+            raise InvalidFunction("function cannot be empty")
+        if not function_name_re.match(self.function):
+            raise InvalidFunction(
+                f"function '{self.function}' contains invalid characters"
+            )
+
+        if self.initializers is not None:
+            if not isinstance(self.initializers, Sequence):
+                raise InvalidFunction(
+                    f"initializers of function {self.function} must be a Sequence"
+                )
+            elif not all(
+                isinstance(param, Column) or is_literal(param)
+                for param in self.initializers
+            ):
+                raise InvalidFunction(
+                    f"initializers to function {self.function} must be a scalar or column"
+                )
+
+        if self.alias is not None:
+            if not isinstance(self.alias, str) or self.alias == "":
+                raise InvalidFunction(
+                    f"alias '{self.alias}' of function {self.function} must be None or a non-empty string"
+                )
+            if not alias_re.match(self.alias):
+                raise InvalidFunction(
+                    f"alias '{self.alias}' of function {self.function} contains invalid characters"
+                )
+
+        if self.parameters is not None:
+            if not isinstance(self.parameters, Sequence):
+                raise InvalidFunction(
+                    f"parameters of function {self.function} must be a Sequence"
+                )
+            for param in self.parameters:
+                if not isinstance(
+                    param, (Column, CurriedFunction, Function)
+                ) and not is_scalar(param):
+                    assert not isinstance(param, bytes)  # mypy
+                    raise InvalidFunction(
+                        f"parameter '{param}' of function {self.function} is an invalid type"
+                    )
+
+    def __eq__(self, other: object) -> bool:
+        # Don't use the alias to compare equality
+        if not isinstance(other, CurriedFunction):
+            return False
+
+        return (
+            self.function == other.function
+            and self.initializers == other.initializers
+            and self.parameters == other.parameters
+        )
+
+
+@dataclass(frozen=True)
+class Function(CurriedFunction):
+    initializers: Optional[Sequence[Union[ScalarLiteralType, Column]]] = field(
+        init=False, default=None
+    )

--- a/snuba_sdk/legacy.py
+++ b/snuba_sdk/legacy.py
@@ -1,15 +1,11 @@
 from datetime import datetime
 from typing import Any, Mapping, Sequence
 
+from snuba_sdk.column import Column
 from snuba_sdk.conditions import Condition, Op
 from snuba_sdk.entity import Entity
-from snuba_sdk.expressions import (
-    Column,
-    Direction,
-    Function,
-    LimitBy,
-    OrderBy,
-)
+from snuba_sdk.function import Function
+from snuba_sdk.orderby import Direction, LimitBy, OrderBy
 from snuba_sdk.query import Query
 from snuba_sdk.query_visitors import InvalidQuery
 
@@ -57,7 +53,7 @@ def parse_exp(value: Any) -> Any:
 def json_to_snql(body: Mapping[str, Any], entity: str) -> Query:
     dataset = body.get("dataset", "")
     sample = body.get("sample")
-    query = Query(dataset, Entity(entity, sample))
+    query = Query(dataset, Entity(entity, None, sample))
 
     selected_columns = list(map(parse_exp, body.get("selected_columns", [])))
     for a in body.get("aggregations", []):

--- a/snuba_sdk/orderby.py
+++ b/snuba_sdk/orderby.py
@@ -1,0 +1,40 @@
+from dataclasses import dataclass
+from enum import Enum
+from typing import Union
+
+from snuba_sdk.column import Column
+from snuba_sdk.function import CurriedFunction, Function
+from snuba_sdk.expressions import Expression, InvalidExpression
+
+
+class Direction(Enum):
+    ASC = "ASC"
+    DESC = "DESC"
+
+
+@dataclass(frozen=True)
+class OrderBy(Expression):
+    exp: Union[Column, CurriedFunction, Function]
+    direction: Direction
+
+    def validate(self) -> None:
+        if not isinstance(self.exp, (Column, CurriedFunction, Function)):
+            raise InvalidExpression(
+                "OrderBy expression must be a Column, CurriedFunction or Function"
+            )
+        if not isinstance(self.direction, Direction):
+            raise InvalidExpression("OrderBy direction must be a Direction")
+
+
+@dataclass(frozen=True)
+class LimitBy(Expression):
+    column: Column
+    count: int
+
+    def validate(self) -> None:
+        if not isinstance(self.column, Column):
+            raise InvalidExpression("LimitBy can only be used on a Column")
+        if not isinstance(self.count, int) or self.count <= 0 or self.count > 10000:
+            raise InvalidExpression(
+                "LimitBy count must be a positive integer (max 10,000)"
+            )

--- a/snuba_sdk/query.py
+++ b/snuba_sdk/query.py
@@ -1,22 +1,20 @@
 from dataclasses import dataclass, fields, replace
 from typing import Any, List, Optional, Sequence, Union
 
+from snuba_sdk.column import Column
 from snuba_sdk.conditions import BooleanCondition, Condition
+from snuba_sdk.function import CurriedFunction, Function
 from snuba_sdk.entity import Entity
 from snuba_sdk.expressions import (
-    Column,
     Consistent,
-    CurriedFunction,
     Debug,
-    Function,
     Granularity,
     Limit,
-    LimitBy,
     Offset,
-    OrderBy,
     Totals,
     Turbo,
 )
+from snuba_sdk.orderby import LimitBy, OrderBy
 from snuba_sdk.query_visitors import InvalidQuery, Printer, Translator, Validator
 
 

--- a/snuba_sdk/query_visitors.py
+++ b/snuba_sdk/query_visitors.py
@@ -339,8 +339,8 @@ class Validator(QueryVisitor[None]):
         # - Must have certain conditions (project, timestamp, organization etc.)
         ## SUBQUERIES
         # - outer query must only reference columns from inner query, and reference by alias
+        all_columns = self.column_finder.visit(query)
         if isinstance(query.match, main.Query):
-            outer_exps = self.column_finder.visit(query)
             inner_match = set()
             assert query.match.select is not None
             for s in query.match.select:
@@ -349,7 +349,7 @@ class Validator(QueryVisitor[None]):
                 elif isinstance(s, Column):
                     inner_match.add(s.name)
 
-            for c in outer_exps:
+            for c in all_columns:
                 if isinstance(c, Column) and c.name not in inner_match:
                     raise InvalidQuery(
                         f"outer query is referencing column {c.name} that does not exist in subquery"

--- a/snuba_sdk/query_visitors.py
+++ b/snuba_sdk/query_visitors.py
@@ -12,23 +12,21 @@ from typing import (
     Union,
 )
 
-from snuba_sdk.entity import Entity
+from snuba_sdk.column import Column
 from snuba_sdk.conditions import BooleanCondition, Condition
+from snuba_sdk.function import CurriedFunction, Function
+from snuba_sdk.entity import Entity
 from snuba_sdk.expressions import (
-    Column,
     Consistent,
-    CurriedFunction,
     Debug,
     Expression,
-    Function,
     Granularity,
     Limit,
-    LimitBy,
     Offset,
-    OrderBy,
     Totals,
     Turbo,
 )
+from snuba_sdk.orderby import LimitBy, OrderBy
 from snuba_sdk.visitors import ExpressionFinder, Translation
 
 # Import the module due to sphinx autodoc problems
@@ -341,10 +339,7 @@ class Validator(QueryVisitor[None]):
         # - Must have certain conditions (project, timestamp, organization etc.)
         ## SUBQUERIES
         # - outer query must only reference columns from inner query, and reference by alias
-        # - inner query must be valid
         if isinstance(query.match, main.Query):
-            self.visit(query.match)
-
             outer_exps = self.column_finder.visit(query)
             inner_match = set()
             assert query.match.select is not None

--- a/snuba_sdk/visitors.py
+++ b/snuba_sdk/visitors.py
@@ -151,9 +151,14 @@ class ExpressionVisitor(ABC, Generic[TVisited]):
 
 
 class Translation(ExpressionVisitor[str]):
+    def __init__(self, use_entity_aliases: bool = False):
+        # Eventually JOINs will set this to True, but single entity/sub queries
+        # don't support entity aliases.
+        self.use_entity_aliases = use_entity_aliases
+
     def _visit_column(self, column: Column) -> str:
         alias_clause = ""
-        if column.entity is not None:
+        if column.entity is not None and self.use_entity_aliases:
             alias_clause = f"{column.entity.alias}."
         return f"{alias_clause}{column.name}"
 
@@ -188,7 +193,7 @@ class Translation(ExpressionVisitor[str]):
 
     def _visit_entity(self, entity: Entity) -> str:
         alias_clause = ""
-        if entity.alias is not None:
+        if entity.alias is not None and self.use_entity_aliases:
             alias_clause = f"{entity.alias}: "
 
         sample_clause = ""

--- a/snuba_sdk/visitors.py
+++ b/snuba_sdk/visitors.py
@@ -3,27 +3,25 @@ from abc import ABC, abstractmethod
 from datetime import date, datetime
 from typing import Any, Generic, Set, TypeVar
 
-from snuba_sdk.entity import Entity
+from snuba_sdk.column import Column
 from snuba_sdk.conditions import BooleanCondition, Condition
+from snuba_sdk.entity import Entity
+from snuba_sdk.function import CurriedFunction, Function
 from snuba_sdk.expressions import (
-    Column,
     Consistent,
-    CurriedFunction,
     Debug,
     Expression,
-    Function,
     Granularity,
     InvalidExpression,
     is_scalar,
     Limit,
-    LimitBy,
     Offset,
-    OrderBy,
     Scalar,
     ScalarType,
     Totals,
     Turbo,
 )
+from snuba_sdk.orderby import LimitBy, OrderBy
 
 
 # validation regexes
@@ -154,7 +152,10 @@ class ExpressionVisitor(ABC, Generic[TVisited]):
 
 class Translation(ExpressionVisitor[str]):
     def _visit_column(self, column: Column) -> str:
-        return column.name
+        alias_clause = ""
+        if column.entity is not None:
+            alias_clause = f"{column.entity.alias}."
+        return f"{alias_clause}{column.name}"
 
     def _visit_curried_function(self, func: CurriedFunction) -> str:
         alias = "" if func.alias is None else f" AS {func.alias}"
@@ -186,13 +187,17 @@ class Translation(ExpressionVisitor[str]):
         return f"{literal:d}"
 
     def _visit_entity(self, entity: Entity) -> str:
+        alias_clause = ""
+        if entity.alias is not None:
+            alias_clause = f"{entity.alias}: "
+
         sample_clause = ""
         if entity.sample is not None:
             if isinstance(entity.sample, int):
                 sample_clause = f" SAMPLE {entity.sample:d}"
             else:
                 sample_clause = f" SAMPLE {entity.sample:f}"
-        return f"({entity.name}{sample_clause})"
+        return f"({alias_clause}{entity.name}{sample_clause})"
 
     def _visit_condition(self, cond: Condition) -> str:
         rhs = None

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,8 +1,9 @@
 import types
 from typing import Any, Callable, List, Optional
 
+from snuba_sdk.column import Column
 from snuba_sdk.conditions import And, BooleanCondition, Condition, Or
-from snuba_sdk.expressions import Column, CurriedFunction, Function
+from snuba_sdk.function import CurriedFunction, Function
 
 
 # Wrappers to lazily build the expressions

--- a/tests/test_column.py
+++ b/tests/test_column.py
@@ -88,7 +88,7 @@ tests = [
 ]
 
 
-TRANSLATOR = Translation()
+TRANSLATOR = Translation(use_entity_aliases=True)
 
 
 @pytest.mark.parametrize("column_name, valid, translated, exception", tests)

--- a/tests/test_column.py
+++ b/tests/test_column.py
@@ -1,11 +1,9 @@
 import pytest
 import re
-from typing import Optional, Tuple
+from typing import Any, Optional, Tuple
 
-from snuba_sdk.expressions import (
-    Column,
-    InvalidExpression,
-)
+from snuba_sdk.column import Column, InvalidColumn
+from snuba_sdk.entity import Entity
 from snuba_sdk.visitors import Translation
 
 tests = [
@@ -47,7 +45,7 @@ tests = [
         "a1[a:b][aasdc]",
         None,
         None,
-        InvalidExpression(
+        InvalidColumn(
             "column 'a1[a:b][aasdc]' is empty or contains invalid characters"
         ),
         id="only one subscriptable",
@@ -56,35 +54,35 @@ tests = [
         "a1[a?]",
         None,
         None,
-        InvalidExpression("column 'a1[a?]' is empty or contains invalid characters"),
+        InvalidColumn("column 'a1[a?]' is empty or contains invalid characters"),
         id="invalid subscriptable",
     ),
     pytest.param(
         "_valid",
         None,
         None,
-        InvalidExpression("column '_valid' is empty or contains invalid characters"),
+        InvalidColumn("column '_valid' is empty or contains invalid characters"),
         id="underscore column test",
     ),
     pytest.param(
         "..valid",
         None,
         None,
-        InvalidExpression("column '..valid' is empty or contains invalid characters"),
+        InvalidColumn("column '..valid' is empty or contains invalid characters"),
         id="invalid column",
     ),
     pytest.param(
         10,
         None,
         None,
-        InvalidExpression("column '10' must be a string"),
+        InvalidColumn("column '10' must be a string"),
         id="invalid column type",
     ),
     pytest.param(
         "",
         None,
         None,
-        InvalidExpression("column '' is empty or contains invalid characters"),
+        InvalidColumn("column '' is empty or contains invalid characters"),
         id="empty column",
     ),
 ]
@@ -100,15 +98,48 @@ def test_columns(
     translated: str,
     exception: Optional[Exception],
 ) -> None:
-    def verify() -> None:
+    if exception is not None:
+        with pytest.raises(type(exception), match=re.escape(str(exception))):
+            Column(column_name)
+    else:
         exp = Column(column_name)
         assert exp.name == valid[0]
         assert exp.subscriptable == valid[1]
         assert exp.key == valid[2]
         assert TRANSLATOR.visit(exp) == translated
 
+
+entity_tests = [
+    pytest.param("foo", Entity("events", "e"), "e.foo", None, id="column with entity"),
+    pytest.param(
+        "foo",
+        Entity("events"),
+        None,
+        InvalidColumn("column foo expects an Entity with an alias"),
+        id="column with entity but no alias",
+    ),
+    pytest.param(
+        "foo",
+        "events",
+        None,
+        InvalidColumn("column foo expects an Entity"),
+        id="column with non-entity",
+    ),
+]
+
+
+@pytest.mark.parametrize("column_name, entity, translated, exception", entity_tests)
+def test_columns_with_entities(
+    column_name: str,
+    entity: Any,
+    translated: str,
+    exception: Optional[Exception],
+) -> None:
     if exception is not None:
         with pytest.raises(type(exception), match=re.escape(str(exception))):
-            verify()
+            Column(column_name, entity)
     else:
-        verify()
+        exp = Column(column_name, entity)
+        assert exp.name == column_name
+        assert exp.entity == entity
+        assert TRANSLATOR.visit(exp) == translated

--- a/tests/test_condition.py
+++ b/tests/test_condition.py
@@ -2,12 +2,17 @@ import pytest
 import re
 from typing import Any, Callable, Optional
 
-from snuba_sdk.conditions import And, BooleanCondition, BooleanOp, Condition, Op, Or
-from snuba_sdk.expressions import (
-    Function,
-    Column,
-    InvalidExpression,
+from snuba_sdk.column import Column
+from snuba_sdk.conditions import (
+    And,
+    BooleanCondition,
+    BooleanOp,
+    Condition,
+    InvalidCondition,
+    Op,
+    Or,
 )
+from snuba_sdk.function import Function
 from snuba_sdk.visitors import Translation
 from tests import and_cond, bool_cond, cond, or_cond
 
@@ -55,7 +60,7 @@ tests = [
         cond(Column("foo"), Op.IS_NULL, "foo"),
         None,
         "",
-        InvalidExpression(
+        InvalidCondition(
             "invalid condition: unary operators don't have rhs conditions",
         ),
         id="unary too many conditions",
@@ -64,7 +69,7 @@ tests = [
         cond("foo", Op.EQ, "foo"),
         None,
         "",
-        InvalidExpression(
+        InvalidCondition(
             "invalid condition: LHS of a condition must be a Column, CurriedFunction or Function, not <class 'str'>"
         ),
         id="lhs invalid type",
@@ -73,14 +78,14 @@ tests = [
         cond(Column("foo"), Column("bar"), "foo"),
         None,
         "",
-        InvalidExpression("invalid condition: operator of a condition must be an Op"),
+        InvalidCondition("invalid condition: operator of a condition must be an Op"),
         id="op invalid type",
     ),
     pytest.param(
         cond(Column("foo"), Op.EQ, Op.EQ),
         None,
         "",
-        InvalidExpression(
+        InvalidCondition(
             "invalid condition: RHS of a condition must be a Column, CurriedFunction, Function or Scalar not <enum 'Op'>"
         ),
         id="rhs invalid type",
@@ -189,14 +194,14 @@ boolean_tests = [
         ),
         None,
         None,
-        InvalidExpression("invalid boolean: operator of a boolean must be a BooleanOp"),
+        InvalidCondition("invalid boolean: operator of a boolean must be a BooleanOp"),
         id="invalid op",
     ),
     pytest.param(
         and_cond(Condition(Column("a"), Op.EQ, 1)),
         None,
         None,
-        InvalidExpression(
+        InvalidCondition(
             "invalid boolean: conditions must be a list of other conditions"
         ),
         id="not a list",
@@ -205,15 +210,15 @@ boolean_tests = [
         bool_cond(BooleanOp.OR, [Condition(Column("a"), Op.EQ, 1)]),
         None,
         None,
-        InvalidExpression("invalid boolean: must supply at least two conditions"),
+        InvalidCondition("invalid boolean: must supply at least two conditions"),
         id="only one",
     ),
     pytest.param(
         or_cond([Condition(Column("a"), Op.EQ, 1), Column("event_id")]),
         None,
         None,
-        InvalidExpression(
-            "invalid boolean: Column(name='event_id', subscriptable=None, key=None) is not a valid condition"
+        InvalidCondition(
+            "invalid boolean: Column(name='event_id', entity=None, subscriptable=None, key=None) is not a valid condition"
         ),
         id="not all conditions",
     ),

--- a/tests/test_entity.py
+++ b/tests/test_entity.py
@@ -9,13 +9,18 @@ from snuba_sdk.visitors import Translation
 TRANSLATOR = Translation()
 
 tests = [
-    pytest.param("sessions", None, "(sessions)", None),
-    pytest.param("sessions", 0.1, "(sessions SAMPLE 0.100000)", None),
-    pytest.param("sessions", 10, "(sessions SAMPLE 10)", None),
-    pytest.param("", None, None, InvalidEntity("is not a valid entity name")),
-    pytest.param(1, None, None, InvalidEntity("1 is not a valid entity name")),
+    pytest.param("sessions", None, None, "(sessions)", None),
+    pytest.param("sessions", None, 0.1, "(sessions SAMPLE 0.100000)", None),
+    pytest.param("sessions", None, 10, "(sessions SAMPLE 10)", None),
+    pytest.param("sessions", "s", None, "(s: sessions)", None),
+    pytest.param("sessions", "s", 10, "(s: sessions SAMPLE 10)", None),
+    pytest.param("", "s", None, None, InvalidEntity("'' is not a valid entity name")),
+    pytest.param(1, None, None, None, InvalidEntity("'1' is not a valid entity name")),
+    pytest.param("sessions", "", None, None, InvalidEntity("'' is not a valid alias")),
+    pytest.param("sessions", 1, None, None, InvalidEntity("'1' is not a valid alias")),
     pytest.param(
         "sessions",
+        None,
         "0.1",
         None,
         InvalidEntity(
@@ -24,21 +29,28 @@ tests = [
     ),
     pytest.param(
         "sessions",
+        "s",
         -0.1,
         None,
         InvalidEntity("float samples must be between 0.0 and 1.0 (%age of rows)"),
     ),
     pytest.param(
         "sessions",
+        None,
         1.1,
         None,
         InvalidEntity("float samples must be between 0.0 and 1.0 (%age of rows)"),
     ),
     pytest.param(
-        "sessions", 0, None, InvalidEntity("int samples must be at least 1 (# of rows)")
+        "sessions",
+        None,
+        0,
+        None,
+        InvalidEntity("int samples must be at least 1 (# of rows)"),
     ),
     pytest.param(
         "sessions",
+        "s",
         -1,
         None,
         InvalidEntity("int samples must be at least 1 (# of rows)"),
@@ -46,15 +58,19 @@ tests = [
 ]
 
 
-@pytest.mark.parametrize("name, sample, formatted, exception", tests)
+@pytest.mark.parametrize("name, alias, sample, formatted, exception", tests)
 def test_entity(
-    name: Any, sample: Any, formatted: Optional[str], exception: Optional[Exception]
+    name: Any,
+    alias: Any,
+    sample: Any,
+    formatted: Optional[str],
+    exception: Optional[Exception],
 ) -> None:
     if exception is not None:
         with pytest.raises(type(exception), match=re.escape(str(exception))):
-            Entity(name, sample)
+            Entity(name, alias, sample)
     else:
-        entity = Entity(name, sample)
+        entity = Entity(name, alias, sample)
         assert entity.name == name
         assert entity.sample == sample
         if formatted is not None:

--- a/tests/test_entity.py
+++ b/tests/test_entity.py
@@ -6,7 +6,7 @@ from snuba_sdk.entity import Entity, InvalidEntity
 from snuba_sdk.visitors import Translation
 
 
-TRANSLATOR = Translation()
+TRANSLATOR = Translation(use_entity_aliases=True)
 
 tests = [
     pytest.param("sessions", None, None, "(sessions)", None),

--- a/tests/test_expression.py
+++ b/tests/test_expression.py
@@ -2,21 +2,19 @@ import pytest
 import re
 from typing import Any, Optional
 
+from snuba_sdk.column import Column
 from snuba_sdk.expressions import (
-    Column,
     Consistent,
     Debug,
-    Direction,
-    Function,
     Granularity,
     InvalidExpression,
     Limit,
-    LimitBy,
     Offset,
-    OrderBy,
     Totals,
     Turbo,
 )
+from snuba_sdk.function import Function
+from snuba_sdk.orderby import Direction, LimitBy, OrderBy
 
 limit_tests = [
     pytest.param(1, None),

--- a/tests/test_function.py
+++ b/tests/test_function.py
@@ -2,12 +2,12 @@ import pytest
 import re
 from typing import Any, Callable, Optional
 
+from snuba_sdk.column import Column, InvalidColumn
 from snuba_sdk.conditions import Op
-from snuba_sdk.expressions import (
-    Column,
+from snuba_sdk.function import (
     CurriedFunction,
     Function,
-    InvalidExpression,
+    InvalidFunction,
 )
 from snuba_sdk.visitors import Translation
 from tests import col, func, cur_func
@@ -57,28 +57,28 @@ tests = [
         func(1, ["foo"], "invalid"),
         None,
         "",
-        InvalidExpression("function '1' must be a string"),
+        InvalidFunction("function '1' must be a string"),
         id="invalid function",
     ),
     pytest.param(
         func("", ["foo"], "invalid"),
         None,
         "",
-        InvalidExpression("function cannot be empty"),
+        InvalidFunction("function cannot be empty"),
         id="empty function",
     ),
     pytest.param(
         func("¡amigo!", ["foo"], "invalid"),
         None,
         "",
-        InvalidExpression("function '¡amigo!' contains invalid characters"),
+        InvalidFunction("function '¡amigo!' contains invalid characters"),
         id="empty function",
     ),
     pytest.param(
         func("foo", ["foo"], 10),
         None,
         "",
-        InvalidExpression(
+        InvalidFunction(
             "alias '10' of function foo must be None or a non-empty string"
         ),
         id="invalid alias type",
@@ -87,32 +87,28 @@ tests = [
         func("foo", ["foo"], ""),
         None,
         "",
-        InvalidExpression(
-            "alias '' of function foo must be None or a non-empty string"
-        ),
+        InvalidFunction("alias '' of function foo must be None or a non-empty string"),
         id="empty alias",
     ),
     pytest.param(
         func("foo", ["foo"], "¡amigo!"),
         None,
         "",
-        InvalidExpression(
-            "alias '¡amigo!' of function foo contains invalid characters"
-        ),
+        InvalidFunction("alias '¡amigo!' of function foo contains invalid characters"),
         id="invalid alias",
     ),
     pytest.param(
         func("toString", ["foo", Op.EQ, Column("foo")], "invalid"),
         None,
         "",
-        InvalidExpression("parameter 'Op.EQ' of function toString is an invalid type"),
+        InvalidFunction("parameter 'Op.EQ' of function toString is an invalid type"),
         id="invalid function parameter type",
     ),
     pytest.param(
         func("toString", ["foo", col("¡amigo!")], "invalid"),
         None,
         "",
-        InvalidExpression("'¡amigo!' is empty or contains invalid characters"),
+        InvalidColumn("'¡amigo!' is empty or contains invalid characters"),
         id="invalid function parameter",
     ),
 ]
@@ -200,7 +196,7 @@ curried_tests = [
         cur_func("foo", [[1, 2, 3]], ["foo"], "invalid"),
         None,
         "",
-        InvalidExpression("initializers to function foo must be a scalar or column"),
+        InvalidFunction("initializers to function foo must be a scalar or column"),
         id="invalid initializers",
     ),
 ]

--- a/tests/test_invalid_query.py
+++ b/tests/test_invalid_query.py
@@ -2,8 +2,10 @@ import pytest
 import re
 from typing import Any, Mapping, Sequence
 
+from snuba_sdk.column import Column
 from snuba_sdk.entity import Entity
-from snuba_sdk.expressions import Column, Function, InvalidExpression
+from snuba_sdk.expressions import InvalidExpression
+from snuba_sdk.function import Function
 from snuba_sdk.query import Query
 from snuba_sdk.query_visitors import InvalidQuery
 

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -2,20 +2,17 @@ import pytest
 import re
 from datetime import datetime, timezone
 
+from snuba_sdk.column import Column
 from snuba_sdk.conditions import BooleanCondition, BooleanOp, Condition, Op
 from snuba_sdk.entity import Entity
+from snuba_sdk.function import CurriedFunction, Function
 from snuba_sdk.expressions import (
-    Column,
-    CurriedFunction,
     Debug,
-    Direction,
-    Function,
     Granularity,
     Limit,
-    LimitBy,
     Offset,
-    OrderBy,
 )
+from snuba_sdk.orderby import Direction, LimitBy, OrderBy
 from snuba_sdk.query import Query
 from snuba_sdk.query_visitors import InvalidQuery
 
@@ -38,7 +35,7 @@ tests = [
     pytest.param(
         Query(
             dataset="discover",
-            match=Entity("events", 0.2),
+            match=Entity("events", "ev", 0.2),
             select=[
                 Column("title"),
                 Column("tags[release:1]"),
@@ -61,7 +58,7 @@ tests = [
         id="complex query",
     ),
     pytest.param(
-        Query("discover", Entity("events", 0.2))
+        Query("discover", Entity("events", None, 0.2))
         .set_select([Column("event_id")])
         .set_where([Condition(Column("timestamp"), Op.GT, NOW)])
         .set_limit(10)
@@ -309,7 +306,7 @@ invalid_tests = [
             granularity=Granularity(3600),
         ),
         InvalidQuery(
-            "Column(name='title', subscriptable=None, key=None) missing from the groupby"
+            "Column(name='title', entity=None, subscriptable=None, key=None) missing from the groupby"
         ),
         id="groupby must include all non aggregates",
     ),

--- a/tests/test_query_visitors.py
+++ b/tests/test_query_visitors.py
@@ -81,7 +81,7 @@ tests = [
             totals=Totals(True),
         ),
         (
-            "MATCH (e: events SAMPLE 1000)",
+            "MATCH (events SAMPLE 1000)",
             "SELECT title, uniq(event_id) AS uniq_events, quantile(0.5)(duration) AS p50",
             "BY title",
             (
@@ -250,7 +250,7 @@ tests = [
         .set_offset(1)
         .set_granularity(3600),
         (
-            "MATCH { MATCH (ev: events) SELECT toString(event_id) AS new_event, title, timestamp }",
+            "MATCH { MATCH (events) SELECT toString(event_id) AS new_event, title, timestamp }",
             "SELECT uniq(new_event) AS uniq_event, title",
             "BY title",
             "WHERE timestamp IS NOT NULL",


### PR DESCRIPTION
Add an alias field to an entity, and add an entity field to a column. This is in
preparation for adding JOIN support. Having Column dependent on Entity forced a
code restructure which was huge as everything uses Column. Move all complex
expressions into their own modules.