### PR TITLE
feat(CapMan): Add tenant_ids to Request object

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,12 @@
 Changelog and versioning
 ==========================
 
+1.0.4
+------
+
+- Add `tenant_ids` required field to Request object so additional information about the request can be passed from Sentry.
+    - "tenants" include referrer, organization ID, etc.
+
 1.0.3
 ------
 

--- a/snuba_sdk/legacy.py
+++ b/snuba_sdk/legacy.py
@@ -364,6 +364,7 @@ def json_to_snql(body: Mapping[str, Any], entity: str) -> Request:
 
     dataset = body.get("dataset") or entity
     app_id = body.get("app_id") or "legacy"
-    request = Request(dataset, app_id, query, flags)
+    tenant_ids = body.get("tenant_ids") or {"legacy": "legacy"}
+    request = Request(dataset, app_id, tenant_ids, query, flags)
 
     return request

--- a/snuba_sdk/request.py
+++ b/snuba_sdk/request.py
@@ -44,6 +44,7 @@ FLAG_RE = re.compile(r"^[a-zA-Z0-9_\.\+\*\/:\-\[\]]*$")
 class Request:
     dataset: str
     app_id: str
+    tenant_ids: dict[str, str | int]
     query: Query
     flags: Flags = field(default_factory=Flags)
     parent_api: str = "<unknown>"
@@ -62,11 +63,14 @@ class Request:
         if not self.parent_api or not isinstance(self.parent_api, str):
             raise InvalidRequestError(f"`{self.parent_api}` is not a valid parent_api")
 
+        if not self.tenant_ids or not isinstance(self.tenant_ids, dict):
+            raise InvalidRequestError("Request must have a `tenant_ids` dictionary")
+
         self.query.validate()
         if self.flags is not None:
             self.flags.validate()
 
-    def to_dict(self) -> dict[str, str | bool]:
+    def to_dict(self) -> dict[str, str | bool | dict[str, str | int]]:
         self.validate()
         flags = self.flags.to_dict() if self.flags is not None else {}
         return {
@@ -74,6 +78,7 @@ class Request:
             "query": self.query.serialize(),
             "dataset": self.dataset,
             "app_id": self.app_id,
+            "tenant_ids": self.tenant_ids,
             "parent_api": self.parent_api,
         }
 

--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -26,6 +26,7 @@ tests = [
     pytest.param(
         "events",
         "default",
+        {"organization_id": 1, "referrer": "default"},
         BASIC_QUERY,
         Flags(consistent=True, turbo=True, dry_run=True, legacy=True, debug=True),
         "s/g",
@@ -37,6 +38,7 @@ tests = [
             "dry_run": True,
             "dataset": "events",
             "app_id": "default",
+            "tenant_ids": {"organization_id": 1, "referrer": "default"},
             "parent_api": "s/g",
             "legacy": True,
         },
@@ -46,6 +48,7 @@ tests = [
     pytest.param(
         None,
         "default",
+        {"organization_id": 1, "referrer": "default"},
         BASIC_QUERY,
         Flags(consistent=True),
         "s/g",
@@ -56,6 +59,7 @@ tests = [
     pytest.param(
         "@@ff@@",
         "default",
+        {"organization_id": 1, "referrer": "default"},
         BASIC_QUERY,
         Flags(consistent=True),
         "s/g",
@@ -66,6 +70,7 @@ tests = [
     pytest.param(
         "events",
         2,
+        {"organization_id": 1, "referrer": "default"},
         BASIC_QUERY,
         Flags(consistent=True),
         "s/g",
@@ -76,6 +81,7 @@ tests = [
     pytest.param(
         "events",
         "@@ff@@",
+        {"organization_id": 1, "referrer": "default"},
         BASIC_QUERY,
         Flags(consistent=True),
         "s/g",
@@ -86,6 +92,7 @@ tests = [
     pytest.param(
         "events",
         "default",
+        {"organization_id": 1, "referrer": "default"},
         BASIC_QUERY,
         Flags(consistent=True),
         6,
@@ -96,6 +103,7 @@ tests = [
     pytest.param(
         "events",
         "default",
+        {"organization_id": 1, "referrer": "default"},
         Query(Entity("events")),
         Flags(consistent=True, turbo=True, dry_run=True, legacy=True, debug=True),
         "s/g",
@@ -106,6 +114,7 @@ tests = [
     pytest.param(
         "events",
         "default",
+        {"organization_id": 1, "referrer": "default"},
         BASIC_QUERY,
         Flags(consistent=1),  # type: ignore
         "s/g",
@@ -117,11 +126,12 @@ tests = [
 
 
 @pytest.mark.parametrize(
-    "dataset, app_id, query, flags, parent_api, expected, exception", tests
+    "dataset, app_id, tenant_ids, query, flags, parent_api, expected, exception", tests
 )
 def test_request(
     dataset: str,
     app_id: str,
+    tenant_ids: dict[str, str | int],
     query: Query,
     flags: Flags,
     parent_api: str,
@@ -130,17 +140,23 @@ def test_request(
 ) -> None:
     if exception:
         with pytest.raises(type(exception), match=re.escape(str(exception))):
-            request = Request(dataset, app_id, query, flags, parent_api)
+            request = Request(dataset, app_id, tenant_ids, query, flags, parent_api)
             request.validate()
     else:
-        request = Request(dataset, app_id, query, flags, parent_api)
+        request = Request(dataset, app_id, tenant_ids, query, flags, parent_api)
         request.validate()
         assert request.to_dict() == expected
         assert request.print() == json.dumps(expected, sort_keys=True, indent=4 * " ")
 
 
 def test_request_set_methods() -> None:
-    request = Request("events", "default", BASIC_QUERY, Flags(consistent=True))
+    request = Request(
+        "events",
+        "default",
+        {"organization_id": 1, "referrer": "default"},
+        BASIC_QUERY,
+        Flags(consistent=True),
+    )
     request.flags = Flags(consistent=False)
     request.query = BASIC_QUERY.set_select([Column("trace_id")])
     request.validate()


### PR DESCRIPTION
### Overview
- As part of the Capacity Management project, we want to consolidate "tenant" (or general grouping of a query eg referrer, org_id, etc) information into a single dictionary in the Request
- This would be passed by Sentry to Snuba, which will use this information to manage capacity (or rate limit) in a more organized and methodical fashion
- As of now there are no constraints on what these tenants can be