### PR TITLE
fix(groupby) Handle legacy queries with nested aliases of aggregates

### DIFF
--- a/snuba_sdk/function.py
+++ b/snuba_sdk/function.py
@@ -11,7 +11,6 @@ from snuba_sdk.expressions import (
     ScalarLiteralType,
     ScalarType,
 )
-from snuba_sdk.snuba import is_aggregation_function
 
 
 class InvalidFunction(InvalidExpression):
@@ -35,20 +34,6 @@ class CurriedFunction(Expression):
         Sequence[Union[ScalarType, Column, "CurriedFunction", "Function"]]
     ] = None
     alias: Optional[str] = None
-
-    def is_aggregate(self) -> bool:
-        if is_aggregation_function(self.function):
-            return True
-
-        if self.parameters is not None:
-            for param in self.parameters:
-                if (
-                    isinstance(param, (CurriedFunction, Function))
-                    and param.is_aggregate()
-                ):
-                    return True
-
-        return False
 
     def validate(self) -> None:
         if not isinstance(self.function, str):

--- a/snuba_sdk/snuba.py
+++ b/snuba_sdk/snuba.py
@@ -1,6 +1,6 @@
 import numbers
 import re
-from typing import Any, List, Optional
+from typing import Any, List, Optional, Set
 
 # This is supposed to enumerate the functions snuba supports (with their
 # validator) so we can keep control of the functions snuba
@@ -33,6 +33,7 @@ _AGGREGATION_FUNCTIONS_BASE = {
     "avgWeighted",
     "topK",
     "topKWeighted",
+    "transform",
     "groupArray",
     "groupUniqArray",
     "groupArrayInsertAt",
@@ -109,11 +110,15 @@ AGGREGATION_FUNCTIONS = {
 FUNCTION_NAME = re.compile(r"([a-zA-Z_]+)\(")
 
 
-def is_aggregation_function(func_name: str) -> bool:
+def is_aggregation_function(func_name: str, aliases: Optional[Set[str]] = None) -> bool:
     # Special case for legacy functions
     if "(" in func_name:
         matches = FUNCTION_NAME.findall(func_name)
-        return any(func in AGGREGATION_FUNCTIONS for func in matches)
+        if any(func in AGGREGATION_FUNCTIONS for func in matches):
+            return True
+
+        if aliases is not None and any(alias in func_name for alias in aliases):
+            return True
 
     return func_name in AGGREGATION_FUNCTIONS
 


### PR DESCRIPTION
This fix is to handle legacy queries where some of the expressions are functions
on aliases of other aggregate functions, e.g. `avg(x) AS avg_x, minus(avg_x, 2)`
When checking to see if the second function is an aggregate, also check all the
aggregate aliases found in the first pass of the function. I'm aware that this
will not work if aggregates are nested multiple levels down, but this will have
to do for now.  It also fixes a bug where if there is a non-aggregate function
on a column in the groupby, only the original column needs to be in the groupby,
 not the entire expression. E.g. `SELECT count(), toString(stuff) BY stuff`