### PR TITLE
chore: Update logo in readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,6 @@
-.. image:: https://sentry-brand.storage.googleapis.com/sentry-logo-black.png
+.. image:: https://sentry-brand.storage.googleapis.com/sentry-wordmark-dark-280x84.png
     :width: 280
-    :target: https://sentry.io
+    :target: https://sentry.io/?utm_source=github&utm_medium=logo
 
 See here for the full `documentation <https://getsentry.github.io/snuba-sdk/>`_.
 


### PR DESCRIPTION
Switch to using the purple Sentry logo in the readme, as the black one does not render well on a black background, which will happen if you are using a dark theme in your GitHub settings.

Since the readme also renders on PyPi, where the system theme is ignored, the purple logo will look good there as well.

Also updated the sentry url to include utm source/medium parameters, as we do on the other repos.

Thanks.

#skip-changelog