### PR TITLE
feat(dry_run) Add a dry_run flag support

### DIFF
--- a/snuba_sdk/expressions.py
+++ b/snuba_sdk/expressions.py
@@ -140,3 +140,8 @@ class Turbo(BooleanFlag):
 @dataclass(frozen=True)
 class Debug(BooleanFlag):
     name: str = "debug"
+
+
+@dataclass(frozen=True)
+class DryRun(BooleanFlag):
+    name: str = "dry_run"

--- a/snuba_sdk/legacy.py
+++ b/snuba_sdk/legacy.py
@@ -287,6 +287,7 @@ def json_to_snql(body: Mapping[str, Any], entity: str) -> Query:
         "consistent",
         "turbo",
         "debug",
+        "dry_run",
     )
     for extra in extras:
         if body.get(extra) is not None:

--- a/snuba_sdk/query.py
+++ b/snuba_sdk/query.py
@@ -8,6 +8,7 @@ from snuba_sdk.entity import Entity
 from snuba_sdk.expressions import (
     Consistent,
     Debug,
+    DryRun,
     Granularity,
     Limit,
     Offset,
@@ -57,6 +58,7 @@ class Query:
     consistent: Consistent = Consistent(False)
     turbo: Turbo = Turbo(False)
     debug: Debug = Debug(False)
+    dry_run: DryRun = DryRun(False)
 
     def __post_init__(self) -> None:
         """
@@ -160,6 +162,9 @@ class Query:
 
     def set_debug(self, debug: bool) -> "Query":
         return self._replace("debug", Debug(debug))
+
+    def set_dry_run(self, dry_run: bool) -> "Query":
+        return self._replace("dry_run", DryRun(dry_run))
 
     def validate(self) -> None:
         VALIDATOR.visit(self)

--- a/snuba_sdk/visitors.py
+++ b/snuba_sdk/visitors.py
@@ -10,6 +10,7 @@ from snuba_sdk.function import CurriedFunction, Function
 from snuba_sdk.expressions import (
     Consistent,
     Debug,
+    DryRun,
     Expression,
     Granularity,
     InvalidExpression,
@@ -103,6 +104,8 @@ class ExpressionVisitor(ABC, Generic[TVisited]):
             return self._visit_turbo(node)
         elif isinstance(node, Debug):
             return self._visit_debug(node)
+        elif isinstance(node, DryRun):
+            return self._visit_dry_run(node)
 
         assert False, f"Unhandled Expression: {node}"
 
@@ -160,6 +163,10 @@ class ExpressionVisitor(ABC, Generic[TVisited]):
 
     @abstractmethod
     def _visit_debug(self, debug: Debug) -> TVisited:
+        raise NotImplementedError
+
+    @abstractmethod
+    def _visit_dry_run(self, dry_run: DryRun) -> TVisited:
         raise NotImplementedError
 
 
@@ -258,6 +265,9 @@ class Translation(ExpressionVisitor[str]):
     def _visit_debug(self, debug: Debug) -> str:
         return str(debug)
 
+    def _visit_dry_run(self, dry_run: DryRun) -> str:
+        return str(dry_run)
+
 
 class ExpressionFinder(ExpressionVisitor[Set[Expression]]):
     def __init__(self, exp_type: Any) -> None:
@@ -351,4 +361,9 @@ class ExpressionFinder(ExpressionVisitor[Set[Expression]]):
     def _visit_debug(self, debug: Debug) -> Set[Expression]:
         if isinstance(debug, self.exp_type):
             return set([debug])
+        return set()
+
+    def _visit_dry_run(self, dry_run: DryRun) -> Set[Expression]:
+        if isinstance(dry_run, self.exp_type):
+            return set([dry_run])
         return set()

--- a/tests/test_expression.py
+++ b/tests/test_expression.py
@@ -6,6 +6,7 @@ from snuba_sdk.column import Column
 from snuba_sdk.expressions import (
     Consistent,
     Debug,
+    DryRun,
     Granularity,
     InvalidExpression,
     Limit,
@@ -133,6 +134,7 @@ boolean_tests = [
     pytest.param("consistent", Consistent),
     pytest.param("turbo", Turbo),
     pytest.param("debug", Debug),
+    pytest.param("dry_run", DryRun),
 ]
 
 

--- a/tests/test_legacy_api.py
+++ b/tests/test_legacy_api.py
@@ -479,6 +479,35 @@ discover_tests = [
         "discover_events",
         id="exception_stack_column_boolean_condition_arrayjoin_function",
     ),
+    pytest.param(
+        {
+            "dataset": "discover",
+            "project": 2,
+            "selected_columns": ["type", "tags[custom_tag]", "release"],
+            "conditions": [["type", "!=", "transaction"]],
+            "orderby": "timestamp",
+            "limit": 1000,
+            "from_date": "2020-10-17T20:51:46.110774",
+            "to_date": "2021-01-15T20:51:47.110825",
+            "dry_run": True,
+        },
+        (
+            "-- DATASET: discover",
+            "-- DRY_RUN: True",
+            "MATCH (discover_events)",
+            "SELECT type, tags[custom_tag], release",
+            (
+                "WHERE timestamp >= toDateTime('2020-10-17T20:51:46.110774') "
+                "AND timestamp < toDateTime('2021-01-15T20:51:47.110825') "
+                "AND project_id IN tuple(2) "
+                "AND type != 'transaction'"
+            ),
+            "ORDER BY timestamp ASC",
+            "LIMIT 1000",
+        ),
+        "discover_events",
+        id="dry_run_flag",
+    ),
 ]
 
 


### PR DESCRIPTION
Add a dry_run flag that can be used by SnQL to leverage the same flag in the
legacy implementation.

See https://github.com/getsentry/snuba/pull/1781 for how this will be used.