### PR TITLE
ref(legacy) Add a flag to the query for legacy queries

### DIFF
--- a/snuba_sdk/expressions.py
+++ b/snuba_sdk/expressions.py
@@ -145,3 +145,8 @@ class Debug(BooleanFlag):
 @dataclass(frozen=True)
 class DryRun(BooleanFlag):
     name: str = "dry_run"
+
+
+@dataclass(frozen=True)
+class Legacy(BooleanFlag):
+    name: str = "legacy"

--- a/snuba_sdk/legacy.py
+++ b/snuba_sdk/legacy.py
@@ -9,7 +9,6 @@ from snuba_sdk.function import Function
 from snuba_sdk.orderby import Direction, LimitBy, OrderBy
 from snuba_sdk.query import Query
 
-
 CONDITION_OPERATORS = set(op.value for op in Op)
 
 
@@ -317,4 +316,5 @@ def json_to_snql(body: Mapping[str, Any], entity: str) -> Query:
         if body.get(extra) is not None:
             query = getattr(query, f"set_{extra}")(body.get(extra))
 
+    query.set_legacy(True)
     return query

--- a/snuba_sdk/query.py
+++ b/snuba_sdk/query.py
@@ -3,21 +3,22 @@ from typing import Any, List, Optional, Sequence, Union
 
 from snuba_sdk.column import Column
 from snuba_sdk.conditions import BooleanCondition, Condition
-from snuba_sdk.function import CurriedFunction, Function
 from snuba_sdk.entity import Entity
 from snuba_sdk.expressions import (
     Consistent,
     Debug,
     DryRun,
     Granularity,
+    Legacy,
     Limit,
     Offset,
     Totals,
     Turbo,
 )
-from snuba_sdk.relationships import Join
+from snuba_sdk.function import CurriedFunction, Function
 from snuba_sdk.orderby import LimitBy, OrderBy
 from snuba_sdk.query_visitors import InvalidQuery, Printer, Translator, Validator
+from snuba_sdk.relationships import Join
 
 
 def list_type(vals: Sequence[Any], type_classes: Sequence[Any]) -> bool:
@@ -60,6 +61,7 @@ class Query:
     turbo: Turbo = Turbo(False)
     debug: Debug = Debug(False)
     dry_run: DryRun = DryRun(False)
+    legacy: Legacy = Legacy(False)
 
     def __post_init__(self) -> None:
         """
@@ -172,6 +174,9 @@ class Query:
 
     def set_dry_run(self, dry_run: bool) -> "Query":
         return self._replace("dry_run", DryRun(dry_run))
+
+    def set_legacy(self, legacy: bool) -> "Query":
+        return self._replace("legacy", Legacy(legacy))
 
     def validate(self) -> None:
         VALIDATOR.visit(self)

--- a/tests/test_expression.py
+++ b/tests/test_expression.py
@@ -10,6 +10,7 @@ from snuba_sdk.expressions import (
     DryRun,
     Granularity,
     InvalidExpression,
+    Legacy,
     Limit,
     Offset,
     Totals,
@@ -136,6 +137,7 @@ boolean_tests = [
     pytest.param("turbo", Turbo),
     pytest.param("debug", Debug),
     pytest.param("dry_run", DryRun),
+    pytest.param("legacy", Legacy),
 ]
 
 

--- a/tests/test_query_visitors.py
+++ b/tests/test_query_visitors.py
@@ -112,6 +112,8 @@ tests = [
         .set_totals(False)
         .set_consistent(True)
         .set_turbo(True)
+        .set_dry_run(True)
+        .set_legacy(True)
         .set_debug(True),
         (
             "MATCH (events SAMPLE 0.200000)",
@@ -122,7 +124,13 @@ tests = [
             "OFFSET 1",
             "GRANULARITY 3600",
         ),
-        [("consistent", True), ("turbo", True), ("debug", True)],
+        [
+            ("consistent", True),
+            ("turbo", True),
+            ("debug", True),
+            ("dry_run", True),
+            ("legacy", True),
+        ],
         id="multiple ORDER BY",
     ),
     pytest.param(


### PR DESCRIPTION
This flag gets automatically set to True when a legacy Snuba query is converted to a SnQL query. Snuba can then track this flag for metrics and for special code cases etc.