### PR TITLE
fix(validate) Remove groupby checks

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,11 @@
 Changelog and versioning
 ==========================
 
+0.0.20
+------
+
+- Remove brittle, inconsistent and incomplete group by checks.
+
 0.0.19
 ------
 

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -281,59 +281,6 @@ invalid_tests = [
         Query(
             dataset="discover",
             match=Entity("events"),
-            select=[Column("title"), Function("count", [], "count")],
-            groupby=None,
-            where=[Condition(Column("timestamp"), Op.GT, NOW)],
-            limit=Limit(10),
-            offset=Offset(1),
-            granularity=Granularity(3600),
-        ),
-        InvalidQuery(
-            "groupby must be included if there are aggregations in the select"
-        ),
-        id="groupby can't be None with aggregate",
-    ),
-    pytest.param(
-        Query(
-            dataset="discover",
-            match=Entity("events"),
-            select=[
-                Column("title"),
-                Function(
-                    "plus", [Function("count", []), Function("count", [])], "added"
-                ),
-            ],
-            groupby=None,
-            where=[Condition(Column("timestamp"), Op.GT, NOW)],
-            limit=Limit(10),
-            offset=Offset(1),
-            granularity=Granularity(3600),
-        ),
-        InvalidQuery(
-            "groupby must be included if there are aggregations in the select"
-        ),
-        id="groupby can't be None with nested aggregate",
-    ),
-    pytest.param(
-        Query(
-            dataset="discover",
-            match=Entity("events"),
-            select=[Column("title"), Function("count", [], "count")],
-            groupby=[Column("day")],
-            where=[Condition(Column("timestamp"), Op.GT, NOW)],
-            limit=Limit(10),
-            offset=Offset(1),
-            granularity=Granularity(3600),
-        ),
-        InvalidQuery(
-            "Column(name='title', entity=None, subscriptable=None, key=None) missing from the groupby"
-        ),
-        id="groupby must include all non aggregates",
-    ),
-    pytest.param(
-        Query(
-            dataset="discover",
-            match=Entity("events"),
             select=[Column("title")],
             where=[Condition(Column("timestamp"), Op.GT, NOW)],
             limit=Limit(10),


### PR DESCRIPTION
This code has been brittle and difficult to follow for a while, but what pushed
this change over the edge was queries being written for sessions. The `sessions`
column in Sentry is an alias for an aggregate function in Snuba, but the SDK
doesn't know that so it treats it as a non-aggregate and gets upset if it's not
included in the group by. So the SDK would need to know about all such aliases
in Snuba and it's just not worth it. Let Snuba handle this validation.