### PR TITLE
fix(legacy) Try to ensure tag conditions are on strings

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,11 @@
 Changelog and versioning
 ==========================
 
+0.0.21
+------
+
+- Try to convert wrapped conditions on tags to always use string comparisons.
+
 0.0.20
 ------
 

--- a/snuba_sdk/legacy.py
+++ b/snuba_sdk/legacy.py
@@ -173,6 +173,18 @@ def parse_condition(cond: Sequence[Any]) -> Condition:
             lhs.subscriptable == "tags" or lhs.name == "release"
         ):
             only_strings = True
+        elif (
+            isinstance(lhs, Function)
+            and lhs.function == "ifNull"
+            and lhs.parameters
+            and len(lhs.parameters) > 1
+        ):
+            first = lhs.parameters[0]
+            if isinstance(first, Column) and (
+                first.subscriptable == "tags" or first.name == "release"
+            ):
+                only_strings = True
+
         rhs = parse_scalar(cond[2], only_strings=only_strings)
 
     return Condition(parse_exp(cond[0]), Op(cond[1]), rhs)

--- a/tests/test_legacy_api.py
+++ b/tests/test_legacy_api.py
@@ -1325,6 +1325,48 @@ discover_tests = [
         "discover",
         id="crazy_apdex_functions",
     ),
+    pytest.param(
+        {
+            "conditions": [
+                [
+                    ["ifNull", ["tags[event.timestamp]", "''"]],
+                    "=",
+                    "2021-06-06T01:00:00",
+                ],
+                ["type", "!=", "transaction"],
+                ("project_id", "IN", [1]),
+                ("group_id", "IN", [1234567890]),
+            ],
+            "dataset": "events",
+            "from_date": "2021-04-01T20:05:27",
+            "to_date": "2021-04-15T20:05:27",
+            "groupby": [],
+            "limit": 101,
+            "offset": 0,
+            "orderby": ["-timestamp", "-event_id"],
+            "project": ["1818675"],
+            "selected_columns": ["event_id", "group_id", "project_id", "timestamp"],
+        },
+        (
+            "-- DATASET: events",
+            "MATCH (events)",
+            "SELECT event_id, group_id, project_id, timestamp",
+            (
+                "WHERE timestamp >= toDateTime('2021-04-01T20:05:27') "
+                "AND timestamp < toDateTime('2021-04-15T20:05:27') "
+                "AND project_id IN tuple('1818675') "
+                "AND ifNull(tags[event.timestamp], '') = '2021-06-06T01:00:00' "
+                "AND type != 'transaction' "
+                "AND project_id IN tuple(1) "
+                "AND group_id IN tuple(1234567890)"
+            ),
+            "ORDER BY timestamp DESC, event_id DESC",
+            "LIMIT 101",
+            "OFFSET 0",
+        ),
+        "events",
+        id="wrapped_tag_functions",
+    ),
 ]
 
 


### PR DESCRIPTION
Sometimes tag conditions are passed wrapped in functions. In particular with
datetimes, this behaviour in the legacy API was completely ambiguous, and Snuba
would leave the value as a string. In the SnQL translator, it would attempt to
convert the string to a datetime which is incorrect. In order to ensure that
SnQL remains backwards compatible, handle this case as well.