### PR TITLE
feat: Allow importing from snuba_sdk directly

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog and versioning
 0.0.17
 ------
 
+- Allow importing directly from snuba_sdk, e.g. `from snuba_sdk import Column, Function`
 - Fix bug where conditions on releases were being incorrectly parsed.
 
 0.0.16

--- a/snuba_sdk/__init__.py
+++ b/snuba_sdk/__init__.py
@@ -1,0 +1,42 @@
+from snuba_sdk.column import Column
+from snuba_sdk.conditions import And, BooleanCondition, BooleanOp, Condition, Op, Or
+from snuba_sdk.entity import Entity
+from snuba_sdk.expressions import (
+    Consistent,
+    Debug,
+    Granularity,
+    Limit,
+    Offset,
+    Totals,
+    Turbo,
+)
+from snuba_sdk.function import CurriedFunction, Function
+from snuba_sdk.orderby import Direction, LimitBy, OrderBy
+from snuba_sdk.query import Query
+from snuba_sdk.relationships import Join, Relationship
+
+__all__ = [
+    "And",
+    "BooleanCondition",
+    "BooleanOp",
+    "Column",
+    "Condition",
+    "Consistent",
+    "CurriedFunction",
+    "Debug",
+    "Direction",
+    "Entity",
+    "Function",
+    "Granularity",
+    "Join",
+    "Limit",
+    "LimitBy",
+    "Offset",
+    "Op",
+    "Or",
+    "OrderBy",
+    "Query",
+    "Relationship",
+    "Totals",
+    "Turbo",
+]

--- a/snuba_sdk/query.py
+++ b/snuba_sdk/query.py
@@ -1,26 +1,24 @@
 from dataclasses import dataclass, fields, replace
 from typing import Any, List, Optional, Sequence, Union
 
-from snuba_sdk import (
-    BooleanCondition,
-    Column,
-    Condition,
+from snuba_sdk.column import Column
+from snuba_sdk.conditions import BooleanCondition, Condition
+from snuba_sdk.entity import Entity
+from snuba_sdk.expressions import (
     Consistent,
-    CurriedFunction,
     Debug,
-    Entity,
-    Function,
+    DryRun,
     Granularity,
-    Join,
+    Legacy,
     Limit,
-    LimitBy,
     Offset,
-    OrderBy,
     Totals,
     Turbo,
 )
-from snuba_sdk.expressions import DryRun, Legacy
+from snuba_sdk.function import CurriedFunction, Function
+from snuba_sdk.orderby import LimitBy, OrderBy
 from snuba_sdk.query_visitors import InvalidQuery, Printer, Translator, Validator
+from snuba_sdk.relationships import Join
 
 
 def list_type(vals: Sequence[Any], type_classes: Sequence[Any]) -> bool:

--- a/snuba_sdk/query.py
+++ b/snuba_sdk/query.py
@@ -1,24 +1,26 @@
 from dataclasses import dataclass, fields, replace
 from typing import Any, List, Optional, Sequence, Union
 
-from snuba_sdk.column import Column
-from snuba_sdk.conditions import BooleanCondition, Condition
-from snuba_sdk.entity import Entity
-from snuba_sdk.expressions import (
+from snuba_sdk import (
+    BooleanCondition,
+    Column,
+    Condition,
     Consistent,
+    CurriedFunction,
     Debug,
-    DryRun,
+    Entity,
+    Function,
     Granularity,
-    Legacy,
+    Join,
     Limit,
+    LimitBy,
     Offset,
+    OrderBy,
     Totals,
     Turbo,
 )
-from snuba_sdk.function import CurriedFunction, Function
-from snuba_sdk.orderby import LimitBy, OrderBy
+from snuba_sdk.expressions import DryRun, Legacy
 from snuba_sdk.query_visitors import InvalidQuery, Printer, Translator, Validator
-from snuba_sdk.relationships import Join
 
 
 def list_type(vals: Sequence[Any], type_classes: Sequence[Any]) -> bool:

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -3,13 +3,24 @@ from datetime import datetime, timezone
 
 import pytest
 
-from snuba_sdk.column import Column
-from snuba_sdk.conditions import BooleanCondition, BooleanOp, Condition, Op
-from snuba_sdk.entity import Entity
-from snuba_sdk.expressions import Debug, Granularity, Limit, Offset
-from snuba_sdk.function import CurriedFunction, Function
-from snuba_sdk.orderby import Direction, LimitBy, OrderBy
-from snuba_sdk.query import Query
+from snuba_sdk import (
+    BooleanCondition,
+    BooleanOp,
+    Column,
+    Condition,
+    CurriedFunction,
+    Debug,
+    Direction,
+    Entity,
+    Function,
+    Granularity,
+    Limit,
+    LimitBy,
+    Offset,
+    Op,
+    OrderBy,
+    Query,
+)
 from snuba_sdk.query_visitors import InvalidQuery
 
 NOW = datetime(2021, 1, 2, 3, 4, 5, 6, timezone.utc)
@@ -91,11 +102,7 @@ tests = [
                 BooleanCondition(
                     BooleanOp.OR,
                     [
-                        Condition(
-                            Function("uniq", [Column("event_id")]),
-                            Op.GTE,
-                            10,
-                        ),
+                        Condition(Function("uniq", [Column("event_id")]), Op.GTE, 10),
                         Condition(
                             CurriedFunction("quantile", [0.5], [Column("duration")]),
                             Op.GTE,


### PR DESCRIPTION
This is a big time saver for users of the SDK since it cleans the code up and
means that users don't have to hunt down which package certain classes are in.
Some things that are meant for special cases (DryRun, Legacy) are not added.