### PR TITLE
fix(legacy) Strip backticks out of aliases

### DIFF
--- a/snuba_sdk/legacy.py
+++ b/snuba_sdk/legacy.py
@@ -105,6 +105,8 @@ def parse_exp(value: Any) -> Any:
         return parse_scalar(value)
 
     alias = value[2] if len(value) > 2 else None
+    if alias and alias.startswith("`") and alias.endswith("`"):
+        alias = alias[1:-1]
 
     if value[0].endswith("()") and not value[1]:
         return Function(value[0].strip("()"), [], alias)

--- a/tests/test_legacy_api.py
+++ b/tests/test_legacy_api.py
@@ -1135,6 +1135,54 @@ discover_tests = [
         "events",
         id="condition_on_empty_string",
     ),
+    pytest.param(
+        {
+            "selected_columns": [
+                "timestamp",
+                "message",
+                "title",
+                "event_id",
+                "project_id",
+                [
+                    "transform",
+                    [
+                        ["toString", ["project_id"]],
+                        ["array", ["'1'"]],
+                        ["array", ["'proj'"]],
+                        "''",
+                    ],
+                    "`project.name`",
+                ],
+            ],
+            "having": [],
+            "limit": 81,
+            "offset": 0,
+            "project": [1],
+            "dataset": "discover",
+            "from_date": "2021-04-01T20:05:27",
+            "to_date": "2021-04-15T20:05:27",
+            "groupby": [],
+            "conditions": [[["environment", "=", "PROD"]], ["project_id", "IN", [1]]],
+            "aggregations": [],
+            "consistent": False,
+        },
+        (
+            "-- DATASET: discover",
+            "MATCH (events)",
+            "SELECT timestamp, message, title, event_id, project_id, transform(toString(project_id), array('1'), array('proj'), '') AS project.name",
+            (
+                "WHERE timestamp >= toDateTime('2021-04-01T20:05:27') "
+                "AND timestamp < toDateTime('2021-04-15T20:05:27') "
+                "AND project_id IN tuple(1) "
+                "AND environment = 'PROD' "
+                "AND project_id IN tuple(1)"
+            ),
+            "LIMIT 81",
+            "OFFSET 0",
+        ),
+        "events",
+        id="dots_in_alias",
+    ),
 ]
 
 


### PR DESCRIPTION
Some older discover queries were using backticks around aliases, presumably from
before the AST could properly escape aliases. They're not needed anymore.