### PR TITLE
fix(legacy) Handle weird edge case with escaping

### DIFF
--- a/snuba_sdk/legacy.py
+++ b/snuba_sdk/legacy.py
@@ -59,6 +59,14 @@ def parse_datetime(date_str: str) -> datetime:
     raise ValueError(f"{date_str} is not a recognized datetime")
 
 
+def parse_string(value: str) -> str:
+    escaped = value.replace("'", "\\'")
+    if escaped and escaped[-1] == "\\":
+        if len(escaped) == 1 or escaped[-2] != "\\":
+            escaped += "\\"
+    return escaped
+
+
 def parse_scalar(value: Any, only_strings: Optional[bool] = False) -> Any:
     """
     Convert a scalar value into the expected value for the SDK.
@@ -76,10 +84,9 @@ def parse_scalar(value: Any, only_strings: Optional[bool] = False) -> Any:
                 date_scalar = parse_datetime(value)
                 return date_scalar
         except ValueError:
-            escaped = value.replace("'", "\\'")
-            return escaped
+            return parse_string(value)
     elif isinstance(value, str):
-        return value.replace("'", "\\'")
+        return parse_string(value)
 
     return value
 
@@ -98,7 +105,7 @@ def parse_exp(value: Any) -> Any:
             return value
         elif value.startswith("'") and value.endswith("'"):
             value = value[1:-1]
-            return value
+            return parse_string(value)
 
         return Column(value)
     elif not isinstance(value, list):

--- a/tests/test_legacy_api.py
+++ b/tests/test_legacy_api.py
@@ -1183,6 +1183,51 @@ discover_tests = [
         "events",
         id="dots_in_alias",
     ),
+    pytest.param(
+        {
+            "project": [1],
+            "dataset": "events",
+            "from_date": "2021-04-01T20:05:27",
+            "to_date": "2021-04-15T20:05:27",
+            "groupby": ["group_id"],
+            "conditions": [
+                [["positionCaseInsensitive", ["message", "'Api\\'"]], "!=", 0],
+                ["project_id", "IN", [1]],
+                ["group_id", "IN", [1234567890]],
+                ["environment", "IN", ["production"]],
+            ],
+            "aggregations": [
+                ["count()", "", "times_seen"],
+                ["min", "timestamp", "first_seen"],
+                ["max", "timestamp", "last_seen"],
+                ["uniq", "tags[sentry:user]", "count"],
+            ],
+            "consistent": False,
+            "debug": False,
+        },
+        (
+            "-- DATASET: events",
+            "MATCH (events)",
+            (
+                "SELECT count() AS times_seen, "
+                "min(timestamp) AS first_seen, "
+                "max(timestamp) AS last_seen, "
+                "uniq(tags[sentry:user]) AS count"
+            ),
+            "BY group_id",
+            (
+                "WHERE timestamp >= toDateTime('2021-04-01T20:05:27') "
+                "AND timestamp < toDateTime('2021-04-15T20:05:27') "
+                "AND project_id IN tuple(1) "
+                "AND positionCaseInsensitive(message, 'Api\\\\') != 0 "
+                "AND project_id IN tuple(1) "
+                "AND group_id IN tuple(1234567890) "
+                "AND environment IN tuple('production')"
+            ),
+        ),
+        "events",
+        id="quotes_escaped_with_backslash",
+    ),
 ]
 
 


### PR DESCRIPTION
There seems to be a bug in Sentry that sends search strings like this, but since
the legacy endpoint would allow this the SDK should make it work. Sometimes a
string is received with a single backslash on the end, which was incorrectly
escaping the single quote around the string and causing a parsing error. If
there is a trailing backslash, escape it.