### PR TITLE
fix(escaping) Properly escape strings

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,11 @@
 Changelog and versioning
 ==========================
 
+0.0.19
+------
+
+- Fix escaping in queries. Move escaping from the legacy parser to the translator.
+
 0.0.18
 ------
 

--- a/snuba_sdk/legacy.py
+++ b/snuba_sdk/legacy.py
@@ -60,11 +60,7 @@ def parse_datetime(date_str: str) -> datetime:
 
 
 def parse_string(value: str) -> str:
-    escaped = value.replace("'", "\\'")
-    if escaped and escaped[-1] == "\\":
-        if len(escaped) == 1 or escaped[-2] != "\\":
-            escaped += "\\"
-    return escaped
+    return value
 
 
 def parse_scalar(value: Any, only_strings: Optional[bool] = False) -> Any:

--- a/tests/test_legacy_api.py
+++ b/tests/test_legacy_api.py
@@ -203,7 +203,7 @@ discover_tests = [
             "dataset": "events",
             "project": 2,
             "selected_columns": ["event_id"],
-            "conditions": [["event_id", "LIKE", "stuff \\\" ' \\' stuff"]],
+            "conditions": [["event_id", "LIKE", "stuff \\\" ' \\' stuff\\"]],
             "limit": 4,
             "orderby": ["event_id"],
             "from_date": "2020-10-17T20:51:46.110774",
@@ -217,7 +217,7 @@ discover_tests = [
                 "WHERE timestamp >= toDateTime('2020-10-17T20:51:46.110774') "
                 "AND timestamp < toDateTime('2021-01-15T20:51:47.110825') "
                 "AND project_id IN tuple(2) "
-                "AND event_id LIKE 'stuff \\\" \\' \\\\' stuff'"
+                "AND event_id LIKE 'stuff \\\\\" \\' \\\\\\' stuff\\\\'"
             ),
             "ORDER BY event_id ASC",
             "LIMIT 4",

--- a/tests/test_scalar.py
+++ b/tests/test_scalar.py
@@ -33,7 +33,7 @@ tests = [
     pytest.param("abc", "'abc'"),
     pytest.param(b"abc", "'abc'"),
     pytest.param("a'b''c'", "'a\\'b\\'\\'c\\''"),
-    pytest.param("a\\''b''c'", "'a\\'\\'b\\'\\'c\\''"),
+    pytest.param("a\\''b''c'", "'a\\\\\\'\\'b\\'\\'c\\''"),
     pytest.param("a\nb\nc", "'a\\nb\\nc'"),
     pytest.param([1, 2, 3], "array(1, 2, 3)"),
     pytest.param(


### PR DESCRIPTION
The visitor now correctly escapes ' \ and \n. Snuba requires a change to correctly handle these values as well, so once this is in a release, we'll have to coordinate using it in Sentry and Snuba.