### PR TITLE
feat(metrics) Add translators/validators for MetricsQuery

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,15 @@
 Changelog and versioning
 ==========================
 
+
+2.0.2
+-----
+
+- Add validators and translators for the MetricsQuery and all its child objects
+- Rename some components to be consistent between Metric and Metrics
+- Move MetricsScope and Rollup to the timeseries module
+    - Also stop treating them as Expressions, so they can be visited in a more nuanced way
+
 2.0.1
 -----
 

--- a/snuba_sdk/__init__.py
+++ b/snuba_sdk/__init__.py
@@ -4,10 +4,12 @@ from snuba_sdk.conditions import And, BooleanCondition, BooleanOp, Condition, Op
 from snuba_sdk.entity import Entity
 from snuba_sdk.expressions import Granularity, Limit, Offset, Totals
 from snuba_sdk.function import CurriedFunction, Function, Identifier, Lambda
+from snuba_sdk.metrics_query import MetricsQuery
 from snuba_sdk.orderby import Direction, LimitBy, OrderBy
 from snuba_sdk.query import Query
 from snuba_sdk.relationships import Join, Relationship
 from snuba_sdk.request import Flags, Request
+from snuba_sdk.timeseries import Metric, MetricsScope, Rollup, Timeseries
 
 __all__ = [
     "AliasedExpression",
@@ -27,6 +29,9 @@ __all__ = [
     "Lambda",
     "Limit",
     "LimitBy",
+    "Metric",
+    "MetricsQuery",
+    "MetricsScope",
     "Offset",
     "Op",
     "Or",
@@ -34,5 +39,7 @@ __all__ = [
     "Query",
     "Relationship",
     "Request",
+    "Rollup",
+    "Timeseries",
     "Totals",
 ]

--- a/snuba_sdk/metrics_query_visitors.py
+++ b/snuba_sdk/metrics_query_visitors.py
@@ -1,0 +1,225 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from datetime import datetime
+from typing import Generic, Mapping, Sequence, TypeVar
+
+# Import the module due to sphinx autodoc problems
+# https://github.com/agronholm/sphinx-autodoc-typehints#dealing-with-circular-imports
+from snuba_sdk import metrics_query as main
+from snuba_sdk.column import Column
+from snuba_sdk.conditions import BooleanCondition, Condition, ConditionGroup, Op
+from snuba_sdk.expressions import list_type
+from snuba_sdk.metrics_visitors import (
+    RollupSnQLPrinter,
+    ScopeSnQLPrinter,
+    TimeseriesSnQLPrinter,
+)
+from snuba_sdk.timeseries import MetricsScope, Rollup, Timeseries
+from snuba_sdk.visitors import Translation
+
+
+class InvalidMetricsQueryError(Exception):
+    pass
+
+
+QVisited = TypeVar("QVisited")
+
+
+class MetricsQueryVisitor(ABC, Generic[QVisited]):
+    def visit(self, query: main.MetricsQuery) -> QVisited:
+        fields = query.get_fields()
+        returns = {}
+        for field in fields:
+            returns[field] = getattr(self, f"_visit_{field}")(getattr(query, field))
+
+        return self._combine(query, returns)
+
+    @abstractmethod
+    def _combine(
+        self,
+        query: main.MetricsQuery,
+        returns: Mapping[str, QVisited | Mapping[str, QVisited]],
+    ) -> QVisited:
+        raise NotImplementedError
+
+    @abstractmethod
+    def _visit_query(self, query: Timeseries | None) -> Mapping[str, QVisited]:
+        raise NotImplementedError
+
+    @abstractmethod
+    def _visit_filters(self, filters: ConditionGroup | None) -> QVisited:
+        raise NotImplementedError
+
+    @abstractmethod
+    def _visit_groupby(self, groupby: Sequence[Column] | None) -> QVisited:
+        raise NotImplementedError
+
+    @abstractmethod
+    def _visit_start(self, start: datetime | None) -> QVisited:
+        raise NotImplementedError
+
+    @abstractmethod
+    def _visit_end(self, end: datetime | None) -> QVisited:
+        raise NotImplementedError
+
+    @abstractmethod
+    def _visit_rollup(self, rollup: Rollup | None) -> Mapping[str, QVisited]:
+        raise NotImplementedError
+
+    @abstractmethod
+    def _visit_scope(self, scope: MetricsScope | None) -> QVisited:
+        raise NotImplementedError
+
+
+class SnQLPrinter(MetricsQueryVisitor[str]):
+    def __init__(self, pretty: bool = False) -> None:
+        self.pretty = pretty
+        self.expression_visitor = Translation()
+        self.timeseries_visitor = TimeseriesSnQLPrinter(self.expression_visitor)
+        self.rollup_visitor = RollupSnQLPrinter(self.expression_visitor)
+        self.scope_visitor = ScopeSnQLPrinter(self.expression_visitor)
+        self.separator = "\n" if self.pretty else " "
+
+    def _combine(
+        self, query: main.MetricsQuery, returns: Mapping[str, str | Mapping[str, str]]
+    ) -> str:
+        clauses = []
+
+        timeseries_data = returns["query"]
+        assert isinstance(timeseries_data, dict)
+
+        entity = timeseries_data["entity"]
+        clauses.append(f"MATCH ({entity})")
+
+        select_columns = []
+        assert query.rollup is not None
+        if not query.rollup.totals:
+            select_columns.append(
+                "timestamp"
+            )  # TODO: For arbitrary intervals, this might be a function
+
+        if timeseries_data["groupby"]:
+            select_columns.append(timeseries_data["groupby"])
+
+        select_columns.append(timeseries_data["aggregate"])
+        clauses.append(f"SELECT {', '.join(select_columns)}")
+
+        if timeseries_data["groupby"]:
+            clauses.append(f"BY {timeseries_data['groupby']}")
+
+        where_clauses = []
+        where_clauses.append(timeseries_data["metric_filter"])
+        if timeseries_data["filters"]:
+            where_clauses.append(timeseries_data["filters"])
+        if returns["filters"]:
+            where_clauses.append(returns["filters"])
+
+        rollup_data = returns["rollup"]
+        assert isinstance(rollup_data, dict)
+
+        where_clauses.append(rollup_data["filter"])
+        where_clauses.append(returns["scope"])
+        where_clauses.append(returns["start"])
+        where_clauses.append(returns["end"])
+
+        clauses.append(f"WHERE {' AND '.join(where_clauses)}")
+
+        return self.separator.join(clauses)
+
+    def _visit_query(self, query: Timeseries | None) -> Mapping[str, str]:
+        if query is None:
+            raise InvalidMetricsQueryError("MetricQuery.query must not be None")
+
+        return self.timeseries_visitor.visit(query)
+
+    def _visit_filters(self, filters: ConditionGroup | None) -> str:
+        if filters is not None:
+            return f"{' AND '.join(self.expression_visitor.visit(c) for c in filters)}"
+        return ""
+
+    def _visit_groupby(self, groupby: Sequence[Column] | None) -> str:
+        if groupby is not None:
+            return f"{', '.join(self.expression_visitor.visit(g) for g in groupby)}"
+        return ""
+
+    def _visit_start(self, start: datetime | None) -> str:
+        if start is None:
+            raise InvalidMetricsQueryError("MetricQuery.start must not be None")
+
+        condition = Condition(Column("timestamp"), Op.GTE, start)
+        return self.expression_visitor.visit(condition)
+
+    def _visit_end(self, end: datetime | None) -> str:
+        if end is None:
+            raise InvalidMetricsQueryError("MetricQuery.end must not be None")
+
+        condition = Condition(Column("timestamp"), Op.LT, end)
+        return self.expression_visitor.visit(condition)
+
+    def _visit_rollup(self, rollup: Rollup | None) -> Mapping[str, str]:
+        if rollup is None:
+            raise InvalidMetricsQueryError("MetricQuery.rollup must not be None")
+
+        return self.rollup_visitor.visit(rollup)
+
+    def _visit_scope(self, scope: MetricsScope | None) -> str:
+        if scope is None:
+            raise InvalidMetricsQueryError("MetricQuery.scope must not be None")
+
+        return self.scope_visitor.visit(scope)
+
+
+class Validator(MetricsQueryVisitor[None]):
+    def _combine(
+        self, query: main.MetricsQuery, returns: Mapping[str, None | Mapping[str, None]]
+    ) -> None:
+        pass
+
+    def _visit_query(self, query: Timeseries | None) -> Mapping[str, None]:
+        if query is None:
+            raise InvalidMetricsQueryError("query is required for a metrics query")
+        elif not isinstance(query, Timeseries):
+            raise InvalidMetricsQueryError("query must be a Timeseries")
+        query.validate()
+        return {}  # Necessary for typing
+
+    def _visit_filters(self, filters: ConditionGroup | None) -> None:
+        if filters is not None:
+            if not list_type(filters, (Condition, BooleanCondition)):
+                raise InvalidMetricsQueryError("filters must be a list of Conditions")
+            (c.validate() for c in filters)
+
+    def _visit_groupby(self, groupby: Sequence[Column] | None) -> None:
+        if groupby is not None:
+            if not list_type(groupby, (Column,)):
+                raise InvalidMetricsQueryError("groupby must be a list of Columns")
+            for g in groupby:
+                g.validate()
+
+    def _visit_start(self, start: datetime | None) -> None:
+        if start is None:
+            raise InvalidMetricsQueryError("start is required for a metrics query")
+        elif not isinstance(start, datetime):
+            raise InvalidMetricsQueryError("start must be a datetime")
+
+    def _visit_end(self, end: datetime | None) -> None:
+        if end is None:
+            raise InvalidMetricsQueryError("end is required for a metrics query")
+        elif not isinstance(end, datetime):
+            raise InvalidMetricsQueryError("end must be a datetime")
+
+    def _visit_rollup(self, rollup: Rollup | None) -> Mapping[str, None]:
+        if rollup is None:
+            raise InvalidMetricsQueryError("rollup is required for a metrics query")
+        elif not isinstance(rollup, Rollup):
+            raise InvalidMetricsQueryError("rollup must be a Rollup object")
+        rollup.validate()
+        return {}
+
+    def _visit_scope(self, scope: MetricsScope | None) -> None:
+        if scope is None:
+            raise InvalidMetricsQueryError("scope is required for a metrics query")
+        elif not isinstance(scope, MetricsScope):
+            raise InvalidMetricsQueryError("scope must be a MetricsScope object")
+        scope.validate()

--- a/snuba_sdk/metrics_visitors.py
+++ b/snuba_sdk/metrics_visitors.py
@@ -1,0 +1,206 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Any, Generic, Mapping, TypeVar
+
+from snuba_sdk.column import Column
+from snuba_sdk.conditions import And, Condition, ConditionGroup, Op
+from snuba_sdk.expressions import InvalidExpressionError
+from snuba_sdk.function import CurriedFunction
+from snuba_sdk.orderby import OrderBy
+from snuba_sdk.timeseries import Metric, MetricsScope, Rollup, Timeseries
+from snuba_sdk.visitors import Translation
+
+TVisited = TypeVar("TVisited")
+
+
+class TimeseriesVisitor(ABC, Generic[TVisited]):
+    def visit(self, timeseries: Timeseries) -> Mapping[str, TVisited]:
+        fields = timeseries.get_fields()
+        returns = {}
+        for field in fields:
+            if field == "aggregate_params":
+                continue
+            elif field == "aggregate":
+                returns[field] = self._visit_aggregate(
+                    getattr(timeseries, field), timeseries.aggregate_params
+                )
+            else:
+                returns[field] = getattr(self, f"_visit_{field}")(
+                    getattr(timeseries, field)
+                )
+
+        return self._combine(timeseries, returns)
+
+    @abstractmethod
+    def _combine(
+        self,
+        timeseries: Timeseries,
+        returns: Mapping[str, TVisited | Mapping[str, TVisited]],
+    ) -> Mapping[str, TVisited]:
+        raise NotImplementedError
+
+    @abstractmethod
+    def _visit_metric(self, metric: Metric) -> Mapping[str, TVisited]:
+        raise NotImplementedError
+
+    @abstractmethod
+    def _visit_aggregate(
+        self, aggregate: str, aggregate_params: list[Any] | None
+    ) -> TVisited:
+        raise NotImplementedError
+
+    @abstractmethod
+    def _visit_filters(self, filters: ConditionGroup | None) -> TVisited:
+        raise NotImplementedError
+
+    @abstractmethod
+    def _visit_groupby(self, groupby: list[Column] | None) -> TVisited:
+        raise NotImplementedError
+
+
+# Used in the SELECT and in the ORDER BY
+AGGREGATE_ALIAS = "aggregate_value"
+
+
+class TimeseriesSnQLPrinter(TimeseriesVisitor[str]):
+    def __init__(
+        self,
+        expression_visitor: Translation | None = None,
+        metrics_visitor: MetricSnQLPrinter | None = None,
+    ) -> None:
+        self.expression_visitor = expression_visitor or Translation()
+        self.metrics_visitor = metrics_visitor or MetricSnQLPrinter(expression_visitor)
+
+    def _combine(
+        self,
+        timeseries: Timeseries,
+        returns: Mapping[str, str | Mapping[str, str]],
+    ) -> Mapping[str, str]:
+        metric_data = returns["metric"]
+        assert isinstance(metric_data, Mapping)  # mypy
+
+        ret = {
+            "entity": metric_data["entity"],
+            "aggregate": str(returns["aggregate"]),
+            "metric_filter": metric_data["metric_filter"],
+        }
+
+        if returns["filters"] is not None:
+            ret["filters"] = str(returns["filters"])
+
+        if returns["groupby"] is not None:
+            ret["groupby"] = str(returns["groupby"])
+
+        if timeseries.groupby is not None:
+            ret[
+                "groupby"
+            ] = f"{', '.join(self.expression_visitor.visit(c) for c in timeseries.groupby)}"
+
+        return ret
+
+    def _visit_metric(self, metric: Metric) -> Mapping[str, str]:
+        return self.metrics_visitor.visit(metric)
+
+    def _visit_aggregate(
+        self, aggregate: str, aggregate_params: list[Any] | None
+    ) -> str:
+        aggregate = CurriedFunction(
+            aggregate, aggregate_params, [Column("value")], AGGREGATE_ALIAS
+        )
+        return self.expression_visitor.visit(aggregate)
+
+    def _visit_filters(self, filters: ConditionGroup | None) -> str:
+        if filters is not None:
+            return " AND ".join(self.expression_visitor.visit(c) for c in filters)
+        return ""
+
+    def _visit_groupby(self, groupby: list[Column] | None) -> str:
+        if groupby is not None:
+            return ", ".join(self.expression_visitor.visit(c) for c in groupby)
+        return ""
+
+
+class MetricVisitor(ABC, Generic[TVisited]):
+    @abstractmethod
+    def visit(self, metric: Metric) -> TVisited:
+        raise NotImplementedError
+
+
+class MetricSnQLPrinter(MetricVisitor[Mapping[str, str]]):
+    def __init__(self, translator: Translation | None = None) -> None:
+        self.translator = translator or Translation()
+
+    def visit(self, metric: Metric) -> Mapping[str, str]:
+        if metric.id is None:
+            raise InvalidExpressionError("metric.id is required for serialization")
+
+        metric_filter = Condition(
+            lhs=Column("metric_id"),
+            op=Op.EQ,
+            rhs=metric.id,
+        )
+        # TODO: Add a function that looks up the appropriate entity for a metric?
+        assert metric.entity is not None
+        return {
+            "entity": metric.entity,
+            "metric_filter": self.translator.visit(metric_filter),
+        }
+
+
+class RollupVisitor(ABC, Generic[TVisited]):
+    @abstractmethod
+    def visit(self, rollup: Rollup) -> TVisited:
+        raise NotImplementedError
+
+
+class RollupSnQLPrinter(RollupVisitor[Mapping[str, str]]):
+    def __init__(self, translator: Translation | None = None) -> None:
+        self.translator = translator or Translation()
+
+    def visit(self, rollup: Rollup) -> Mapping[str, str]:
+        condition = Condition(
+            lhs=Column("granularity"),
+            op=Op.EQ,
+            rhs=rollup.interval,
+        )
+        orderby = ""
+        if rollup.orderby is not None:
+            orderby_exp = OrderBy(Column(AGGREGATE_ALIAS), rollup.orderby)
+            orderby = self.translator.visit(orderby_exp)
+
+        return {"orderby": orderby, "filter": self.translator.visit(condition)}
+
+
+class ScopeVisitor(ABC, Generic[TVisited]):
+    @abstractmethod
+    def visit(self, scope: MetricsScope) -> TVisited:
+        raise NotImplementedError
+
+
+class ScopeSnQLPrinter(ScopeVisitor[str]):
+    def __init__(self, translator: Translation | None = None) -> None:
+        self.translator = translator or Translation()
+
+    def visit(self, scope: MetricsScope) -> str:
+        condition = And(
+            [
+                Condition(
+                    Column("org_id"),
+                    Op.IN,
+                    scope.org_ids,
+                ),
+                Condition(
+                    Column("project_id"),
+                    Op.IN,
+                    scope.project_ids,
+                ),
+                Condition(
+                    Column("use_case_id"),
+                    Op.EQ,
+                    scope.use_case_id,
+                ),
+            ]
+        )
+
+        return self.translator.visit(condition)

--- a/snuba_sdk/query.py
+++ b/snuba_sdk/query.py
@@ -46,6 +46,10 @@ class BaseQuery(ABC):
     def print(self) -> str:
         raise NotImplementedError
 
+    def get_fields(self) -> Sequence[str]:
+        self_fields = fields(self)  # Verified the order in the Python source
+        return tuple(f.name for f in self_fields)
+
 
 @dataclass(frozen=True)
 class Query(BaseQuery):
@@ -91,10 +95,6 @@ class Query(BaseQuery):
     def _replace(self, field: str, value: Any) -> Query:
         new = replace(self, **{field: value})
         return new
-
-    def get_fields(self) -> Sequence[str]:
-        self_fields = fields(self)  # Verified the order in the Python source
-        return tuple(f.name for f in self_fields)
 
     def set_match(self, match: Union[Entity, Join, Query]) -> Query:
         if not isinstance(match, (Entity, Join, Query)):

--- a/snuba_sdk/timeseries.py
+++ b/snuba_sdk/timeseries.py
@@ -13,18 +13,6 @@ class InvalidTimeseriesError(Exception):
     pass
 
 
-VALID_ENTITIES = set(
-    [
-        "generic_metrics_distributions",
-        "generic_metrics_counters",
-        "generic_metrics_sets",
-        "metrics_distributions",
-        "metrics_counters",
-        "metrics_sets",
-    ]
-)
-
-
 @dataclass(frozen=True)
 class Metric:
     """
@@ -53,10 +41,6 @@ class Metric:
             raise InvalidTimeseriesError("id must be an integer")
         if self.entity is not None and not isinstance(self.entity, str):
             raise InvalidTimeseriesError("entity must be a string")
-        if self.entity is not None and self.entity not in VALID_ENTITIES:
-            raise InvalidTimeseriesError(
-                f"'{self.entity}' is not a valid metrics entity"
-            )
 
         if all(v is None for v in (self.public_name, self.mri, self.id)):
             raise InvalidTimeseriesError(
@@ -77,6 +61,11 @@ class Metric:
         if not isinstance(id, int):
             raise InvalidExpressionError("id must be an int")
         return replace(self, id=id)
+
+    def set_entity(self, entity: str) -> Metric:
+        if not isinstance(entity, str):
+            raise InvalidExpressionError("entity must be an str")
+        return replace(self, entity=entity)
 
 
 @dataclass

--- a/snuba_sdk/timeseries.py
+++ b/snuba_sdk/timeseries.py
@@ -1,15 +1,32 @@
 from __future__ import annotations
 
-from dataclasses import dataclass, replace
-from typing import Any
+from dataclasses import dataclass, fields, replace
+from typing import Any, Sequence
 
 from snuba_sdk.column import Column
 from snuba_sdk.conditions import Condition
-from snuba_sdk.expressions import Expression, InvalidExpressionError, is_literal
+from snuba_sdk.expressions import InvalidExpressionError, is_literal, list_type
+from snuba_sdk.orderby import Direction
+
+
+class InvalidTimeseriesError(Exception):
+    pass
+
+
+VALID_ENTITIES = set(
+    [
+        "generic_metrics_distributions",
+        "generic_metrics_counters",
+        "generic_metrics_sets",
+        "metrics_distributions",
+        "metrics_counters",
+        "metrics_sets",
+    ]
+)
 
 
 @dataclass(frozen=True)
-class Metric(Expression):
+class Metric:
     """
     Metric represents a raw metric that is being populated. It can be created with
     one of public name, mri or raw ID.
@@ -18,17 +35,31 @@ class Metric(Expression):
     public_name: str | None = None
     mri: str | None = None
     id: int | None = None
+    entity: str | None = None
+
+    def __post_init__(self) -> None:
+        self.validate()
+
+    def get_fields(self) -> Sequence[str]:
+        self_fields = fields(self)  # Verified the order in the Python source
+        return tuple(f.name for f in self_fields)
 
     def validate(self) -> None:
-        if not isinstance(self.public_name, str) and self.public_name is not None:
-            raise InvalidExpressionError("public_name must be a string")
-        if not isinstance(self.mri, str) and self.mri is not None:
-            raise InvalidExpressionError("mri must be a string")
-        if not isinstance(self.id, int) and self.id is not None:
-            raise InvalidExpressionError("id must be an integer")
+        if self.public_name is not None and not isinstance(self.public_name, str):
+            raise InvalidTimeseriesError("public_name must be a string")
+        if self.mri is not None and not isinstance(self.mri, str):
+            raise InvalidTimeseriesError("mri must be a string")
+        if self.id is not None and not isinstance(self.id, int):
+            raise InvalidTimeseriesError("id must be an integer")
+        if self.entity is not None and not isinstance(self.entity, str):
+            raise InvalidTimeseriesError("entity must be a string")
+        if self.entity is not None and self.entity not in VALID_ENTITIES:
+            raise InvalidTimeseriesError(
+                f"'{self.entity}' is not a valid metrics entity"
+            )
 
         if all(v is None for v in (self.public_name, self.mri, self.id)):
-            raise InvalidExpressionError(
+            raise InvalidTimeseriesError(
                 "Metric must have at least one of public_name, mri or id"
             )
 
@@ -49,7 +80,7 @@ class Metric(Expression):
 
 
 @dataclass
-class Timeseries(Expression):
+class Timeseries:
     """
     A code representation of a single timeseries. This is the basic unit of a metrics query.
     A raw metric, aggregated by an aggregate function. It can be filtered by tag conditions.
@@ -63,43 +94,151 @@ class Timeseries(Expression):
     filters: list[Condition] | None = None
     groupby: list[Column] | None = None
 
+    def __post_init__(self) -> None:
+        self.validate()
+
+    def get_fields(self) -> Sequence[str]:
+        self_fields = fields(self)  # Verified the order in the Python source
+        return tuple(f.name for f in self_fields)
+
     def validate(self) -> None:
         if not isinstance(self.metric, Metric):
-            raise InvalidExpressionError("metric must be an instance of a Metric")
+            raise InvalidTimeseriesError("metric must be an instance of a Metric")
         self.metric.validate()
 
         # TODO: Restrict which specific aggregates are allowed
         # TODO: Validate aggregate_params based on the aggregate supplied e.g. quantile needs a float
         if not isinstance(self.aggregate, str):
-            raise InvalidExpressionError("aggregate must be a string")
+            raise InvalidTimeseriesError("aggregate must be a string")
         if self.aggregate_params is not None:
             if not isinstance(self.aggregate_params, list):
-                raise InvalidExpressionError("aggregate_params must be a list")
+                raise InvalidTimeseriesError("aggregate_params must be a list")
             for p in self.aggregate_params:
                 if not is_literal(p):
-                    raise InvalidExpressionError(
-                        "aggregate_params can only be simple types"
+                    raise InvalidTimeseriesError(
+                        "aggregate_params can only be literal types"
                     )
 
         # TODO: Validate these are tag conditions only
         # TODO: Validate these are simple conditions e.g. tag[x] op literal
         if self.filters is not None:
             if not isinstance(self.filters, list):
-                raise InvalidExpressionError("filters must be a list")
+                raise InvalidTimeseriesError("filters must be a list")
             for f in self.filters:
                 if not isinstance(f, Condition):
-                    raise InvalidExpressionError("filters must be a list of Conditions")
+                    raise InvalidTimeseriesError("filters must be a list of Conditions")
 
         # TODO: Can you group by meta information like project_id?
         # TODO: Validate these are appropriate columns for grouping
         if self.groupby is not None:
             if not isinstance(self.groupby, list):
-                raise InvalidExpressionError("groupby must be a list")
+                raise InvalidTimeseriesError("groupby must be a list")
             for g in self.groupby:
                 if not isinstance(g, Column):
-                    raise InvalidExpressionError("groupby must be a list of Columns")
+                    raise InvalidTimeseriesError("groupby must be a list of Columns")
 
     def set_metric(self, metric: Metric) -> Timeseries:
         if not isinstance(metric, Metric):
-            raise InvalidExpressionError("metric must be a Metric")
+            raise InvalidTimeseriesError("metric must be a Metric")
         return replace(self, metric=metric)
+
+
+ALLOWED_GRANULARITIES = (60, 3600, 86400)
+
+
+@dataclass(frozen=True)
+class Rollup:
+    """
+    Rollup instructs how the timeseries queries should be grouped on time. If the query is for a set of timeseries, then
+    the interval field should be specified. It is the number of seconds to group the timeseries by.
+    For a query that returns only the totals, specify Totals(True). A totals query can be ordered using the orderby field.
+    """
+
+    interval: int | None = None
+    totals: bool | None = None
+    orderby: Direction | None = None  # TODO: This doesn't make sense: ordered by what?
+
+    def __post_init__(self) -> None:
+        self.validate()
+
+    def validate(self) -> None:
+        # TODO: This value is currently used directly to select a granularity
+        # However, a totals query in theory shouldn't need to specify an interval
+        # Ensure an interval is always set for now, and once we have code in place
+        # to allow arbitrary intervals we can also add code to pick the appropriate
+        # granularity based on the start/end interval of the query.
+        if self.interval is None:
+            raise InvalidExpressionError(
+                f"interval must be an integer and one of {ALLOWED_GRANULARITIES}"
+            )
+
+        if not isinstance(self.interval, int):
+            raise InvalidExpressionError(
+                f"interval must be an integer and one of {ALLOWED_GRANULARITIES}"
+            )
+
+        # TODO: this can allow more values once we support automatic granularity calculations
+        if self.interval not in ALLOWED_GRANULARITIES:
+            raise InvalidExpressionError(
+                f"interval {self.interval} must be one of {ALLOWED_GRANULARITIES}"
+            )
+
+        # TODO: Add this back once we can properly infer granularity. See comment above.
+        # if self.interval is not None and self.totals is not None:
+        #     raise InvalidExpressionError(
+        #         "Only one of interval and totals can be set: Timeseries can't be rolled up by an interval and by a total"
+        #     )
+
+        if self.totals is not None:
+            if not isinstance(self.totals, bool):
+                raise InvalidExpressionError("totals must be a boolean")
+
+        if self.orderby is not None:
+            if not isinstance(self.orderby, Direction):
+                raise InvalidExpressionError("orderby must be a Direction object")
+
+        if self.totals is None and self.orderby is not None:
+            raise InvalidExpressionError(
+                "Metric queries can't be ordered without using totals"
+            )
+
+        # TODO: Add this back once we can properly infer granularity. See comment above.
+        # if self.interval is None and not self.totals:
+        #     raise InvalidExpressionError(
+        #         "Rollup must have at least one of interval or totals"
+        #     )
+
+
+@dataclass
+class MetricsScope:
+    """
+    This contains all the meta information necessary to resolve a metric and to safely query
+    the metrics dataset. All these values get automatically added to the query conditions.
+    The idea of this class is to contain all the filter values that are not represented by
+    tags in the API.
+
+    use_case_id is treated separately since it can be derived separate from the MRIs of the
+    metrics in the outer query.
+    """
+
+    org_ids: list[int]
+    project_ids: list[int]
+    use_case_id: str | None = None
+
+    def __post_init__(self) -> None:
+        self.validate()
+
+    def validate(self) -> None:
+        if not list_type(self.org_ids, (int,)):
+            raise InvalidExpressionError("org_ids must be a list of integers")
+
+        if not list_type(self.project_ids, (int,)):
+            raise InvalidExpressionError("project_ids must be a list of integers")
+
+        if self.use_case_id is not None and not isinstance(self.use_case_id, str):
+            raise InvalidExpressionError("use_case_id must be an str")
+
+    def set_use_case_id(self, use_case_id: str) -> MetricsScope:
+        if not isinstance(use_case_id, str):
+            raise InvalidExpressionError("use_case_id must be an str")
+        return replace(self, use_case_id=use_case_id)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -90,9 +90,9 @@ def cur_func(
 def timeseries(
     metric: Any,
     aggregate: Any,
-    aggregate_params: list[Any] | None = None,
-    filters: list[Any] | None = None,
-    groupby: list[Any] | None = None,
+    aggregate_params: Any = None,
+    filters: Any = None,
+    groupby: Any = None,
 ) -> Callable[[], Any]:
     def to_timeseries() -> Timeseries:
         return Timeseries(metric, aggregate, aggregate_params, filters, groupby)

--- a/tests/test_metrics_expressions.py
+++ b/tests/test_metrics_expressions.py
@@ -1,24 +1,36 @@
+from __future__ import annotations
+
 import re
-from typing import Any, Optional
+from typing import Any, Mapping, Optional
 
 import pytest
 
 from snuba_sdk.expressions import InvalidExpressionError, Totals
-from snuba_sdk.metrics_query import MetricScope, Rollup
-
-# TODO: Test orderby properly once it's correctly implemented
+from snuba_sdk.metrics_visitors import RollupSnQLPrinter, ScopeSnQLPrinter
+from snuba_sdk.orderby import Direction
+from snuba_sdk.timeseries import MetricsScope, Rollup
 
 rollup_tests = [
-    pytest.param(60, None, None, None),
-    pytest.param(None, True, None, None),
+    pytest.param(60, None, None, {"orderby": "", "filter": "granularity = 60"}, None),
+    pytest.param(
+        60,
+        True,
+        Direction.ASC,
+        {"orderby": "aggregate_value ASC", "filter": "granularity = 60"},
+        None,
+    ),
     pytest.param(
         None,
         None,
         None,
-        InvalidExpressionError("Rollup must have at least one of interval or totals"),
+        None,
+        InvalidExpressionError(
+            "interval must be an integer and one of (60, 3600, 86400)"
+        ),
     ),
     pytest.param(
         61,
+        None,
         None,
         None,
         InvalidExpressionError("interval 61 must be one of (60, 3600, 86400)"),
@@ -27,104 +39,149 @@ rollup_tests = [
         "61",
         None,
         None,
+        None,
         InvalidExpressionError(
             "interval must be an integer and one of (60, 3600, 86400)"
         ),
     ),
     pytest.param(
-        None,
+        60,
         Totals(True),
         None,
+        None,
         InvalidExpressionError("totals must be a boolean"),
     ),
     pytest.param(
-        None,
-        False,
-        None,
-        InvalidExpressionError("Rollup must have at least one of interval or totals"),
-    ),
-    pytest.param(
-        None,
+        60,
         "False",
         None,
+        None,
         InvalidExpressionError("totals must be a boolean"),
+    ),
+    pytest.param(
+        60,
+        None,
+        6,
+        None,
+        InvalidExpressionError("orderby must be a Direction object"),
     ),
 ]
 
 
-@pytest.mark.parametrize("interval, totals, orderby, exception", rollup_tests)
+TRANSLATOR = RollupSnQLPrinter()
+
+
+@pytest.mark.parametrize(
+    "interval, totals, orderby, translated, exception", rollup_tests
+)
 def test_rollup(
-    interval: Any, totals: Any, orderby: Any, exception: Optional[Exception]
+    interval: Any,
+    totals: Any,
+    orderby: Any,
+    translated: Mapping[str, str],
+    exception: Optional[Exception],
 ) -> None:
     if exception is not None:
         with pytest.raises(type(exception), match=re.escape(str(exception))):
             Rollup(interval, totals, orderby)
     else:
-        assert Rollup(interval, totals, orderby).interval == interval
+        rollup = Rollup(interval, totals, orderby)
+        assert rollup.interval == interval
+        assert TRANSLATOR.visit(rollup) == translated
 
 
 metric_scope_tests = [
-    pytest.param([1], [11], "transactions", None),
-    pytest.param([1, 2], [11, 12], "transactions", None),
-    pytest.param([1, 2], [11, 12], None, None),
+    pytest.param(
+        [1],
+        [11],
+        "transactions",
+        "(org_id IN array(1) AND project_id IN array(11) AND use_case_id = 'transactions')",
+        None,
+    ),
+    pytest.param(
+        [1, 2],
+        [11, 12],
+        "transactions",
+        "(org_id IN array(1, 2) AND project_id IN array(11, 12) AND use_case_id = 'transactions')",
+        None,
+    ),
+    pytest.param([1, 2], [11, 12], None, None, None),
     pytest.param(
         "1",
         [11, 12],
         "transactions",
+        None,
         InvalidExpressionError("org_ids must be a list of integers"),
     ),
     pytest.param(
         [1, "2"],
         [11, 12],
         "transactions",
+        None,
         InvalidExpressionError("org_ids must be a list of integers"),
     ),
     pytest.param(
         None,
         [11, 12],
         "transactions",
+        None,
         InvalidExpressionError("org_ids must be a list of integers"),
     ),
     pytest.param(
         [1, 2],
         "12",
         "transactions",
+        None,
         InvalidExpressionError("project_ids must be a list of integers"),
     ),
     pytest.param(
         [1, 2],
         [11, "12"],
         "transactions",
+        None,
         InvalidExpressionError("project_ids must be a list of integers"),
     ),
     pytest.param(
         [1, 2],
         None,
         "transactions",
+        None,
         InvalidExpressionError("project_ids must be a list of integers"),
     ),
     pytest.param(
         [1, 2],
         [11, 12],
-        1,
+        111,
+        None,
         InvalidExpressionError("use_case_id must be an str"),
     ),
 ]
 
+SCOPE_TRANSLATOR = ScopeSnQLPrinter()
+
 
 @pytest.mark.parametrize(
-    "org_ids, project_ids, use_case_id, exception", metric_scope_tests
+    "org_ids, project_ids, use_case_id, translated, exception", metric_scope_tests
 )
 def test_metric_scope(
-    org_ids: Any, project_ids: Any, use_case_id: Any, exception: Optional[Exception]
+    org_ids: Any,
+    project_ids: Any,
+    use_case_id: Any,
+    translated: str | None,
+    exception: Exception | None,
 ) -> None:
     if exception is not None:
         with pytest.raises(type(exception), match=re.escape(str(exception))):
-            MetricScope(org_ids, project_ids, use_case_id)
+            m = MetricsScope(org_ids, project_ids, use_case_id)
+            SCOPE_TRANSLATOR.visit(m)
     else:
-        assert MetricScope(org_ids, project_ids, use_case_id).project_ids == project_ids
+        scope = MetricsScope(org_ids, project_ids, use_case_id)
+        assert scope.project_ids == project_ids
+        if translated is not None:
+            assert SCOPE_TRANSLATOR.visit(scope) == translated
+
         if use_case_id:  # It's not possible to "unset" a use_case_id
-            new_scope = MetricScope(org_ids, project_ids, None).set_use_case_id(
+            new_scope = MetricsScope(org_ids, project_ids, None).set_use_case_id(
                 use_case_id
             )
             assert new_scope.use_case_id == use_case_id

--- a/tests/test_timeseries.py
+++ b/tests/test_timeseries.py
@@ -110,14 +110,6 @@ metric_tests = [
         None,
         InvalidTimeseriesError("entity must be a string"),
     ),
-    pytest.param(
-        "transaction.duration",
-        "d:transactions/duration@millisecond",
-        123,
-        "generic_metrics",
-        None,
-        InvalidTimeseriesError("'generic_metrics' is not a valid metrics entity"),
-    ),
 ]
 
 METRIC_PRINTER = MetricSnQLPrinter()

--- a/tests/test_timeseries.py
+++ b/tests/test_timeseries.py
@@ -1,29 +1,80 @@
+from __future__ import annotations
+
 import re
-from typing import Any, Callable, Optional
+from typing import Any, Callable, Mapping, Optional
 
 import pytest
 
-from snuba_sdk.expressions import InvalidExpressionError
-from snuba_sdk.timeseries import Metric, Timeseries
+from snuba_sdk.column import Column
+from snuba_sdk.conditions import Condition, Op
+from snuba_sdk.metrics_visitors import MetricSnQLPrinter, TimeseriesSnQLPrinter
+from snuba_sdk.timeseries import InvalidTimeseriesError, Metric
 from tests import timeseries
 
 metric_tests = [
     pytest.param(
-        "transaction.duration", "d:transactions/duration@millisecond", 123, None
+        "transaction.duration",
+        "d:transactions/duration@millisecond",
+        123,
+        "generic_metrics_distributions",
+        {"entity": "generic_metrics_distributions", "metric_filter": "metric_id = 123"},
+        None,
     ),
     pytest.param(
-        "transaction.duration", "d:transactions/duration@millisecond", None, None
+        "transaction.duration",
+        "d:transactions/duration@millisecond",
+        None,
+        "generic_metrics_distributions",
+        None,
+        None,
     ),
-    pytest.param("transaction.duration", None, 123, None),
-    pytest.param(None, "d:transactions/duration@millisecond", 123, None),
-    pytest.param("transaction.duration", None, None, None),
-    pytest.param(None, "d:transactions/duration@millisecond", None, None),
-    pytest.param(None, None, 123, None),
+    pytest.param(
+        "transaction.duration",
+        None,
+        123,
+        "generic_metrics_distributions",
+        {"entity": "generic_metrics_distributions", "metric_filter": "metric_id = 123"},
+        None,
+    ),
+    pytest.param(
+        None,
+        "d:transactions/duration@millisecond",
+        123,
+        "generic_metrics_distributions",
+        {"entity": "generic_metrics_distributions", "metric_filter": "metric_id = 123"},
+        None,
+    ),
+    pytest.param(
+        "transaction.duration",
+        None,
+        None,
+        "generic_metrics_distributions",
+        None,
+        None,
+    ),
+    pytest.param(
+        None,
+        "d:transactions/duration@millisecond",
+        None,
+        "generic_metrics_distributions",
+        None,
+        None,
+    ),
+    pytest.param(
+        None,
+        None,
+        123,
+        "generic_metrics_distributions",
+        {"entity": "generic_metrics_distributions", "metric_filter": "metric_id = 123"},
+        None,
+    ),
     pytest.param(
         None,
         None,
         None,
-        InvalidExpressionError(
+        "generic_metrics_distributions",
+        None,
+        InvalidTimeseriesError(
             "Metric must have at least one of public_name, mri or id"
         ),
     ),
@@ -31,66 +82,243 @@ metric_tests = [
         123,
         "d:transactions/duration@millisecond",
         123,
-        InvalidExpressionError("public_name must be a string"),
+        "generic_metrics_distributions",
+        None,
+        InvalidTimeseriesError("public_name must be a string"),
     ),
     pytest.param(
         "transaction.duration",
         123,
         123,
-        InvalidExpressionError("mri must be a string"),
+        "generic_metrics_distributions",
+        None,
+        InvalidTimeseriesError("mri must be a string"),
     ),
     pytest.param(
         "transaction.duration",
         "d:transactions/duration@millisecond",
         "wrong",
-        InvalidExpressionError("id must be an integer"),
+        "generic_metrics_distributions",
+        None,
+        InvalidTimeseriesError("id must be an integer"),
+    ),
+    pytest.param(
+        "transaction.duration",
+        "d:transactions/duration@millisecond",
+        123,
+        667,
+        None,
+        InvalidTimeseriesError("entity must be a string"),
+    ),
+    pytest.param(
+        "transaction.duration",
+        "d:transactions/duration@millisecond",
+        123,
+        "generic_metrics",
+        None,
+        InvalidTimeseriesError("'generic_metrics' is not a valid metrics entity"),
     ),
 ]
 
+METRIC_PRINTER = MetricSnQLPrinter()
 
-@pytest.mark.parametrize("public_name, mri, mid, exception", metric_tests)
+
+@pytest.mark.parametrize(
+    "public_name, mri, mid, entity, translated, exception", metric_tests
+)
 def test_metric(
-    public_name: Any, mri: Any, mid: Any, exception: Optional[Exception]
+    public_name: Any,
+    mri: Any,
+    mid: Any,
+    entity: Any,
+    translated: dict[str, str] | None,
+    exception: Optional[Exception],
 ) -> None:
     if exception is not None:
         with pytest.raises(type(exception), match=re.escape(str(exception))):
-            Metric(public_name, mri, mid)
+            Metric(public_name, mri, mid, entity)
     else:
-        assert Metric(public_name, mri, mid).id == mid
+        metric = Metric(public_name, mri, mid, entity)
+        assert metric.id == mid
+        if translated:
+            assert METRIC_PRINTER.visit(metric) == translated
 
 
 timeseries_tests = [
     pytest.param(
-        timeseries(Metric(id=123), "count", None, None, None),
-        Timeseries(Metric(id=123), "count", None, None, None),
-        "",
+        timeseries(Metric(id=123, entity="metrics_sets"), "count", None, None, None),
+        {
+            "entity": "metrics_sets",
+            "aggregate": "count(value) AS `aggregate_value`",
+            "filters": "",
+            "groupby": "",
+            "metric_filter": "metric_id = 123",
+        },
         None,
         id="simple test",
     ),
     pytest.param(
-        timeseries(Metric(id=123), 456, None, None, None),
+        timeseries(
+            Metric(id=123, entity="metrics_sets"), "quantile", [0.95], None, None
+        ),
+        {
+            "entity": "metrics_sets",
+            "aggregate": "quantile(0.95)(value) AS `aggregate_value`",
+            "filters": "",
+            "groupby": "",
+            "metric_filter": "metric_id = 123",
+        },
         None,
-        "",
-        InvalidExpressionError("aggregate must be a string"),
+        id="aggregate params",
+    ),
+    pytest.param(
+        timeseries(
+            Metric(id=123, entity="metrics_sets"),
+            "quantile",
+            [0.95],
+            [Condition(Column("tags[release]"), Op.EQ, "1.2.3")],
+            None,
+        ),
+        {
+            "entity": "metrics_sets",
+            "aggregate": "quantile(0.95)(value) AS `aggregate_value`",
+            "filters": "tags[release] = '1.2.3'",
+            "groupby": "",
+            "metric_filter": "metric_id = 123",
+        },
+        None,
+        id="filter",
+    ),
+    pytest.param(
+        timeseries(
+            Metric(id=123, entity="metrics_sets"),
+            "quantile",
+            [0.95],
+            [
+                Condition(Column("tags[release]"), Op.EQ, "1.2.3"),
+                Condition(Column("tags[highway]"), Op.EQ, "401"),
+            ],
+            None,
+        ),
+        {
+            "entity": "metrics_sets",
+            "aggregate": "quantile(0.95)(value) AS `aggregate_value`",
+            "filters": "tags[release] = '1.2.3' AND tags[highway] = '401'",
+            "groupby": "",
+            "metric_filter": "metric_id = 123",
+        },
+        None,
+        id="filters",
+    ),
+    pytest.param(
+        timeseries(
+            Metric(id=123, entity="metrics_sets"),
+            "quantile",
+            [0.95],
+            [
+                Condition(Column("tags[release]"), Op.EQ, "1.2.3"),
+                Condition(Column("tags[highway]"), Op.EQ, "401"),
+            ],
+            [Column("tags[transaction]")],
+        ),
+        {
+            "entity": "metrics_sets",
+            "aggregate": "quantile(0.95)(value) AS `aggregate_value`",
+            "filters": "tags[release] = '1.2.3' AND tags[highway] = '401'",
+            "groupby": "tags[transaction]",
+            "metric_filter": "metric_id = 123",
+        },
+        None,
+        id="groupby",
+    ),
+    pytest.param(
+        timeseries(
+            Metric(id=123, entity="metrics_sets"),
+            "quantile",
+            [0.95],
+            [
+                Condition(Column("tags[release]"), Op.EQ, "1.2.3"),
+                Condition(Column("tags[highway]"), Op.EQ, "401"),
+            ],
+            [Column("tags[transaction]"), Column("tags[device]")],
+        ),
+        {
+            "entity": "metrics_sets",
+            "aggregate": "quantile(0.95)(value) AS `aggregate_value`",
+            "filters": "tags[release] = '1.2.3' AND tags[highway] = '401'",
+            "groupby": "tags[transaction], tags[device]",
+            "metric_filter": "metric_id = 123",
+        },
+        None,
+        id="groupbys",
+    ),
+    pytest.param(
+        timeseries(Metric(id=123, entity="metrics_sets"), 456, None, None, None),
+        None,
+        InvalidTimeseriesError("aggregate must be a string"),
         id="invalid aggregate",
+    ),
+    pytest.param(
+        timeseries(Metric(id=123, entity="metrics_sets"), "count", 6, None, None),
+        None,
+        InvalidTimeseriesError("aggregate_params must be a list"),
+        id="invalid aggregate param",
+    ),
+    pytest.param(
+        timeseries(
+            Metric(id=123, entity="metrics_sets"), "count", [Column("test")], None, None
+        ),
+        None,
+        InvalidTimeseriesError("aggregate_params can only be literal types"),
+        id="invalid aggregate params",
+    ),
+    pytest.param(
+        timeseries(Metric(id=123, entity="metrics_sets"), "count", None, 6, None),
+        None,
+        InvalidTimeseriesError("filters must be a list"),
+        id="invalid filter",
+    ),
+    pytest.param(
+        timeseries(
+            Metric(id=123, entity="metrics_sets"), "count", None, [Column("test")], None
+        ),
+        None,
+        InvalidTimeseriesError("filters must be a list of Conditions"),
+        id="invalid filters",
+    ),
+    pytest.param(
+        timeseries(Metric(id=123, entity="metrics_sets"), "count", None, None, 3),
+        None,
+        InvalidTimeseriesError("groupby must be a list"),
+        id="invalid groupby",
+    ),
+    pytest.param(
+        timeseries(
+            Metric(id=123, entity="metrics_sets"),
+            "count",
+            None,
+            None,
+            [Metric(id=123)],
+        ),
+        None,
+        InvalidTimeseriesError("groupby must be a list of Columns"),
+        id="invalid groupbys",
     ),
 ]
 
 # TODO: Add this back when we have a proper translator
-# TRANSLATOR = Translation()
+TRANSLATOR = TimeseriesSnQLPrinter()
 
 
-@pytest.mark.parametrize("func_wrapper, valid, translated, exception", timeseries_tests)
+@pytest.mark.parametrize("func_wrapper, translated, exception", timeseries_tests)
 def test_timeseries(
     func_wrapper: Callable[[], Any],
-    valid: Optional[Timeseries],
-    translated: str,
-    exception: Optional[Exception],
+    translated: Mapping[str, str] | None,
+    exception: Exception | None,
 ) -> None:
     def verify() -> None:
         exp = func_wrapper()
-        assert exp == valid
-        # assert TRANSLATOR.visit(exp) == translated # TODO: Translator doesn't exist yet
+        assert TRANSLATOR.visit(exp) == translated
 
     if exception is not None:
         with pytest.raises(type(exception), match=re.escape(str(exception))):


### PR DESCRIPTION
Add the basic SnQL translators for the MetricsQuery object and all the objects
it uses.

This adds a translator and validator visitor for the MetricsQuery class. It
also changes Timeseries, Metric, Rollup and MetricScope to all be in the same
file, and to not be Expressions. All of these classes return complex types when
being serialized, in that they affect multiple parts of the query separately.
For example, Rollup impacts the conditions as well as the ORDER BY clause. So
each of these classes also has a visitor in a similar way to the query.
