### PR TITLE
fix(legacy) Convert infix conditions to functions

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,11 @@
 Changelog and versioning
 ==========================
 
+0.0.24
+------
+
+- Fix a bug in legacy converter that correctly handles infix conditions inside other functions
+
 0.0.23
 ------
 

--- a/snuba_sdk/conditions.py
+++ b/snuba_sdk/conditions.py
@@ -1,15 +1,10 @@
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Optional, Sequence, Union
+from typing import Mapping, Optional, Sequence, Union
 
 from snuba_sdk.column import Column
+from snuba_sdk.expressions import Expression, InvalidExpression, ScalarType, is_scalar
 from snuba_sdk.function import CurriedFunction, Function
-from snuba_sdk.expressions import (
-    Expression,
-    InvalidExpression,
-    is_scalar,
-    ScalarType,
-)
 
 
 class InvalidCondition(InvalidExpression):
@@ -29,6 +24,37 @@ class Op(Enum):
     NOT_LIKE = "NOT LIKE"
     IS_NULL = "IS NULL"
     IS_NOT_NULL = "IS NOT NULL"
+
+
+class ConditionFunction(Enum):
+    EQ = "equals"
+    NEQ = "notEquals"
+    LTE = "lessOrEquals"
+    GTE = "greaterOrEquals"
+    LT = "less"
+    GT = "greater"
+    IS_NULL = "isNull"
+    IS_NOT_NULL = "isNotNull"
+    LIKE = "like"
+    NOT_LIKE = "notLike"
+    IN = "in"
+    NOT_IN = "notIn"
+
+
+OPERATOR_TO_FUNCTION: Mapping[Op, ConditionFunction] = {
+    Op.GT: ConditionFunction.GT,
+    Op.LT: ConditionFunction.LT,
+    Op.GTE: ConditionFunction.GTE,
+    Op.LTE: ConditionFunction.LTE,
+    Op.EQ: ConditionFunction.EQ,
+    Op.NEQ: ConditionFunction.NEQ,
+    Op.IN: ConditionFunction.IN,
+    Op.NOT_IN: ConditionFunction.NOT_IN,
+    Op.IS_NULL: ConditionFunction.IS_NULL,
+    Op.IS_NOT_NULL: ConditionFunction.IS_NOT_NULL,
+    Op.LIKE: ConditionFunction.LIKE,
+    Op.NOT_LIKE: ConditionFunction.NOT_LIKE,
+}
 
 
 def is_unary(op: Op) -> bool:

--- a/tests/test_legacy_api.py
+++ b/tests/test_legacy_api.py
@@ -1418,6 +1418,69 @@ discover_tests = [
         "events",
         id="string_functions_with_datetimes",
     ),
+    pytest.param(
+        {
+            "aggregations": [],
+            "conditions": [
+                [
+                    [
+                        "or",
+                        [
+                            ["release", "IN", ["hash"]],
+                            [
+                                "or",
+                                [
+                                    ["equals", ["release", "deadbeef"]],
+                                    [
+                                        "or",
+                                        [
+                                            ["equals", ["release", "abadcafe"]],
+                                            ["release", "IN", ["fullhash"]],
+                                        ],
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                    "=",
+                    1,
+                ],
+                ["project_id", "IN", ["1"]],
+            ],
+            "dataset": "sessions",
+            "from_date": "2021-07-22T18:23:15",
+            "to_date": "2021-07-23T18:23:14",
+            "granularity": 86400,
+            "groupby": ["release", "project_id"],
+            "organization": 2,
+            "project": [1],
+            "selected_columns": [
+                "sessions_crashed",
+                "sessions_abnormal",
+                "sessions_errored",
+                "sessions",
+                "project_id",
+                "release",
+            ],
+        },
+        (
+            "-- DATASET: sessions",
+            "MATCH (sessions)",
+            "SELECT sessions_crashed, sessions_abnormal, sessions_errored, sessions, project_id, release",
+            "BY release, project_id",
+            (
+                "WHERE org_id = 2 "
+                "AND started >= toDateTime('2021-07-22T18:23:15') "
+                "AND started < toDateTime('2021-07-23T18:23:14') "
+                "AND project_id IN tuple(1) "
+                "AND or(in(release, tuple('hash')), or(equals(release, deadbeef), or(equals(release, abadcafe), in(release, tuple('fullhash'))))) = 1 "
+                "AND project_id IN tuple('1')"
+            ),
+            "GRANULARITY 86400",
+        ),
+        "sessions",
+        id="conditions_nested_in_or_functions",
+    ),
 ]
 
 


### PR DESCRIPTION
If a legacy function contains an infix condition, convert it to a function with
the correct function operator.

Before, if there was a function call like
```
[
    "or",
    [
        ["equals", ["release", "abadcafe"]],
        ["release", "IN", ["fullhash"]],
    ],
]
```

The second parameter would be evaluated as a function instead of a condition and would throw an Exception.