### PR TITLE
feat(expressions): Allow @ char in alias regex

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,12 @@
 Changelog and versioning
 ==========================
 
+0.1.5
+------
+
+- Modify ALIAS_RE to allow for @ char
+
+
 0.1.4
 ------
 

--- a/linter-requirements.txt
+++ b/linter-requirements.txt
@@ -1,4 +1,4 @@
-black==21.11b1
+black==22.3.0
 flake8==4.0.1
 flake8-import-order==0.18.1
 mypy==0.812

--- a/snuba_sdk/expressions.py
+++ b/snuba_sdk/expressions.py
@@ -20,7 +20,7 @@ class Expression(ABC):
         raise NotImplementedError
 
 
-ALIAS_RE = re.compile(r"^[a-zA-Z0-9_\.\+\*\/:\-\[\]\(\)]*$")
+ALIAS_RE = re.compile(r"^[a-zA-Z0-9_\.\+\*\/:\-\[\]\(\)\@]*$")
 
 
 # For type hinting

--- a/tests/test_aliased_expression.py
+++ b/tests/test_aliased_expression.py
@@ -58,6 +58,13 @@ tests = [
         None,
         id="alias with parenthesis",
     ),
+    pytest.param(
+        Column("stuff"),
+        "sum(c:sessions/session@none)",
+        "stuff AS `sum(c:sessions/session@none)`",
+        None,
+        id="alias with mri",
+    ),
 ]
 
 


### PR DESCRIPTION
Adds @ char as an allowed char in an alias as
with the introduction of MRIs as metrics
ingestion names, @ char is added to identify
unit

For more context: https://github.com/getsentry/relay/pull/1215

Also bumps black to `22.3.0` to fix failing CI
https://github.com/psf/black/issues/2964