### PR TITLE
fix(column) Be less restrictive with tags

### DIFF
--- a/snuba_sdk/column.py
+++ b/snuba_sdk/column.py
@@ -10,7 +10,7 @@ class InvalidColumn(InvalidExpression):
     pass
 
 
-column_name_re = re.compile(r"^[a-zA-Z](\w|\.|:)*(\[([a-zA-Z](\w|\.|:)*)\])?$")
+column_name_re = re.compile(r"^[a-zA-Z_](\w|\.|:)*(\[([^\[\]]*)\])?$")
 
 
 @dataclass(frozen=True)
@@ -19,7 +19,7 @@ class Column(Expression):
     A representation of a single column in the database. Columns are
     expected to be alpha-numeric, with '.', '_`, and `:` allowed as well.
     If the column is subscriptable then you can specify the column in the
-    form `column[key]`. The `column` attribute will contain the outer
+    form `subscriptable[key]`. The `subscriptable` attribute will contain the outer
     column and `key` will contain the inner key.
 
     :param name: The column name.

--- a/tests/test_column.py
+++ b/tests/test_column.py
@@ -51,17 +51,10 @@ tests = [
         id="only one subscriptable",
     ),
     pytest.param(
-        "a1[a?]",
+        ":_valid",
         None,
         None,
-        InvalidColumn("column 'a1[a?]' is empty or contains invalid characters"),
-        id="invalid subscriptable",
-    ),
-    pytest.param(
-        "_valid",
-        None,
-        None,
-        InvalidColumn("column '_valid' is empty or contains invalid characters"),
+        InvalidColumn("column ':_valid' is empty or contains invalid characters"),
         id="underscore column test",
     ),
     pytest.param(

--- a/tests/test_legacy_api.py
+++ b/tests/test_legacy_api.py
@@ -584,6 +584,47 @@ discover_tests = [
         "sessions",
         id="convert_sets_in_legacy",
     ),
+    pytest.param(
+        {
+            "selected_columns": [],
+            "orderby": "-last_seen",
+            "limit": 1000,
+            "project": [2],
+            "dataset": "events",
+            "from_date": "2021-04-01T20:08:40",
+            "to_date": "2021-04-15T20:08:40",
+            "groupby": ["tags[_userEmail]"],
+            "conditions": [
+                ["tags[_userEmail]", "LIKE", "%%b%%"],
+                ["type", "!=", "transaction"],
+                ["project_id", "IN", [2]],
+            ],
+            "aggregations": [
+                ["count()", "", "times_seen"],
+                ["min", "timestamp", "first_seen"],
+                ["max", "timestamp", "last_seen"],
+            ],
+            "consistent": False,
+        },
+        (
+            "-- DATASET: events",
+            "MATCH (events)",
+            "SELECT count() AS times_seen, min(timestamp) AS first_seen, max(timestamp) AS last_seen",
+            "BY tags[_userEmail]",
+            (
+                "WHERE timestamp >= toDateTime('2021-04-01T20:08:40') "
+                "AND timestamp < toDateTime('2021-04-15T20:08:40') "
+                "AND project_id IN tuple(2) "
+                "AND tags[_userEmail] LIKE '%%b%%' "
+                "AND type != 'transaction' "
+                "AND project_id IN tuple(2)"
+            ),
+            "ORDER BY last_seen DESC",
+            "LIMIT 1000",
+        ),
+        "events",
+        id="handle_underscore_in_columns",
+    ),
 ]
 
 


### PR DESCRIPTION
Allow underscores at the start of columns/tags per the example from prod.