### PR TITLE
fix(metrics): Update use_case_id type

### DIFF
--- a/snuba_sdk/metrics_query.py
+++ b/snuba_sdk/metrics_query.py
@@ -79,7 +79,7 @@ class MetricScope(Expression):
 
     org_ids: list[int]
     project_ids: list[int]
-    use_case_id: int | None = None
+    use_case_id: str | None = None
 
     def validate(self) -> None:
         if not list_type(self.org_ids, (int,)):
@@ -88,12 +88,12 @@ class MetricScope(Expression):
         if not list_type(self.project_ids, (int,)):
             raise InvalidExpressionError("project_ids must be a list of integers")
 
-        if self.use_case_id is not None and not isinstance(self.use_case_id, int):
-            raise InvalidExpressionError("use_case_id must be an int")
+        if self.use_case_id is not None and not isinstance(self.use_case_id, str):
+            raise InvalidExpressionError("use_case_id must be an str")
 
-    def set_use_case_id(self, use_case_id: int) -> MetricScope:
-        if not isinstance(use_case_id, int):
-            raise InvalidExpressionError("use_case_id must be an int")
+    def set_use_case_id(self, use_case_id: str) -> MetricScope:
+        if not isinstance(use_case_id, str):
+            raise InvalidExpressionError("use_case_id must be an str")
         return replace(self, use_case_id=use_case_id)
 
 

--- a/tests/test_metrics_expressions.py
+++ b/tests/test_metrics_expressions.py
@@ -64,43 +64,43 @@ def test_rollup(
 
 
 metric_scope_tests = [
-    pytest.param([1], [11], 111, None),
-    pytest.param([1, 2], [11, 12], 111, None),
+    pytest.param([1], [11], "transactions", None),
+    pytest.param([1, 2], [11, 12], "transactions", None),
     pytest.param([1, 2], [11, 12], None, None),
     pytest.param(
         "1",
         [11, 12],
-        111,
+        "transactions",
         InvalidExpressionError("org_ids must be a list of integers"),
     ),
     pytest.param(
         [1, "2"],
         [11, 12],
-        111,
+        "transactions",
         InvalidExpressionError("org_ids must be a list of integers"),
     ),
     pytest.param(
         None,
         [11, 12],
-        111,
+        "transactions",
         InvalidExpressionError("org_ids must be a list of integers"),
     ),
     pytest.param(
         [1, 2],
         "12",
-        111,
+        "transactions",
         InvalidExpressionError("project_ids must be a list of integers"),
     ),
     pytest.param(
         [1, 2],
         [11, "12"],
-        111,
+        "transactions",
         InvalidExpressionError("project_ids must be a list of integers"),
     ),
     pytest.param(
         [1, 2],
         None,
-        111,
+        "transactions",
         InvalidExpressionError("project_ids must be a list of integers"),
     ),
     pytest.param(

--- a/tests/test_metrics_expressions.py
+++ b/tests/test_metrics_expressions.py
@@ -106,8 +106,8 @@ metric_scope_tests = [
     pytest.param(
         [1, 2],
         [11, 12],
-        "111",
-        InvalidExpressionError("use_case_id must be an int"),
+        1,
+        InvalidExpressionError("use_case_id must be an str"),
     ),
 ]
 

--- a/tests/test_metrics_query.py
+++ b/tests/test_metrics_query.py
@@ -26,7 +26,9 @@ tests = [
             start=NOW,
             end=NOW + timedelta(days=14),
             rollup=Rollup(interval=3600, totals=None),
-            scope=MetricScope(org_ids=[1], project_ids=[11], use_case_id=111),
+            scope=MetricScope(
+                org_ids=[1], project_ids=[11], use_case_id="transactions"
+            ),
         ),
         id="basic query",
     ),


### PR DESCRIPTION
The `use_case_id` in `MetricScope` should be type str as stored in ClickHouse.