### PR TITLE
ref(3.9) Upgrade snuba-sdk to use python 3.9

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
-          python-version: '3.6'
+          python-version: '3.9'
 
       - name: Install dependencies
         run: |
@@ -34,7 +34,7 @@ jobs:
     strategy:
       max-parallel: 5
       matrix:
-        python: [3.6,3.7,3.8,3.9]
+        python: [3.7,3.8,3.9]
 
     timeout-minutes: 10
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,10 +1,10 @@
 repos:
   - repo: https://github.com/psf/black
-    rev: 20.8b1
+    rev: 21.10b0
     hooks:
       - id: black
   - repo: git://github.com/pre-commit/pre-commit-hooks
-    rev: v2.4.0
+    rev: v4.0.1
     hooks:
       - id: check-case-conflict
       - id: check-merge-conflict
@@ -17,19 +17,19 @@ repos:
       - id: fix-encoding-pragma
         args: ["--remove"]
   - repo: https://github.com/pycqa/flake8
-    rev: 3.8.4
+    rev: 4.0.1
     hooks:
       - id: flake8
         language_version: python3.9
   - repo: https://github.com/pycqa/isort
-    rev: 5.8.0
+    rev: 5.10.1
     hooks:
       - id: isort
         name: isort (python)
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: 'v0.800'
+    rev: 'v0.910'
     hooks:
     -   id: mypy
         args: [--config-file, mypy.ini, --ignore-missing-imports]
 default_language_version:
-  python: python3.6
+  python: python3.9

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,13 @@
 Changelog and versioning
 ==========================
 
+
+0.1.0
+------
+
+- Move to Python 3.9 and drop support for Python 3.6. Sentry is now using 3.8 so this library can upgrade as well.
+- Update all dependencies to latest and fix subsequent linting errors
+
 0.0.26
 ------
 

--- a/Makefile
+++ b/Makefile
@@ -13,13 +13,13 @@ help:
 	@false
 
 .venv:
-	virtualenv -ppython3.6 $(VENV_PATH)
+	virtualenv -ppython3.9 $(VENV_PATH)
 	. $(VENV_PATH)/bin/activate
 	$(VENV_PATH)/bin/pip install -r test-requirements.txt
 	$(VENV_PATH)/bin/pip install -r linter-requirements.txt
 
 setup-git:
-	pip install 'pre-commit==2.9.3'
+	pip install 'pre-commit==2.15.0'
 	pre-commit install --install-hooks
 
 dist: .venv

--- a/README.rst
+++ b/README.rst
@@ -85,8 +85,8 @@ This outputs:
     OFFSET 0
     GRANULARITY 3600
 
-If an expression in the query is invalid (e.g. ``Column(1)``) then an ``InvalidExpression`` exception will be thrown.
-If there is a problem with a query, it will throw an ``InvalidQuery`` exception when ``.validate()`` or ``.translate()`` is called.
+If an expression in the query is invalid (e.g. ``Column(1)``) then an ``InvalidExpressionError`` exception will be thrown.
+If there is a problem with a query, it will throw an ``InvalidQueryError`` exception when ``.validate()`` or ``.translate()`` is called.
 
 =========
 TODO List

--- a/linter-requirements.txt
+++ b/linter-requirements.txt
@@ -1,7 +1,7 @@
-black==20.8b1
-flake8==3.8.4
+black==21.10b0
+flake8==4.0.1
 flake8-import-order==0.18.1
-mypy==0.790
-flake8-bugbear==20.11.1
-pep8-naming==0.11.1
-isort==5.8.0
+mypy==0.910
+flake8-bugbear==21.9.2
+pep8-naming==0.12.1
+isort==5.10.1

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,8 @@ Snuba-SDK - SnQL SDK for Snuba
 """
 
 import os
-from setuptools import setup, find_packages  # type: ignore
+
+from setuptools import find_packages, setup
 
 here = os.path.abspath(os.path.dirname(__file__))
 
@@ -36,7 +37,7 @@ setup(
     package_data={"snuba_sdk": ["py.typed"]},
     zip_safe=False,
     license="MIT",
-    install_requires=["dataclasses;python_version<='3.6'"],
+    install_requires=[],
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Environment :: Web Environment",
@@ -45,7 +46,6 @@ setup(
         "Operating System :: OS Independent",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",

--- a/snuba_sdk/aliased_expression.py
+++ b/snuba_sdk/aliased_expression.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass
 from typing import Optional
 
 from snuba_sdk.column import Column
-from snuba_sdk.expressions import ALIAS_RE, Expression, InvalidExpression
+from snuba_sdk.expressions import ALIAS_RE, Expression, InvalidExpressionError
 
 
 @dataclass(frozen=True)
@@ -15,7 +15,7 @@ class AliasedExpression(Expression):
 
     :param Expression: The expression to alias.
     :type Expression: Column
-    :raises InvalidExpression: If the expression or alias is invalid.
+    :raises InvalidExpressionError: If the expression or alias is invalid.
     """
 
     # TODO: We should eventually allow Functions here as well, once we think through
@@ -25,14 +25,16 @@ class AliasedExpression(Expression):
 
     def validate(self) -> None:
         if not isinstance(self.exp, Column):
-            raise InvalidExpression("aliased expressions can only contain a Column")
+            raise InvalidExpressionError(
+                "aliased expressions can only contain a Column"
+            )
 
         if self.alias is not None:
             if not isinstance(self.alias, str) or self.alias == "":
