### PR TITLE
feat: Add Lambdas and Identifiers expressions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ repos:
     rev: 21.11b1
     hooks:
       - id: black
-  - repo: git://github.com/pre-commit/pre-commit-hooks
+  - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.0.1
     hooks:
       - id: check-case-conflict
@@ -27,7 +27,7 @@ repos:
       - id: isort
         name: isort (python)
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: 'v0.910'
+    rev: 'v0.812'
     hooks:
     -   id: mypy
         args: [--config-file, mypy.ini, --ignore-missing-imports]

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,9 @@
 Changelog and versioning
 ==========================
 
+0.1.1
+------
+- Add support for lambdas and identifiers, which in turn enable higher order functions like `arrayMap`.
 
 0.1.0
 ------

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ help:
 	$(VENV_PATH)/bin/pip install -r linter-requirements.txt
 
 setup-git:
-	pip install 'pre-commit==2.15.0'
+	pip install 'pre-commit==2.16.0'
 	pre-commit install --install-hooks
 
 dist: .venv

--- a/linter-requirements.txt
+++ b/linter-requirements.txt
@@ -1,7 +1,7 @@
 black==21.11b1
 flake8==4.0.1
 flake8-import-order==0.18.1
-mypy==0.910
+mypy==0.812
 flake8-bugbear==21.9.2
 pep8-naming==0.12.1
 isort==5.10.1

--- a/snuba_sdk/__init__.py
+++ b/snuba_sdk/__init__.py
@@ -11,7 +11,7 @@ from snuba_sdk.expressions import (
     Totals,
     Turbo,
 )
-from snuba_sdk.function import CurriedFunction, Function
+from snuba_sdk.function import CurriedFunction, Function, Identifier, Lambda
 from snuba_sdk.orderby import Direction, LimitBy, OrderBy
 from snuba_sdk.query import Query
 from snuba_sdk.relationships import Join, Relationship
@@ -30,7 +30,9 @@ __all__ = [
     "Entity",
     "Function",
     "Granularity",
+    "Identifier",
     "Join",
+    "Lambda",
     "Limit",
     "LimitBy",
     "Offset",

--- a/tests/test_function.py
+++ b/tests/test_function.py
@@ -5,7 +5,13 @@ import pytest
 
 from snuba_sdk.column import Column, InvalidColumnError
 from snuba_sdk.conditions import Op
-from snuba_sdk.function import CurriedFunction, Function, InvalidFunctionError
+from snuba_sdk.function import (
+    CurriedFunction,
+    Function,
+    Identifier,
+    InvalidFunctionError,
+    Lambda,
+)
 from snuba_sdk.visitors import Translation
 from tests import col, cur_func, func
 
@@ -48,6 +54,21 @@ tests = [
         "someFunc(event_id, NULL, 'stuff', toString(event_id) AS event_id_str) AS someFunc",
         None,
         id="all possible parameter types",
+    ),
+    pytest.param(
+        func(
+            "arrayMap",
+            [Lambda(["x"], Function("identity", [Identifier("x")])), Column("foo")],
+            "equation[0]",
+        ),
+        Function(
+            "arrayMap",
+            [Lambda(["x"], Function("identity", [Identifier("x")])), Column("foo")],
+            "equation[0]",
+        ),
+        "arrayMap((`x`) -> identity(`x`), foo) AS equation[0]",
+        None,
+        id="higher order function",
     ),
     pytest.param(
         func("foo", [Column("foo")], "equation[0]"),

--- a/tests/test_lambda.py
+++ b/tests/test_lambda.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import re
+from typing import Any, Optional
+
+import pytest
+
+from snuba_sdk.column import Column
+from snuba_sdk.function import Function, Identifier, InvalidLambdaError, Lambda
+from snuba_sdk.visitors import Translation
+
+TRANSLATOR = Translation()
+
+tests = [
+    pytest.param(
+        ["x"],
+        Function("identity", [Identifier("x")]),
+        Lambda(["x"], Function("identity", [Identifier("x")])),
+        "(`x`) -> identity(`x`)",
+        None,
+        id="basic lambda",
+    ),
+    pytest.param(
+        ["x", "y"],
+        Function("identity", [Identifier("x"), Identifier("y")]),
+        Lambda(
+            ["x", "y"],
+            Function("identity", [Identifier("x"), Identifier("y")]),
+        ),
+        "(`x`, `y`) -> identity(`x`, `y`)",
+        None,
+        id="lambda with multiple identifiers",
+    ),
+    pytest.param(
+        ["x"],
+        Function(
+            "identity",
+            [Lambda(["y"], Function("tuple", [Identifier("x"), Identifier("y")]))],
+        ),
+        Lambda(
+            ["x"],
+            Function(
+                "identity",
+                [Lambda(["y"], Function("tuple", [Identifier("x"), Identifier("y")]))],
+            ),
+        ),
+        "(`x`) -> identity((`y`) -> tuple(`x`, `y`))",
+        None,
+        id="lambda with nested lambdas",
+    ),
+    pytest.param(
+        [1],
+        Function("identity", [Identifier("x")]),
+        None,
+        "",
+        InvalidLambdaError("1 is not a valid identifier"),
+        id="invalid identifier",
+    ),
+    pytest.param(
+        ["$sdsd!"],
+        Function("identity", [Identifier("x")]),
+        None,
+        "",
+        InvalidLambdaError("$sdsd! is not a valid identifier"),
+        id="invalid identifier chars",
+    ),
+    pytest.param(
+        ["x"],
+        Column("x"),
+        None,
+        "",
+        InvalidLambdaError("transformation must be a function"),
+        id="invalid transformation",
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "identifiers, transformation, valid, translated, exception", tests
+)
+def test_lambda(
+    identifiers: list[Any],
+    transformation: Any,
+    valid: Optional[Lambda],
+    translated: str,
+    exception: Optional[Exception],
+) -> None:
+    def verify() -> None:
+        exp = Lambda(identifiers, transformation)
+        assert exp == valid
+        assert TRANSLATOR.visit(exp) == translated
+
+    if exception is not None:
+        with pytest.raises(type(exception), match=re.escape(str(exception))):
+            verify()
+    else:
+        verify()


### PR DESCRIPTION
Add Lambda and Identifier expressions to the syntax. Lambdas can be used to
build anonymous functions in the form (`x`) -> <transformation>. Identifiers
can be used inside the transformation to reference the identifier(s) in the
lambda. These can be used inside functions to support higher order functions
such as arrayMap.

________

```
Function(
    "arrayMap", 
    Lambda(
        ["x"], 
        Function(
            "toString", 
            [Identifier("x")]
        )
    ), 
    Column("some_array")
)
```