### PR TITLE
fix(legacy) Be less restrictive on aliases

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changelog and versioning
 0.0.22
 ------
 
-- Make aliases less restrictive
+- Allow square brackets in aliases
 
 0.0.21
 ------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,11 @@
 Changelog and versioning
 ==========================
 
+0.0.22
+------
+
+- Make aliases less restrictive
+
 0.0.21
 ------
 

--- a/snuba_sdk/function.py
+++ b/snuba_sdk/function.py
@@ -17,7 +17,7 @@ class InvalidFunction(InvalidExpression):
     pass
 
 
-alias_re = re.compile(r"^[a-zA-Z]([^\s`'\"])*$")
+alias_re = re.compile(r"^[a-zA-Z]([^\s`'\\\"])*$")
 # In theory the function matcher should be the same as the column one.
 # However legacy API sends curried functions as raw strings, and it
 # wasn't worth it to import an entire parsing grammar into the SDK

--- a/snuba_sdk/function.py
+++ b/snuba_sdk/function.py
@@ -17,7 +17,7 @@ class InvalidFunction(InvalidExpression):
     pass
 
 
-alias_re = re.compile(r"^[a-zA-Z](\w|\.)+$")
+alias_re = re.compile(r"^[a-zA-Z]([^\s`'\"])*$")
 # In theory the function matcher should be the same as the column one.
 # However legacy API sends curried functions as raw strings, and it
 # wasn't worth it to import an entire parsing grammar into the SDK

--- a/snuba_sdk/function.py
+++ b/snuba_sdk/function.py
@@ -17,7 +17,7 @@ class InvalidFunction(InvalidExpression):
     pass
 
 
-alias_re = re.compile(r"^[a-zA-Z]([^\s`'\\\"])*$")
+alias_re = re.compile(r"^[a-zA-Z](\w|\.|\[|\])+$")
 # In theory the function matcher should be the same as the column one.
 # However legacy API sends curried functions as raw strings, and it
 # wasn't worth it to import an entire parsing grammar into the SDK

--- a/tests/test_function.py
+++ b/tests/test_function.py
@@ -50,6 +50,13 @@ tests = [
         id="all possible parameter types",
     ),
     pytest.param(
+        func("foo", [Column("foo")], "equation[0]"),
+        Function("foo", [Column("foo")], "equation[0]"),
+        "foo(foo) AS equation[0]",
+        None,
+        id="alias with square brackets",
+    ),
+    pytest.param(
         func(1, ["foo"], "invalid"),
         None,
         "",
@@ -87,10 +94,10 @@ tests = [
         id="empty alias",
     ),
     pytest.param(
-        func("foo", ["foo"], "¡amigo!"),
+        func("foo", ["foo"], "'amigo!"),
         None,
         "",
-        InvalidFunction("alias '¡amigo!' of function foo contains invalid characters"),
+        InvalidFunction("alias ''amigo!' of function foo contains invalid characters"),
         id="invalid alias",
     ),
     pytest.param(


### PR DESCRIPTION
This came up because Sentry was using `equation[0]` as an alias. Ultimately, since we escape aliases with backticks in Snuba, it didn't seem like I should block any alias, except one that would break our own aliases (hence why I blocked the character set ``[`'"\]``