### PR TITLE
fix: Fix dependency error in Sphinx

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -52,6 +52,7 @@ Requests and Queries can be created directly:
 Queries can also be built incrementally:
 
 .. code-block:: python
+
     query = (
         Query("discover", Entity("events"))
         .set_select(
@@ -92,7 +93,7 @@ This outputs:
         "dataset": "discover",
         "app_id": "myappid",
         "query": "MATCH (events) SELECT title, uniq(event_id) AS uniq_events BY title WHERE timestamp > toDateTime('2021-01-01T00:00:00.000000') AND project_id IN tuple(1, 2, 3) LIMIT 10 OFFSET 0 GRANULARITY 3600",
-        "debug": True,
+        "debug": true
     }
 
 If an expression in the query is invalid (e.g. ``Column(1)``) then an ``InvalidExpressionError`` exception will be thrown.

--- a/docs-requirements.txt
+++ b/docs-requirements.txt
@@ -1,4 +1,5 @@
-sphinx==3.5.1
+Jinja2<3.1
+sphinx==3.5.4
 sphinx-rtd-theme
 sphinx-autodoc-typehints[type_comments]>=1.8.0
 typing-extensions


### PR DESCRIPTION
Sphinx was failing with the error "ImportError: cannot import name 'environmentfilter' from 'jinja2'"

That error is fixed by pinning Jinja2 to <3.1

I did try to update Sphinx to 4.x, but that caused another error:
"Could not import extension sphinx.builders.epub3"

I could not figure out how to fix that error no matter what combination of
packages I installed, so I kept the older version that at least works.