### PR TITLE
fix(CapMan): `tenant_ids` field now optional to support gradual adoption

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,11 @@
 Changelog and versioning
 ==========================
 
+1.0.5
+------
+
+- `tenant_ids` required field added previously is now optional to support gradual adoption
+
 1.0.4
 ------
 

--- a/snuba_sdk/legacy.py
+++ b/snuba_sdk/legacy.py
@@ -365,6 +365,6 @@ def json_to_snql(body: Mapping[str, Any], entity: str) -> Request:
     dataset = body.get("dataset") or entity
     app_id = body.get("app_id") or "legacy"
     tenant_ids = body.get("tenant_ids") or {"legacy": "legacy"}
-    request = Request(dataset, app_id, tenant_ids, query, flags)
+    request = Request(dataset, app_id, query, flags, tenant_ids=tenant_ids)
 
     return request

--- a/snuba_sdk/request.py
+++ b/snuba_sdk/request.py
@@ -44,7 +44,7 @@ FLAG_RE = re.compile(r"^[a-zA-Z0-9_\.\+\*\/:\-\[\]]*$")
 class Request:
     dataset: str
     app_id: str
-    tenant_ids: dict[str, str | int]
+    tenant_ids: dict[str, str | int] | None
     query: Query
     flags: Flags = field(default_factory=Flags)
     parent_api: str = "<unknown>"
@@ -63,14 +63,11 @@ class Request:
         if not self.parent_api or not isinstance(self.parent_api, str):
             raise InvalidRequestError(f"`{self.parent_api}` is not a valid parent_api")
 
-        if not self.tenant_ids or not isinstance(self.tenant_ids, dict):
-            raise InvalidRequestError("Request must have a `tenant_ids` dictionary")
-
         self.query.validate()
         if self.flags is not None:
             self.flags.validate()
 
-    def to_dict(self) -> dict[str, str | bool | dict[str, str | int]]:
+    def to_dict(self) -> dict[str, str | bool | dict[str, str | int] | None]:
         self.validate()
         flags = self.flags.to_dict() if self.flags is not None else {}
         return {

--- a/snuba_sdk/request.py
+++ b/snuba_sdk/request.py
@@ -44,10 +44,10 @@ FLAG_RE = re.compile(r"^[a-zA-Z0-9_\.\+\*\/:\-\[\]]*$")
 class Request:
     dataset: str
     app_id: str
-    tenant_ids: dict[str, str | int] | None
     query: Query
     flags: Flags = field(default_factory=Flags)
     parent_api: str = "<unknown>"
+    tenant_ids: dict[str, str | int] = {"<unknown>": "<unknown>"}
 
     def validate(self) -> None:
         if not self.dataset or not isinstance(self.dataset, str):
@@ -63,11 +63,14 @@ class Request:
         if not self.parent_api or not isinstance(self.parent_api, str):
             raise InvalidRequestError(f"`{self.parent_api}` is not a valid parent_api")
 
+        if not self.tenant_ids or not isinstance(self.tenant_ids, dict):
+            raise InvalidRequestError("Request must have a `tenant_ids` dictionary")
+
         self.query.validate()
         if self.flags is not None:
             self.flags.validate()
 
-    def to_dict(self) -> dict[str, str | bool | dict[str, str | int] | None]:
+    def to_dict(self) -> dict[str, str | bool | dict[str, str | int]]:
         self.validate()
         flags = self.flags.to_dict() if self.flags is not None else {}
         return {

--- a/snuba_sdk/request.py
+++ b/snuba_sdk/request.py
@@ -47,7 +47,7 @@ class Request:
     query: Query
     flags: Flags = field(default_factory=Flags)
     parent_api: str = "<unknown>"
-    tenant_ids: dict[str, str | int] = {"<unknown>": "<unknown>"}
+    tenant_ids: dict[str, str | int] = field(default_factory=dict)
 
     def validate(self) -> None:
         if not self.dataset or not isinstance(self.dataset, str):
@@ -63,7 +63,7 @@ class Request:
         if not self.parent_api or not isinstance(self.parent_api, str):
             raise InvalidRequestError(f"`{self.parent_api}` is not a valid parent_api")
 
-        if not self.tenant_ids or not isinstance(self.tenant_ids, dict):
+        if not isinstance(self.tenant_ids, dict):
             raise InvalidRequestError("Request must have a `tenant_ids` dictionary")
 
         self.query.validate()

--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -140,10 +140,10 @@ def test_request(
 ) -> None:
     if exception:
         with pytest.raises(type(exception), match=re.escape(str(exception))):
-            request = Request(dataset, app_id, tenant_ids, query, flags, parent_api)
+            request = Request(dataset, app_id, query, flags, parent_api, tenant_ids)
             request.validate()
     else:
-        request = Request(dataset, app_id, tenant_ids, query, flags, parent_api)
+        request = Request(dataset, app_id, query, flags, parent_api, tenant_ids)
         request.validate()
         assert request.to_dict() == expected
         assert request.print() == json.dumps(expected, sort_keys=True, indent=4 * " ")
@@ -153,7 +153,6 @@ def test_request_set_methods() -> None:
     request = Request(
         "events",
         "default",
-        {"organization_id": 1, "referrer": "default"},
         BASIC_QUERY,
         Flags(consistent=True),
     )


### PR DESCRIPTION
### Overview
- Making this field required right away makes it so updating the Sentry repo with a new snuba-sdk version creates a huge set of changes which would be very hard to review
- This way also allows teams to pass tenant_ids themselves on their own time