### PR TITLE
feat(metrics): Add the base classes for MetricsQuery

### DIFF
--- a/snuba_sdk/expressions.py
+++ b/snuba_sdk/expressions.py
@@ -52,6 +52,12 @@ class InvalidArrayError(Exception):
         )
 
 
+def list_type(vals: Sequence[Any], type_classes: Sequence[Any]) -> bool:
+    return isinstance(vals, list) and all(
+        isinstance(v, tuple(type_classes)) for v in vals
+    )
+
+
 def is_literal(value: Any) -> bool:
     """
     Allow simple scalar types but not lists/tuples.
@@ -105,7 +111,7 @@ class Granularity(Expression):
         _validate_int_literal("granularity", self.granularity, 1, None)
 
 
-@dataclass
+@dataclass(frozen=True)
 class Totals(Expression):
     totals: bool
 

--- a/snuba_sdk/metrics_query.py
+++ b/snuba_sdk/metrics_query.py
@@ -1,0 +1,177 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+from datetime import datetime
+from typing import Any
+
+from snuba_sdk.column import Column
+from snuba_sdk.conditions import Condition
+from snuba_sdk.expressions import Expression, InvalidExpressionError, list_type
+from snuba_sdk.function import Function
+from snuba_sdk.orderby import Direction
+from snuba_sdk.query import BaseQuery
+from snuba_sdk.query_visitors import InvalidQueryError
+from snuba_sdk.timeseries import Timeseries
+
+ALLOWED_GRANULARITIES = (60, 3600, 86400)
+
+
+@dataclass(frozen=True)
+class Rollup(Expression):
+    """
+    Rollup instructs how the timeseries queries should be grouped on time. If the query is for a set of timeseries, then
+    the interval field should be specified. It is the number of seconds to group the timeseries by.
+    For a query that returns only the totals, specify Totals(True). A totals query can be ordered using the orderby field.
+    """
+
+    interval: int | None = None
+    totals: bool | None = None
+    orderby: Direction | None = None  # TODO: This doesn't make sense: ordered by what?
+
+    def validate(self) -> None:
+        if self.interval is not None:
+            if not isinstance(self.interval, int):
+                raise InvalidExpressionError(
+                    f"interval must be an integer and one of {ALLOWED_GRANULARITIES}"
+                )
+
+            # TODO: this can allow more values once we support automatic granularity calculations
+            if self.interval not in ALLOWED_GRANULARITIES:
+                raise InvalidExpressionError(
+                    f"interval {self.interval} must be one of {ALLOWED_GRANULARITIES}"
+                )
+
+        if self.interval is not None and self.totals is not None:
+            raise InvalidExpressionError(
+                "Only one of interval and totals can be set: Timeseries can't be rolled up by an interval and by a total"
+            )
+
+        if self.totals is not None:
+            if not isinstance(self.totals, bool):
+                raise InvalidExpressionError("totals must be a boolean")
+
+        if self.orderby is not None:
+            if not isinstance(self.orderby, Direction):
+                raise InvalidExpressionError("orderby must be a Direction object")
+
+        if self.totals is None and self.orderby is not None:
+            raise InvalidExpressionError(
+                "Metric queries can't be ordered without using totals"
+            )
+
+        if self.interval is None and not self.totals:
+            raise InvalidExpressionError(
+                "Rollup must have at least one of interval or totals"
+            )
+
+
+@dataclass
+class MetricScope(Expression):
+    """
+    This contains all the meta information necessary to resolve a metric and to safely query
+    the metrics dataset. All these values get automatically added to the query conditions.
+    The idea of this class is to contain all the filter values that are not represented by
+    tags in the API.
+
+    use_case_id is treated separately since it can be derived separate from the MRIs of the
+    metrics in the outer query.
+    """
+
+    org_ids: list[int]
+    project_ids: list[int]
+    use_case_id: int | None = None
+
+    def validate(self) -> None:
+        if not list_type(self.org_ids, (int,)):
+            raise InvalidExpressionError("org_ids must be a list of integers")
+
+        if not list_type(self.project_ids, (int,)):
+            raise InvalidExpressionError("project_ids must be a list of integers")
+
+        if self.use_case_id is not None and not isinstance(self.use_case_id, int):
+            raise InvalidExpressionError("use_case_id must be an int")
+
+    def set_use_case_id(self, use_case_id: int) -> MetricScope:
+        if not isinstance(use_case_id, int):
+            raise InvalidExpressionError("use_case_id must be an int")
+        return replace(self, use_case_id=use_case_id)
+
+
+@dataclass
+class MetricsQuery(BaseQuery):
+    """
+    A query on a set of timeseries. This class gets translated into a Snuba request string
+    that returns a list of timeseries data. In order to allow this class to be built incrementally,
+    it is not validated until it is serialized. Any specified filters or groupby fields are pushed
+    down to each of the Timeseries in the query field. It is immutable, so any set functions return
+    a new copy of the query, which also allows chaining calls.
+
+    This class is distinct from the Query class to allow for more specific validation and to provide
+    a simpler syntax for writing timeseries queries, which have fewer available features.
+    """
+
+    # TODO: This should support some kind of calculation. Simply using Function
+    # causes import loop problems.
+    query: Timeseries | None = None
+    filters: list[Condition] | None = None
+    groupby: list[Column] | None = None
+    start: datetime | None = None
+    end: datetime | None = None
+    rollup: Rollup | None = None
+    scope: MetricScope | None = None
+
+    def _replace(self, field: str, value: Any) -> MetricsQuery:
+        new = replace(self, **{field: value})
+        return new
+
+    def set_query(self, query: Function | Timeseries) -> MetricsQuery:
+        if not isinstance(query, (Function, Timeseries)):
+            raise InvalidQueryError("query must be a Function or Timeseries")
+        return self._replace("query", query)
+
+    def set_filters(self, filters: list[Condition]) -> MetricsQuery:
+        if not list_type(filters, (Condition,)):
+            raise InvalidQueryError("filters must be a list of Conditions")
+        return self._replace("filters", filters)
+
+    def set_groupby(self, groupby: list[Column]) -> MetricsQuery:
+        if not list_type(groupby, (Column,)):
+            raise InvalidQueryError("groupby must be a list of Columns")
+        return self._replace("groupby", groupby)
+
+    def set_start(self, start: datetime) -> MetricsQuery:
+        if not isinstance(start, datetime):
+            raise InvalidQueryError("start must be a datetime")
+        return self._replace("start", start)
+
+    def set_end(self, end: datetime) -> MetricsQuery:
+        if not isinstance(end, datetime):
+            raise InvalidQueryError("end must be a datetime")
+        return self._replace("end", end)
+
+    def set_rollup(self, rollup: Rollup) -> MetricsQuery:
+        if not isinstance(rollup, Rollup):
+            raise InvalidQueryError("rollup must be a Rollup")
+        return self._replace("rollup", rollup)
+
+    def set_scope(self, scope: MetricScope) -> MetricsQuery:
+        if not isinstance(scope, MetricScope):
+            raise InvalidQueryError("scope must be a MetricScope")
+        return self._replace("scope", scope)
+
+    def validate(self) -> None:
+        # TODO: Implement visitor
+        raise InvalidQueryError("Not implemented")
+
+    # TODO: implement a nicer version of this
+    # def __str__(self) -> str:
+    #     raise InvalidQueryError("Not implemented")
+
+    # TODO: Implement a vistor for this
+    def serialize(self) -> str:
+        self.validate()
+        raise InvalidQueryError("Not implemented")
+
+    def print(self) -> str:
+        self.validate()
+        raise InvalidQueryError("Not implemented")

--- a/snuba_sdk/request.py
+++ b/snuba_sdk/request.py
@@ -4,7 +4,7 @@ import json
 import re
 from dataclasses import asdict, dataclass, field, fields
 
-from snuba_sdk.query import Query
+from snuba_sdk.query import BaseQuery
 
 
 class InvalidRequestError(Exception):
@@ -44,7 +44,7 @@ FLAG_RE = re.compile(r"^[a-zA-Z0-9_\.\+\*\/:\-\[\]]*$")
 class Request:
     dataset: str
     app_id: str
-    query: Query
+    query: BaseQuery
     flags: Flags = field(default_factory=Flags)
     parent_api: str = "<unknown>"
     tenant_ids: dict[str, str | int] = field(default_factory=dict)

--- a/snuba_sdk/timeseries.py
+++ b/snuba_sdk/timeseries.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from snuba_sdk.column import Column
+from snuba_sdk.conditions import Condition
+from snuba_sdk.expressions import Expression, InvalidExpressionError, is_literal
+
+
+@dataclass(frozen=True)
+class Metric(Expression):
+    """
+    Metric represents a raw metric that is being populated. It can be created with
+    one of public name, mri or raw ID.
+    """
+
+    public_name: str | None = None
+    mri: str | None = None
+    id: int | None = None
+
+    def validate(self) -> None:
+        if not isinstance(self.public_name, str) and self.public_name is not None:
+            raise InvalidExpressionError("public_name must be a string")
+        if not isinstance(self.mri, str) and self.mri is not None:
+            raise InvalidExpressionError("mri must be a string")
+        if not isinstance(self.id, int) and self.id is not None:
+            raise InvalidExpressionError("id must be an integer")
+
+        if all(v is None for v in (self.public_name, self.mri, self.id)):
+            raise InvalidExpressionError(
+                "Metric must have at least one of public_name, mri or id"
+            )
+
+
+@dataclass
+class Timeseries(Expression):
+    """
+    A code representation of a single timeseries. This is the basic unit of a metrics query.
+    A raw metric, aggregated by an aggregate function. It can be filtered by tag conditions.
+    It can also grouped by a set of tag values, which will return one timeseries for each unique
+    grouping of tag values.
+    """
+
+    metric: Metric
+    aggregate: str
+    aggregate_params: list[Any] | None = None
+    filters: list[Condition] | None = None
+    groupby: list[Column] | None = None
+
+    def validate(self) -> None:
+        if not isinstance(self.metric, Metric):
+            raise InvalidExpressionError("metric must be an instance of a Metric")
+        self.metric.validate()
+
+        # TODO: Restrict which specific aggregates are allowed
+        # TODO: Validate aggregate_params based on the aggregate supplied e.g. quantile needs a float
+        if not isinstance(self.aggregate, str):
+            raise InvalidExpressionError("aggregate must be a string")
+        if self.aggregate_params is not None:
+            if not isinstance(self.aggregate_params, list):
+                raise InvalidExpressionError("aggregate_params must be a list")
+            for p in self.aggregate_params:
+                if not is_literal(p):
+                    raise InvalidExpressionError(
+                        "aggregate_params can only be simple types"
+                    )
+
+        # TODO: Validate these are tag conditions only
+        # TODO: Validate these are simple conditions e.g. tag[x] op literal
+        if self.filters is not None:
+            if not isinstance(self.filters, list):
+                raise InvalidExpressionError("filters must be a list")
+            for f in self.filters:
+                if not isinstance(f, Condition):
+                    raise InvalidExpressionError("filters must be a list of Conditions")
+
+        # TODO: Can you group by meta information like project_id?
+        # TODO: Validate these are appropriate columns for grouping
+        if self.groupby is not None:
+            if not isinstance(self.groupby, list):
+                raise InvalidExpressionError("groupby must be a list")
+            for g in self.groupby:
+                if not isinstance(g, Column):
+                    raise InvalidExpressionError("groupby must be a list of Columns")

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -6,6 +6,7 @@ from typing import Any, Callable, Optional
 from snuba_sdk.column import Column
 from snuba_sdk.conditions import And, BooleanCondition, Condition, Or
 from snuba_sdk.function import CurriedFunction, Function
+from snuba_sdk.timeseries import Timeseries
 
 
 # Wrappers to lazily build the expressions
@@ -84,3 +85,16 @@ def cur_func(
         return CurriedFunction(function, initers, params, alias)
 
     return to_func
+
+
+def timeseries(
+    metric: Any,
+    aggregate: Any,
+    aggregate_params: list[Any] | None = None,
+    filters: list[Any] | None = None,
+    groupby: list[Any] | None = None,
+) -> Callable[[], Any]:
+    def to_timeseries() -> Timeseries:
+        return Timeseries(metric, aggregate, aggregate_params, filters, groupby)
+
+    return to_timeseries

--- a/tests/test_metrics_expressions.py
+++ b/tests/test_metrics_expressions.py
@@ -1,0 +1,130 @@
+import re
+from typing import Any, Optional
+
+import pytest
+
+from snuba_sdk.expressions import InvalidExpressionError, Totals
+from snuba_sdk.metrics_query import MetricScope, Rollup
+
+# TODO: Test orderby properly once it's correctly implemented
+
+rollup_tests = [
+    pytest.param(60, None, None, None),
+    pytest.param(None, True, None, None),
+    pytest.param(
+        None,
+        None,
+        None,
+        InvalidExpressionError("Rollup must have at least one of interval or totals"),
+    ),
+    pytest.param(
+        61,
+        None,
+        None,
+        InvalidExpressionError("interval 61 must be one of (60, 3600, 86400)"),
+    ),
+    pytest.param(
+        "61",
+        None,
+        None,
+        InvalidExpressionError(
+            "interval must be an integer and one of (60, 3600, 86400)"
+        ),
+    ),
+    pytest.param(
+        None,
+        Totals(True),
+        None,
+        InvalidExpressionError("totals must be a boolean"),
+    ),
+    pytest.param(
+        None,
+        False,
+        None,
+        InvalidExpressionError("Rollup must have at least one of interval or totals"),
+    ),
+    pytest.param(
+        None,
+        "False",
+        None,
+        InvalidExpressionError("totals must be a boolean"),
+    ),
+]
+
+
+@pytest.mark.parametrize("interval, totals, orderby, exception", rollup_tests)
+def test_rollup(
+    interval: Any, totals: Any, orderby: Any, exception: Optional[Exception]
+) -> None:
+    if exception is not None:
+        with pytest.raises(type(exception), match=re.escape(str(exception))):
+            Rollup(interval, totals, orderby)
+    else:
+        assert Rollup(interval, totals, orderby).interval == interval
+
+
+metric_scope_tests = [
+    pytest.param([1], [11], 111, None),
+    pytest.param([1, 2], [11, 12], 111, None),
+    pytest.param([1, 2], [11, 12], None, None),
+    pytest.param(
+        "1",
+        [11, 12],
+        111,
+        InvalidExpressionError("org_ids must be a list of integers"),
+    ),
+    pytest.param(
+        [1, "2"],
+        [11, 12],
+        111,
+        InvalidExpressionError("org_ids must be a list of integers"),
+    ),
+    pytest.param(
+        None,
+        [11, 12],
+        111,
+        InvalidExpressionError("org_ids must be a list of integers"),
+    ),
+    pytest.param(
+        [1, 2],
+        "12",
+        111,
+        InvalidExpressionError("project_ids must be a list of integers"),
+    ),
+    pytest.param(
+        [1, 2],
+        [11, "12"],
+        111,
+        InvalidExpressionError("project_ids must be a list of integers"),
+    ),
+    pytest.param(
+        [1, 2],
+        None,
+        111,
+        InvalidExpressionError("project_ids must be a list of integers"),
+    ),
+    pytest.param(
+        [1, 2],
+        [11, 12],
+        "111",
+        InvalidExpressionError("use_case_id must be an int"),
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "org_ids, project_ids, use_case_id, exception", metric_scope_tests
+)
+def test_metric_scope(
+    org_ids: Any, project_ids: Any, use_case_id: Any, exception: Optional[Exception]
+) -> None:
+    if exception is not None:
+        with pytest.raises(type(exception), match=re.escape(str(exception))):
+            MetricScope(org_ids, project_ids, use_case_id)
+    else:
+        assert MetricScope(org_ids, project_ids, use_case_id).project_ids == project_ids
+        if use_case_id:  # It's not possible to "unset" a use_case_id
+            new_scope = MetricScope(org_ids, project_ids, None).set_use_case_id(
+                use_case_id
+            )
+            assert new_scope.use_case_id == use_case_id

--- a/tests/test_metrics_query.py
+++ b/tests/test_metrics_query.py
@@ -1,0 +1,120 @@
+import re
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from snuba_sdk import Column, Condition, Op
+from snuba_sdk.metrics_query import MetricScope, MetricsQuery, Rollup
+from snuba_sdk.query_visitors import InvalidQueryError
+from snuba_sdk.timeseries import Metric, Timeseries
+
+NOW = datetime(2023, 1, 2, 3, 4, 5, 6, timezone.utc)
+tests = [
+    pytest.param(
+        MetricsQuery(
+            query=Timeseries(
+                metric=Metric(
+                    "transaction.duration", "d:transactions/duration@millisecond", 123
+                ),
+                aggregate="max",
+                aggregate_params=None,
+                filters=None,
+                groupby=None,
+            ),
+            filters=None,
+            groupby=None,
+            start=NOW,
+            end=NOW + timedelta(days=14),
+            rollup=Rollup(interval=3600, totals=None),
+            scope=MetricScope(org_ids=[1], project_ids=[11], use_case_id=111),
+        ),
+        id="basic query",
+    ),
+    pytest.param(
+        MetricsQuery(
+            query=Timeseries(
+                metric=Metric(
+                    "transaction.duration", "d:transactions/duration@millisecond", 123
+                ),
+                aggregate="max",
+                aggregate_params=None,
+                filters=None,
+                groupby=None,
+            ),
+            filters=[Condition(Column("tags[transaction]"), Op.EQ, "foo")],
+            groupby=[Column("tags[status_code]")],
+            start=NOW,
+            end=NOW + timedelta(days=14),
+            rollup=Rollup(interval=3600, totals=None),
+        ),
+        id="top level filters/group by",
+    ),
+    pytest.param(
+        MetricsQuery(
+            query=Timeseries(
+                metric=Metric(
+                    "transaction.duration", "d:transactions/duration@millisecond", 123
+                ),
+                aggregate="max",
+                aggregate_params=None,
+                filters=[Condition(Column("tags[referrer]"), Op.EQ, "foo")],
+                groupby=[Column("tags[environment]")],
+            ),
+            filters=[Condition(Column("tags[transaction]"), Op.EQ, "foo")],
+            groupby=[Column("tags[status_code]")],
+            start=NOW,
+            end=NOW + timedelta(days=14),
+            rollup=Rollup(interval=3600, totals=None),
+        ),
+        id="top level filters/group by with low level filters",
+    ),
+    pytest.param(
+        MetricsQuery(
+            query=Timeseries(
+                metric=Metric(
+                    "transaction.duration", "d:transactions/duration@millisecond", 123
+                ),
+                aggregate="max",
+                aggregate_params=None,
+                filters=[Condition(Column("tags[referrer]"), Op.EQ, "foo")],
+                groupby=[Column("tags[environment]")],
+            ),
+            filters=[Condition(Column("tags[transaction]"), Op.EQ, "foo")],
+            groupby=[Column("tags[status_code]")],
+            start=NOW,
+            end=NOW + timedelta(days=14),
+            rollup=Rollup(interval=None, totals=True),
+        ),
+        id="totals query",
+    ),
+]
+
+
+@pytest.mark.parametrize("query", tests)
+def test_query(query: MetricsQuery) -> None:
+    with pytest.raises(
+        InvalidQueryError
+    ):  # TODO: This should be removed once validation is implemented
+        query.validate()
+
+
+invalid_tests = [
+    pytest.param(
+        MetricsQuery(
+            query=None,
+            filters=None,
+            groupby=None,
+            start=NOW,
+            end=NOW + timedelta(days=14),
+            rollup=Rollup(interval=3600, totals=None),
+        ),
+        InvalidQueryError("Not implemented"),
+        id="missing query",
+    ),
+]
+
+
+@pytest.mark.parametrize("query, exception", invalid_tests)
+def test_invalid_query(query: MetricsQuery, exception: Exception) -> None:
+    with pytest.raises(type(exception), match=re.escape(str(exception))):
+        query.validate()

--- a/tests/test_timeseries.py
+++ b/tests/test_timeseries.py
@@ -1,0 +1,99 @@
+import re
+from typing import Any, Callable, Optional
+
+import pytest
+
+from snuba_sdk.expressions import InvalidExpressionError
+from snuba_sdk.timeseries import Metric, Timeseries
+from tests import timeseries
+
+metric_tests = [
+    pytest.param(
+        "transaction.duration", "d:transactions/duration@millisecond", 123, None
+    ),
+    pytest.param(
+        "transaction.duration", "d:transactions/duration@millisecond", None, None
+    ),
+    pytest.param("transaction.duration", None, 123, None),
+    pytest.param(None, "d:transactions/duration@millisecond", 123, None),
+    pytest.param("transaction.duration", None, None, None),
+    pytest.param(None, "d:transactions/duration@millisecond", None, None),
+    pytest.param(None, None, 123, None),
+    pytest.param(
+        None,
+        None,
+        None,
+        InvalidExpressionError(
+            "Metric must have at least one of public_name, mri or id"
+        ),
+    ),
+    pytest.param(
+        123,
+        "d:transactions/duration@millisecond",
+        123,
+        InvalidExpressionError("public_name must be a string"),
+    ),
+    pytest.param(
+        "transaction.duration",
+        123,
+        123,
+        InvalidExpressionError("mri must be a string"),
+    ),
+    pytest.param(
+        "transaction.duration",
+        "d:transactions/duration@millisecond",
+        "wrong",
+        InvalidExpressionError("id must be an integer"),
+    ),
+]
+
+
+@pytest.mark.parametrize("public_name, mri, mid, exception", metric_tests)
+def test_metric(
+    public_name: Any, mri: Any, mid: Any, exception: Optional[Exception]
+) -> None:
+    if exception is not None:
+        with pytest.raises(type(exception), match=re.escape(str(exception))):
+            Metric(public_name, mri, mid)
+    else:
+        assert Metric(public_name, mri, mid).id == mid
+
+
+timeseries_tests = [
+    pytest.param(
+        timeseries(Metric(id=123), "count", None, None, None),
+        Timeseries(Metric(id=123), "count", None, None, None),
+        "",
+        None,
+        id="simple test",
+    ),
+    pytest.param(
+        timeseries(Metric(id=123), 456, None, None, None),
+        None,
+        "",
+        InvalidExpressionError("aggregate must be a string"),
+        id="invalid aggregate",
+    ),
+]
+
+# TODO: Add this back when we have a proper translator
+# TRANSLATOR = Translation()
+
+
+@pytest.mark.parametrize("func_wrapper, valid, translated, exception", timeseries_tests)
+def test_timeseries(
+    func_wrapper: Callable[[], Any],
+    valid: Optional[Timeseries],
+    translated: str,
+    exception: Optional[Exception],
+) -> None:
+    def verify() -> None:
+        exp = func_wrapper()
+        assert exp == valid
+        # assert TRANSLATOR.visit(exp) == translated # TODO: Translator doesn't exist yet
+
+    if exception is not None:
+        with pytest.raises(type(exception), match=re.escape(str(exception))):
+            verify()
+    else:
+        verify()


### PR DESCRIPTION
This PR adds all the initial classes necessary to build a MetricsQuery. It also
changes Request to allow MetricsQuery objects.

There are some basic tests added as essentially placeholders. They are not
comprehensive. Also, this PR does not add any visitors necessary for
validation/serialization etc.

This change is not meant to be functional, it is meant to unblock other
development so that work can proceed on improving and using these classes.

Changes to existing code: 
- Create a base query class that Request uses so that it doesn't need to be 
aware of multiple query classes.
- Move list_type to a place that can be used by multiple classes