-                raise InvalidExpression(
+                raise InvalidExpressionError(
                     f"alias '{self.alias}' of expression must be None or a non-empty string"
                 )
             if not ALIAS_RE.match(self.alias):
-                raise InvalidExpression(
+                raise InvalidExpressionError(
                     f"alias '{self.alias}' of expression contains invalid characters"
                 )

--- a/snuba_sdk/column.py
+++ b/snuba_sdk/column.py
@@ -3,10 +3,10 @@ from dataclasses import dataclass, field
 from typing import Optional
 
 from snuba_sdk.entity import Entity
-from snuba_sdk.expressions import Expression, InvalidExpression
+from snuba_sdk.expressions import Expression, InvalidExpressionError
 
 
-class InvalidColumn(InvalidExpression):
+class InvalidColumnError(InvalidExpressionError):
     pass
 
 
@@ -27,7 +27,7 @@ class Column(Expression):
     :param entity: The entity for that column
     :type name: Optional[Entity]
 
-    :raises InvalidColumn: If the column name is not a string or has an
+    :raises InvalidColumnError: If the column name is not a string or has an
         invalid format.
 
     """
@@ -39,18 +39,18 @@ class Column(Expression):
 
     def validate(self) -> None:
         if not isinstance(self.name, str):
-            raise InvalidColumn(f"column '{self.name}' must be a string")
+            raise InvalidColumnError(f"column '{self.name}' must be a string")
             self.name = str(self.name)
         if not column_name_re.match(self.name):
-            raise InvalidColumn(
+            raise InvalidColumnError(
                 f"column '{self.name}' is empty or contains invalid characters"
             )
 
         if self.entity is not None:
             if not isinstance(self.entity, Entity):
-                raise InvalidColumn(f"column {self.name} expects an Entity")
+                raise InvalidColumnError(f"column {self.name} expects an Entity")
             if not self.entity.alias:
-                raise InvalidColumn(
+                raise InvalidColumnError(
                     f"column {self.name} expects an Entity with an alias"
                 )
 

--- a/snuba_sdk/entity.py
+++ b/snuba_sdk/entity.py
@@ -4,11 +4,10 @@ from typing import Optional
 
 from snuba_sdk.expressions import Expression
 
-
 entity_name_re = re.compile(r"^[a-zA-Z_]+$")
 
 
-class InvalidEntity(Exception):
+class InvalidEntityError(Exception):
     pass
 
 
@@ -21,17 +20,17 @@ class Entity(Expression):
     def validate(self) -> None:
         # TODO: There should be a whitelist of entity names at some point
         if not isinstance(self.name, str) or not entity_name_re.match(self.name):
-            raise InvalidEntity(f"'{self.name}' is not a valid entity name")
+            raise InvalidEntityError(f"'{self.name}' is not a valid entity name")
 
         if self.sample is not None:
             if not isinstance(self.sample, float):
-                raise InvalidEntity("sample must be a float")
+                raise InvalidEntityError("sample must be a float")
             elif self.sample <= 0.0:
-                raise InvalidEntity("samples must be greater than 0.0")
+                raise InvalidEntityError("samples must be greater than 0.0")
 
         if self.alias is not None:
             if not isinstance(self.alias, str) or not self.alias:
-                raise InvalidEntity(f"'{self.alias}' is not a valid alias")
+                raise InvalidEntityError(f"'{self.alias}' is not a valid alias")
 
 
 # TODO: This should be handled by the users of the SDK, not the SDK itself.

--- a/snuba_sdk/expressions.py
+++ b/snuba_sdk/expressions.py
@@ -5,7 +5,7 @@ from datetime import date, datetime
 from typing import Any, List, Optional, Sequence, Set, Union
 
 
-class InvalidExpression(Exception):
+class InvalidExpressionError(Exception):
     pass
 
 
@@ -39,7 +39,7 @@ Scalar: Set[type] = {
 }
 
 
-class InvalidArray(Exception):
+class InvalidArrayError(Exception):
     def __init__(self, value: List[Any]) -> None:
         value_str = f"{value}"
         if len(value_str) > 10:
@@ -62,7 +62,7 @@ def is_scalar(value: Any) -> bool:
         return True
     elif isinstance(value, (tuple, list)):
         if not all(is_scalar(v) or isinstance(v, Expression) for v in value):
-            raise InvalidExpression("tuple/array must contain only scalar values")
+            raise InvalidExpressionError("tuple/array must contain only scalar values")
         return True
 
     return False
@@ -72,11 +72,11 @@ def _validate_int_literal(
     name: str, literal: int, minn: Optional[int], maxn: Optional[int]
 ) -> None:
     if not isinstance(literal, int):
-        raise InvalidExpression(f"{name} '{literal}' must be an integer")
+        raise InvalidExpressionError(f"{name} '{literal}' must be an integer")
     if minn is not None and literal < minn:
-        raise InvalidExpression(f"{name} '{literal}' must be at least {minn:,}")
+        raise InvalidExpressionError(f"{name} '{literal}' must be at least {minn:,}")
     elif maxn is not None and literal > maxn:
-        raise InvalidExpression(f"{name} '{literal}' is capped at {maxn:,}")
+        raise InvalidExpressionError(f"{name} '{literal}' is capped at {maxn:,}")
 
 
 @dataclass(frozen=True)
@@ -109,7 +109,7 @@ class ParentAPI(Expression):
 
     def validate(self) -> None:
         if not isinstance(self.name, str) or self.name == "":
-            raise InvalidExpression(f"{self.name} must be non-empty string")
+            raise InvalidExpressionError(f"{self.name} must be non-empty string")
 
 
 @dataclass(frozen=True)
@@ -119,7 +119,7 @@ class BooleanFlag(Expression):
 
     def validate(self) -> None:
         if not isinstance(self.value, bool):
-            raise InvalidExpression(f"{self.name} must be a boolean")
+            raise InvalidExpressionError(f"{self.name} must be a boolean")
 
     def __bool__(self) -> bool:
         return self.value

--- a/snuba_sdk/function.py
+++ b/snuba_sdk/function.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import re
 from dataclasses import dataclass, field
 from typing import Optional, Sequence, Union
@@ -6,7 +8,7 @@ from snuba_sdk.column import Column
 from snuba_sdk.expressions import (
     ALIAS_RE,
     Expression,
-    InvalidExpression,
+    InvalidExpressionError,
     ScalarLiteralType,
     ScalarType,
     is_literal,
@@ -14,7 +16,7 @@ from snuba_sdk.expressions import (
 )
 
 
-class InvalidFunction(InvalidExpression):
+class InvalidFunctionError(InvalidExpressionError):
     pass
 
 
@@ -31,48 +33,48 @@ class CurriedFunction(Expression):
     function: str
     initializers: Optional[Sequence[Union[ScalarLiteralType, Column]]] = None
     parameters: Optional[
-        Sequence[Union[ScalarType, Column, "CurriedFunction", "Function"]]
+        Sequence[Union[ScalarType, Column, CurriedFunction, Function]]
     ] = None
     alias: Optional[str] = None
 
     def validate(self) -> None:
         if not isinstance(self.function, str):
-            raise InvalidFunction(f"function '{self.function}' must be a string")
+            raise InvalidFunctionError(f"function '{self.function}' must be a string")
         if self.function == "":
             # TODO: Have a whitelist of valid functions to check, maybe even with more
             # specific parameter type checking
-            raise InvalidFunction("function cannot be empty")
+            raise InvalidFunctionError("function cannot be empty")
         if not function_name_re.match(self.function):
-            raise InvalidFunction(
+            raise InvalidFunctionError(
                 f"function '{self.function}' contains invalid characters"
             )
 
         if self.initializers is not None:
             if not isinstance(self.initializers, Sequence):
-                raise InvalidFunction(
+                raise InvalidFunctionError(
                     f"initializers of function {self.function} must be a Sequence"
                 )
             elif not all(
                 isinstance(param, Column) or is_literal(param)
                 for param in self.initializers
             ):
-                raise InvalidFunction(
+                raise InvalidFunctionError(
                     f"initializers to function {self.function} must be a scalar or column"
                 )
 
         if self.alias is not None:
             if not isinstance(self.alias, str) or self.alias == "":
-                raise InvalidFunction(
+                raise InvalidFunctionError(
                     f"alias '{self.alias}' of function {self.function} must be None or a non-empty string"
                 )
             if not ALIAS_RE.match(self.alias):
-                raise InvalidFunction(
+                raise InvalidFunctionError(
                     f"alias '{self.alias}' of function {self.function} contains invalid characters"
                 )
 
         if self.parameters is not None:
             if not isinstance(self.parameters, Sequence):
-                raise InvalidFunction(
+                raise InvalidFunctionError(
                     f"parameters of function {self.function} must be a Sequence"
                 )
             for param in self.parameters:
@@ -80,7 +82,7 @@ class CurriedFunction(Expression):
                     param, (Column, CurriedFunction, Function)
                 ) and not is_scalar(param):
                     assert not isinstance(param, bytes)  # mypy
-                    raise InvalidFunction(
+                    raise InvalidFunctionError(
                         f"parameter '{param}' of function {self.function} is an invalid type"
                     )
 

--- a/snuba_sdk/legacy.py
+++ b/snuba_sdk/legacy.py
@@ -220,7 +220,7 @@ def json_to_snql(body: Mapping[str, Any], entity: str) -> Query:
     :param entity: The name of the entity being queried.
     :type entity: str
 
-    :raises InvalidExpression, InvalidQuery: If the legacy body is invalid, the SDK will
+    :raises InvalidExpressionError, InvalidQueryError: If the legacy body is invalid, the SDK will
         raise an exception.
 
     """

--- a/snuba_sdk/orderby.py
+++ b/snuba_sdk/orderby.py
@@ -3,8 +3,8 @@ from enum import Enum
 from typing import Union
 
 from snuba_sdk.column import Column
+from snuba_sdk.expressions import Expression, InvalidExpressionError
 from snuba_sdk.function import CurriedFunction, Function
-from snuba_sdk.expressions import Expression, InvalidExpression
 
 
 class Direction(Enum):
@@ -19,11 +19,11 @@ class OrderBy(Expression):
 
     def validate(self) -> None:
         if not isinstance(self.exp, (Column, CurriedFunction, Function)):
-            raise InvalidExpression(
+            raise InvalidExpressionError(
                 "OrderBy expression must be a Column, CurriedFunction or Function"
             )
         if not isinstance(self.direction, Direction):
-            raise InvalidExpression("OrderBy direction must be a Direction")
+            raise InvalidExpressionError("OrderBy direction must be a Direction")
 
 
 @dataclass(frozen=True)
@@ -33,8 +33,8 @@ class LimitBy(Expression):
 
     def validate(self) -> None:
         if not isinstance(self.column, Column):
-            raise InvalidExpression("LimitBy can only be used on a Column")
+            raise InvalidExpressionError("LimitBy can only be used on a Column")
         if not isinstance(self.count, int) or self.count <= 0 or self.count > 10000:
-            raise InvalidExpression(
+            raise InvalidExpressionError(
                 "LimitBy count must be a positive integer (max 10,000)"
             )

--- a/snuba_sdk/query_visitors.py
+++ b/snuba_sdk/query_visitors.py
@@ -38,7 +38,7 @@ from snuba_sdk.snuba import is_aggregation_function
 from snuba_sdk.visitors import ExpressionFinder, Translation, entity_aliases
 
 
-class InvalidQuery(Exception):
+class InvalidQueryError(Exception):
     pass
 
 
@@ -457,7 +457,7 @@ class Validator(QueryVisitor[None]):
 
             for c in all_columns:
                 if isinstance(c, Column) and c.name not in inner_match:
-                    raise InvalidQuery(
+                    raise InvalidQueryError(
                         f"outer query is referencing column {c.name} that does not exist in subquery"
                     )
         # In a Join, all the columns must have a qualifying entity with a valid alias.
@@ -469,21 +469,21 @@ class Validator(QueryVisitor[None]):
             for c in column_exps:
                 assert isinstance(c, Column)
                 if c.entity is None:
-                    raise InvalidQuery(f"{c.name} must have a qualifying entity")
+                    raise InvalidQueryError(f"{c.name} must have a qualifying entity")
                 elif c.entity.alias not in entity_aliases:
-                    raise InvalidQuery(
+                    raise InvalidQueryError(
                         f"{c.name} has unknown entity alias {c.entity.alias}"
                     )
                 elif entity_aliases[c.entity.alias] != c.entity.name:
-                    raise InvalidQuery(
+                    raise InvalidQueryError(
                         f"{c.name} has incorrect alias for entity {c.entity.name}: {c.entity.alias}"
                     )
 
         if query.select is None or len(query.select) == 0:
-            raise InvalidQuery("query must have at least one expression in select")
+            raise InvalidQueryError("query must have at least one expression in select")
 
         if query.totals and not query.groupby:
-            raise InvalidQuery("totals is only valid with a groupby")
+            raise InvalidQueryError("totals is only valid with a groupby")
 
     def _visit_dataset(self, dataset: str) -> None:
         pass

--- a/snuba_sdk/visitors.py
+++ b/snuba_sdk/visitors.py
@@ -13,7 +13,7 @@ from snuba_sdk.expressions import (
     DryRun,
     Expression,
     Granularity,
-    InvalidExpression,
+    InvalidExpressionError,
     Legacy,
     Limit,
     Offset,
@@ -192,7 +192,7 @@ class Translation(ExpressionVisitor[str]):
             is_scalar(value)  # Throws on an invalid tuple
             return f"tuple({', '.join([self._stringify_scalar(v) for v in value])})"
 
-        raise InvalidExpression(f"'{value}' is not a valid scalar")
+        raise InvalidExpressionError(f"'{value}' is not a valid scalar")
 
     def _visit_aliased_expression(self, aliased: AliasedExpression) -> str:
         alias_clause = ""

--- a/tests/test_aliased_expression.py
+++ b/tests/test_aliased_expression.py
@@ -5,7 +5,7 @@ import pytest
 
 from snuba_sdk.aliased_expression import AliasedExpression
 from snuba_sdk.column import Column
-from snuba_sdk.expressions import InvalidExpression
+from snuba_sdk.expressions import InvalidExpressionError
 from snuba_sdk.visitors import Translation
 
 tests = [
@@ -21,28 +21,32 @@ tests = [
         "stuff",
         "things[1.c-2:3]",
         None,
-        InvalidExpression("aliased expressions can only contain a Column"),
+        InvalidExpressionError("aliased expressions can only contain a Column"),
         id="exp must be a Column",
     ),
     pytest.param(
         Column("stuff"),
         "",
         None,
-        InvalidExpression("alias '' of expression must be None or a non-empty string"),
+        InvalidExpressionError(
+            "alias '' of expression must be None or a non-empty string"
+        ),
         id="alias can't be empty string",
     ),
     pytest.param(
         Column("stuff"),
         1,
         None,
-        InvalidExpression("alias '1' of expression must be None or a non-empty string"),
+        InvalidExpressionError(
+            "alias '1' of expression must be None or a non-empty string"
+        ),
         id="alias must be string",
     ),
     pytest.param(
         Column("stuff"),
         "what???||things!!",
         None,
-        InvalidExpression(
+        InvalidExpressionError(
             "alias 'what???||things!!' of expression contains invalid characters"
         ),
         id="alias has invalid characters",

--- a/tests/test_column.py
+++ b/tests/test_column.py
@@ -3,7 +3,7 @@ from typing import Any, Optional, Tuple
 
 import pytest
 
-from snuba_sdk.column import Column, InvalidColumn
+from snuba_sdk.column import Column, InvalidColumnError
 from snuba_sdk.entity import Entity
 from snuba_sdk.visitors import Translation
 
@@ -46,7 +46,7 @@ tests = [
         "a1[a:b][aasdc]",
         None,
         None,
-        InvalidColumn(
+        InvalidColumnError(
             "column 'a1[a:b][aasdc]' is empty or contains invalid characters"
         ),
         id="only one subscriptable",
@@ -55,28 +55,28 @@ tests = [
         ":_valid",
         None,
         None,
-        InvalidColumn("column ':_valid' is empty or contains invalid characters"),
+        InvalidColumnError("column ':_valid' is empty or contains invalid characters"),
         id="underscore column test",
     ),
     pytest.param(
         "..valid",
         None,
         None,
-        InvalidColumn("column '..valid' is empty or contains invalid characters"),
+        InvalidColumnError("column '..valid' is empty or contains invalid characters"),
         id="invalid column",
     ),
     pytest.param(
         10,
         None,
         None,
-        InvalidColumn("column '10' must be a string"),
+        InvalidColumnError("column '10' must be a string"),
         id="invalid column type",
     ),
     pytest.param(
         "",
         None,
         None,
-        InvalidColumn("column '' is empty or contains invalid characters"),
+        InvalidColumnError("column '' is empty or contains invalid characters"),
         id="empty column",
     ),
 ]
@@ -109,14 +109,14 @@ entity_tests = [
         "foo",
         Entity("events"),
         None,
-        InvalidColumn("column foo expects an Entity with an alias"),
+        InvalidColumnError("column foo expects an Entity with an alias"),
         id="column with entity but no alias",
     ),
     pytest.param(
         "foo",
         "events",
         None,
-        InvalidColumn("column foo expects an Entity"),
+        InvalidColumnError("column foo expects an Entity"),
         id="column with non-entity",
     ),
 ]

--- a/tests/test_condition.py
+++ b/tests/test_condition.py
@@ -9,7 +9,7 @@ from snuba_sdk.conditions import (
     BooleanCondition,
     BooleanOp,
     Condition,
-    InvalidCondition,
+    InvalidConditionError,
     Op,
     Or,
 )
@@ -61,7 +61,7 @@ tests = [
         cond(Column("foo"), Op.IS_NULL, "foo"),
         None,
         "",
-        InvalidCondition(
+        InvalidConditionError(
             "invalid condition: unary operators don't have rhs conditions",
         ),
         id="unary too many conditions",
@@ -70,7 +70,7 @@ tests = [
         cond("foo", Op.EQ, "foo"),
         None,
         "",
-        InvalidCondition(
+        InvalidConditionError(
             "invalid condition: LHS of a condition must be a Column, CurriedFunction or Function, not <class 'str'>"
         ),
         id="lhs invalid type",
@@ -79,14 +79,16 @@ tests = [
         cond(Column("foo"), Column("bar"), "foo"),
         None,
         "",
-        InvalidCondition("invalid condition: operator of a condition must be an Op"),
+        InvalidConditionError(
+            "invalid condition: operator of a condition must be an Op"
+        ),
         id="op invalid type",
     ),
     pytest.param(
         cond(Column("foo"), Op.EQ, Op.EQ),
         None,
         "",
-        InvalidCondition(
+        InvalidConditionError(
             "invalid condition: RHS of a condition must be a Column, CurriedFunction, Function or Scalar not <enum 'Op'>"
         ),
         id="rhs invalid type",
@@ -195,14 +197,16 @@ boolean_tests = [
         ),
         None,
         None,
-        InvalidCondition("invalid boolean: operator of a boolean must be a BooleanOp"),
+        InvalidConditionError(
+            "invalid boolean: operator of a boolean must be a BooleanOp"
+        ),
         id="invalid op",
     ),
     pytest.param(
         and_cond(Condition(Column("a"), Op.EQ, 1)),
         None,
         None,
-        InvalidCondition(
+        InvalidConditionError(
             "invalid boolean: conditions must be a list of other conditions"
         ),
         id="not a list",
@@ -211,14 +215,14 @@ boolean_tests = [
         bool_cond(BooleanOp.OR, [Condition(Column("a"), Op.EQ, 1)]),
         None,
         None,
-        InvalidCondition("invalid boolean: must supply at least two conditions"),
+        InvalidConditionError("invalid boolean: must supply at least two conditions"),
         id="only one",
     ),
     pytest.param(
         or_cond([Condition(Column("a"), Op.EQ, 1), Column("event_id")]),
         None,
         None,
-        InvalidCondition(
+        InvalidConditionError(
             "invalid boolean: Column(name='event_id', entity=None, subscriptable=None, key=None) is not a valid condition"
         ),
         id="not all conditions",

--- a/tests/test_entity.py
+++ b/tests/test_entity.py
@@ -3,7 +3,7 @@ from typing import Any, Optional
 
 import pytest
 
-from snuba_sdk.entity import Entity, InvalidEntity
+from snuba_sdk.entity import Entity, InvalidEntityError
 from snuba_sdk.visitors import Translation
 
 TRANSLATOR = Translation(use_entity_aliases=True)
@@ -14,23 +14,31 @@ tests = [
     pytest.param("sessions", None, 10.0, "(sessions SAMPLE 10.0)", None),
     pytest.param("sessions", "s", None, "(s: sessions)", None),
     pytest.param("sessions", "s", 10.0, "(s: sessions SAMPLE 10.0)", None),
-    pytest.param("", "s", None, None, InvalidEntity("'' is not a valid entity name")),
-    pytest.param(1, None, None, None, InvalidEntity("'1' is not a valid entity name")),
-    pytest.param("sessions", "", None, None, InvalidEntity("'' is not a valid alias")),
-    pytest.param("sessions", 1, None, None, InvalidEntity("'1' is not a valid alias")),
+    pytest.param(
+        "", "s", None, None, InvalidEntityError("'' is not a valid entity name")
+    ),
+    pytest.param(
+        1, None, None, None, InvalidEntityError("'1' is not a valid entity name")
+    ),
+    pytest.param(
+        "sessions", "", None, None, InvalidEntityError("'' is not a valid alias")
+    ),
+    pytest.param(
+        "sessions", 1, None, None, InvalidEntityError("'1' is not a valid alias")
+    ),
     pytest.param(
         "sessions",
         None,
         "0.1",
         None,
-        InvalidEntity("sample must be a float"),
+        InvalidEntityError("sample must be a float"),
     ),
     pytest.param(
         "sessions",
         "s",
         -0.1,
         None,
-        InvalidEntity("samples must be greater than 0.0"),
+        InvalidEntityError("samples must be greater than 0.0"),
     ),
 ]
 

--- a/tests/test_function.py
+++ b/tests/test_function.py
@@ -3,9 +3,9 @@ from typing import Any, Callable, Optional
 
 import pytest
 
-from snuba_sdk.column import Column, InvalidColumn
+from snuba_sdk.column import Column, InvalidColumnError
 from snuba_sdk.conditions import Op
-from snuba_sdk.function import CurriedFunction, Function, InvalidFunction
+from snuba_sdk.function import CurriedFunction, Function, InvalidFunctionError
 from snuba_sdk.visitors import Translation
 from tests import col, cur_func, func
 
@@ -60,28 +60,28 @@ tests = [
         func(1, ["foo"], "invalid"),
         None,
         "",
-        InvalidFunction("function '1' must be a string"),
+        InvalidFunctionError("function '1' must be a string"),
         id="invalid function",
     ),
     pytest.param(
         func("", ["foo"], "invalid"),
         None,
         "",
-        InvalidFunction("function cannot be empty"),
+        InvalidFunctionError("function cannot be empty"),
         id="empty function",
     ),
     pytest.param(
         func("¡amigo!", ["foo"], "invalid"),
         None,
         "",
-        InvalidFunction("function '¡amigo!' contains invalid characters"),
+        InvalidFunctionError("function '¡amigo!' contains invalid characters"),
         id="empty function",
     ),
     pytest.param(
         func("foo", ["foo"], 10),
         None,
         "",
-        InvalidFunction(
+        InvalidFunctionError(
             "alias '10' of function foo must be None or a non-empty string"
         ),
         id="invalid alias type",
@@ -90,28 +90,34 @@ tests = [
         func("foo", ["foo"], ""),
         None,
         "",
-        InvalidFunction("alias '' of function foo must be None or a non-empty string"),
+        InvalidFunctionError(
+            "alias '' of function foo must be None or a non-empty string"
+        ),
         id="empty alias",
     ),
     pytest.param(
         func("foo", ["foo"], "'amigo!"),
         None,
         "",
-        InvalidFunction("alias ''amigo!' of function foo contains invalid characters"),
+        InvalidFunctionError(
+            "alias ''amigo!' of function foo contains invalid characters"
+        ),
         id="invalid alias",
     ),
     pytest.param(
         func("toString", ["foo", Op.EQ, Column("foo")], "invalid"),
         None,
         "",
-        InvalidFunction("parameter 'Op.EQ' of function toString is an invalid type"),
+        InvalidFunctionError(
+            "parameter 'Op.EQ' of function toString is an invalid type"
+        ),
         id="invalid function parameter type",
     ),
     pytest.param(
         func("toString", ["foo", col("¡amigo!")], "invalid"),
         None,
         "",
-        InvalidColumn("'¡amigo!' is empty or contains invalid characters"),
+        InvalidColumnError("'¡amigo!' is empty or contains invalid characters"),
         id="invalid function parameter",
     ),
 ]
@@ -199,7 +205,7 @@ curried_tests = [
         cur_func("foo", [[1, 2, 3]], ["foo"], "invalid"),
         None,
         "",
-        InvalidFunction("initializers to function foo must be a scalar or column"),
+        InvalidFunctionError("initializers to function foo must be a scalar or column"),
         id="invalid initializers",
     ),
 ]

--- a/tests/test_invalid_query.py
+++ b/tests/test_invalid_query.py
@@ -5,32 +5,32 @@ import pytest
 
 from snuba_sdk.aliased_expression import AliasedExpression
 from snuba_sdk.column import Column
-from snuba_sdk.conditions import Condition, InvalidCondition, Op
+from snuba_sdk.conditions import Condition, InvalidConditionError, Op
 from snuba_sdk.entity import Entity
-from snuba_sdk.expressions import InvalidExpression
+from snuba_sdk.expressions import InvalidExpressionError
 from snuba_sdk.function import Function
 from snuba_sdk.query import Query
-from snuba_sdk.query_visitors import InvalidQuery
+from snuba_sdk.query_visitors import InvalidQueryError
 
 
 def test_invalid_query() -> None:
     with pytest.raises(
-        InvalidQuery, match=re.escape("queries must have a valid dataset")
+        InvalidQueryError, match=re.escape("queries must have a valid dataset")
     ):
         Query(dataset=1, match=Entity("events"))  # type: ignore
 
     with pytest.raises(
-        InvalidQuery, match=re.escape("queries must have a valid dataset")
+        InvalidQueryError, match=re.escape("queries must have a valid dataset")
     ):
         Query(dataset="", match=Entity("events"))
 
     with pytest.raises(
-        InvalidQuery, match=re.escape("queries must have a valid Entity")
+        InvalidQueryError, match=re.escape("queries must have a valid Entity")
     ):
         Query(dataset="discover", match="events")  # type: ignore
 
     with pytest.raises(
-        InvalidCondition,
+        InvalidConditionError,
         match=re.escape(
             "invalid condition: LHS of a condition must be a Column, CurriedFunction or Function, not <class 'snuba_sdk.aliased_expression.AliasedExpression'>"
         ),
@@ -64,45 +64,47 @@ def test_invalid_query_set() -> None:
     }
 
     match, err = tests["match"]
-    with pytest.raises(InvalidQuery, match=re.escape(err)):
+    with pytest.raises(InvalidQueryError, match=re.escape(err)):
         query.set_match(match)
 
     for val in tests["select"][0]:
-        with pytest.raises(InvalidQuery, match=re.escape(tests["select"][1])):
+        with pytest.raises(InvalidQueryError, match=re.escape(tests["select"][1])):
             query.set_select(val)
 
     for val in tests["groupby"][0]:
-        with pytest.raises(InvalidQuery, match=re.escape(tests["groupby"][1])):
+        with pytest.raises(InvalidQueryError, match=re.escape(tests["groupby"][1])):
             query.set_groupby(val)
 
     for val in tests["where"][0]:
-        with pytest.raises(InvalidQuery, match=re.escape(tests["where"][1])):
+        with pytest.raises(InvalidQueryError, match=re.escape(tests["where"][1])):
             query.set_where(val)
 
     for val in tests["having"][0]:
-        with pytest.raises(InvalidQuery, match=re.escape(tests["having"][1])):
+        with pytest.raises(InvalidQueryError, match=re.escape(tests["having"][1])):
             query.set_having(val)
 
     for val in tests["orderby"][0]:
-        with pytest.raises(InvalidQuery, match=re.escape(tests["orderby"][1])):
+        with pytest.raises(InvalidQueryError, match=re.escape(tests["orderby"][1])):
             query.set_orderby(val)
 
-    with pytest.raises(InvalidQuery, match=re.escape(tests["limitby"][1])):
+    with pytest.raises(InvalidQueryError, match=re.escape(tests["limitby"][1])):
         query.set_limitby(tests["limitby"][0])
 
-    with pytest.raises(InvalidExpression, match=re.escape(tests["limit"][1])):
+    with pytest.raises(InvalidExpressionError, match=re.escape(tests["limit"][1])):
         query.set_limit(tests["limit"][0])
 
-    with pytest.raises(InvalidExpression, match=re.escape(tests["offset"][1])):
+    with pytest.raises(InvalidExpressionError, match=re.escape(tests["offset"][1])):
         query.set_offset(tests["offset"][0])
 
-    with pytest.raises(InvalidExpression, match=re.escape(tests["granularity"][1])):
+    with pytest.raises(
+        InvalidExpressionError, match=re.escape(tests["granularity"][1])
+    ):
         query.set_granularity(tests["granularity"][0])
 
 
 def test_invalid_subquery() -> None:
     with pytest.raises(
-        InvalidQuery,
+        InvalidQueryError,
         match=re.escape(
             "inner query is invalid: query must have at least one expression in select"
         ),
@@ -112,7 +114,7 @@ def test_invalid_subquery() -> None:
         )
 
     with pytest.raises(
-        InvalidQuery,
+        InvalidQueryError,
         match=re.escape(
             "inner query is invalid: query must have at least one expression in select"
         ),

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -21,7 +21,7 @@ from snuba_sdk import (
     OrderBy,
     Query,
 )
-from snuba_sdk.query_visitors import InvalidQuery
+from snuba_sdk.query_visitors import InvalidQueryError
 
 NOW = datetime(2021, 1, 2, 3, 4, 5, 6, timezone.utc)
 tests = [
@@ -274,7 +274,7 @@ invalid_tests = [
             offset=Offset(1),
             granularity=Granularity(3600),
         ),
-        InvalidQuery("query must have at least one expression in select"),
+        InvalidQueryError("query must have at least one expression in select"),
         id="missing select",
     ),
     pytest.param(
@@ -287,7 +287,7 @@ invalid_tests = [
             offset=Offset(1),
             granularity=Granularity(3600),
         ).set_totals(True),
-        InvalidQuery("totals is only valid with a groupby"),
+        InvalidQueryError("totals is only valid with a groupby"),
         id="Totals must have a groupby",
     ),
     pytest.param(
@@ -304,7 +304,7 @@ invalid_tests = [
         .set_limit(10)
         .set_offset(1)
         .set_granularity(3600),
-        InvalidQuery(
+        InvalidQueryError(
             "outer query is referencing column group_id that does not exist in subquery"
         ),
         id="invalid column reference in outer query",
@@ -330,7 +330,7 @@ invalid_tests = [
         .set_limit(10)
         .set_offset(1)
         .set_granularity(3600),
-        InvalidQuery(
+        InvalidQueryError(
             "outer query is referencing column event_id that does not exist in subquery"
         ),
         id="outer query is referencing column not alias",

--- a/tests/test_relationship_expression.py
+++ b/tests/test_relationship_expression.py
@@ -4,7 +4,7 @@ from typing import Any, Optional
 import pytest
 
 from snuba_sdk.entity import Entity
-from snuba_sdk.expressions import InvalidExpression
+from snuba_sdk.expressions import InvalidExpressionError
 from snuba_sdk.relationships import Join, Relationship
 from snuba_sdk.visitors import Translation
 
@@ -23,14 +23,14 @@ relationship_tests = [
         "contains",
         Entity("transactions", "t"),
         None,
-        InvalidExpression("'' must be an Entity"),
+        InvalidExpressionError("'' must be an Entity"),
     ),
     pytest.param(
         Entity("events", None, 100.0),
         "contains",
         Entity("transactions", "t"),
         None,
-        InvalidExpression(
+        InvalidExpressionError(
             "Entity(name='events', alias=None, sample=100.0) must have a valid alias"
         ),
     ),
@@ -39,14 +39,14 @@ relationship_tests = [
         1,
         Entity("transactions", "t"),
         None,
-        InvalidExpression("'1' is not a valid relationship name"),
+        InvalidExpressionError("'1' is not a valid relationship name"),
     ),
     pytest.param(
         Entity("events", "e", 100.0),
         "",
         Entity("transactions", "t"),
         None,
-        InvalidExpression("'' is not a valid relationship name"),
+        InvalidExpressionError("'' is not a valid relationship name"),
     ),
 ]
 
@@ -87,10 +87,12 @@ join_tests = [
         None,
     ),
     pytest.param(
-        [], None, InvalidExpression("Join must have at least one Relationship")
+        [], None, InvalidExpressionError("Join must have at least one Relationship")
     ),
     pytest.param(
-        [1, 2], None, InvalidExpression("Join expects a list of Relationship objects")
+        [1, 2],
+        None,
+        InvalidExpressionError("Join expects a list of Relationship objects"),
     ),
     pytest.param(
         [
@@ -98,7 +100,7 @@ join_tests = [
             Relationship(Entity("events", "e"), "hasnt", Entity("sessions", "e", 10.0)),
         ],
         None,
-        InvalidExpression("alias 'e' is duplicated for entities events, sessions"),
+        InvalidExpressionError("alias 'e' is duplicated for entities events, sessions"),
     ),
 ]
 

--- a/tests/test_relationships.py
+++ b/tests/test_relationships.py
@@ -10,7 +10,7 @@ from snuba_sdk.entity import Entity
 from snuba_sdk.function import Function
 from snuba_sdk.orderby import Direction, OrderBy
 from snuba_sdk.query import Query
-from snuba_sdk.query_visitors import InvalidQuery
+from snuba_sdk.query_visitors import InvalidQueryError
 from snuba_sdk.relationships import Join, Relationship
 
 tests = [
@@ -170,7 +170,7 @@ invalid_tests = [
         .set_offset(1)
         .set_granularity(3600)
         .set_consistent(True),
-        InvalidQuery("group_id must have a qualifying entity"),
+        InvalidQueryError("group_id must have a qualifying entity"),
         id="all columns must be qualified",
     ),
     pytest.param(
@@ -194,7 +194,7 @@ invalid_tests = [
         .set_offset(1)
         .set_granularity(3600)
         .set_consistent(True),
-        InvalidQuery("group_id has unknown entity alias t"),
+        InvalidQueryError("group_id has unknown entity alias t"),
         id="column with different entity",
     ),
     pytest.param(
@@ -218,7 +218,7 @@ invalid_tests = [
         .set_offset(1)
         .set_granularity(3600)
         .set_consistent(True),
-        InvalidQuery("group_id has unknown entity alias t"),
+        InvalidQueryError("group_id has unknown entity alias t"),
         id="column with different entity alias",
     ),
     pytest.param(
@@ -242,7 +242,7 @@ invalid_tests = [
         .set_offset(1)
         .set_granularity(3600)
         .set_consistent(True),
-        InvalidQuery("group_id has incorrect alias for entity transactions: e"),
+        InvalidQueryError("group_id has incorrect alias for entity transactions: e"),
         id="duplicate entity alias",
     ),
 ]

--- a/tests/test_scalar.py
+++ b/tests/test_scalar.py
@@ -4,7 +4,7 @@ from datetime import date, datetime, timedelta, timezone
 import pytest
 
 from snuba_sdk.column import Column
-from snuba_sdk.expressions import InvalidExpression, ScalarType
+from snuba_sdk.expressions import InvalidExpressionError, ScalarType
 from snuba_sdk.visitors import Translation
 
 tests = [
@@ -64,13 +64,13 @@ def test_scalars(scalar: ScalarType, expected: str) -> None:
 def test_invalid_scalars() -> None:
     translator = Translation()
     with pytest.raises(
-        InvalidExpression,
+        InvalidExpressionError,
         match=re.escape("tuple/array must contain only scalar values"),
     ):
         translator._stringify_scalar(({"a": 1}, {1, 2, 3}))  # type: ignore
 
     with pytest.raises(
-        InvalidExpression,
+        InvalidExpressionError,
         match=re.escape("tuple/array must contain only scalar values"),
     ):
         translator._stringify_scalar([{"a": 1}, {1, 2, 3}])  # type: ignore

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@
 [tox]
 envlist =
     # === Core ===
-    py{3.6,3.7,3.8,3.9}
+    py{3.7,3.8,3.9}
 usedevelop = True
 
 [testenv]
@@ -20,7 +20,6 @@ setenv =
     TESTPATH=tests
     COVERAGE_FILE=.coverage-{envname}
 basepython =
-    py3.6: python3.6
     py3.7: python3.7
     py3.8: python3.8
     py3.9: python3.9


### PR DESCRIPTION
The sentry repository has been updated to 3.8, so we can now finally update and
drop support for 3.6. This also means we can use annotations which is nice.