### PR TITLE
feat(column): Expand column regex [TET-323]

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,10 @@
 Changelog and versioning
 ==========================
 
+1.0.1
+------
+
+- Modify column_name_re to allow for @ and / characters in column names.
 
 1.0.0
 ------

--- a/snuba_sdk/column.py
+++ b/snuba_sdk/column.py
@@ -10,7 +10,7 @@ class InvalidColumnError(InvalidExpressionError):
     pass
 
 
-column_name_re = re.compile(r"^[a-zA-Z_](\w|\.|:)*(\[([^\[\]]*)\])?$")
+column_name_re = re.compile(r"^[a-zA-Z_](\w|\.|:|\/|@)*(\[([^\[\]]*)\])?$")
 
 
 @dataclass(frozen=True)

--- a/tests/test_column.py
+++ b/tests/test_column.py
@@ -45,6 +45,13 @@ tests = [
         id="colon subscriptable",
     ),
     pytest.param(
+        "e:sessions/duration@millisecond",
+        ("e:sessions/duration@millisecond", None, None),
+        "e:sessions/duration@millisecond",
+        None,
+        id="mri format"
+    ),
+    pytest.param(
         "a1[a:b][aasdc]",
         None,
         None,

--- a/tests/test_column.py
+++ b/tests/test_column.py
@@ -49,7 +49,7 @@ tests = [
         ("e:sessions/duration@millisecond", None, None),
         "e:sessions/duration@millisecond",
         None,
-        id="mri format"
+        id="mri format",
     ),
     pytest.param(
         "a1[a:b][aasdc]",


### PR DESCRIPTION
Expands columns regex to accept "/" and "@"
chars to support MRI formats for column names
such as "d:sessions/duration@millisecond"

Counterpart to https://github.com/getsentry/snuba/pull/3045