### PR TITLE
fix(metrics): Changes/bugfixes to support querying from Sentry

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,23 @@
 Changelog and versioning
 ==========================
 
+2.0.3
+-----
+
+- Bug fixes and changes to support using the MetricsQuery in production
+- Add `granularity` to the Rollup to delineate the interval (the results
+bucketing) vs. the granularity of the underlying data
+    - `granularity` is mandatory for now
+    - This means adding back the restrictions of having interval or totals but not both
+- Use the interval to rollup the time automatically
+    - This also means supporting arbitrary intervals
+    - Automatically order timeseries by the rolled up time
+- Allow AliasedExpression in the groupby clause. This is to support resolving
+    in Sentry. The result of the query should have the original tag key, not the
+    resolved tag number. With AliasedExpression we can have Clickhouse do the mapping
+    automatically.
+
+
 
 2.0.2
 -----


### PR DESCRIPTION
Fix some bugs and issues with the way queries were being built.

- Add a separate granularity field in the rollup
    - This is a mandatory field, and separate from interval
    - This allows interval to be arbitrary, meaning arbitrary rollups are now
      supported
    - Since granularity is mandatory, the restriction is the rollup must have
      one of but not both interval and totals
- The rolled up time function is automatically added to the group by
- The query is ordered by the rolled up time automatically

- Support AliasedExpression in the group by of Timeseries and MetricsQuery.
  This was a change made to accomodate columns that are indexed. If a groupby
contains a column that is indexed, the result set would have the indexed value
instead of the original value. Using AliasedExpression allows the indexed value
to be aliased back to the original value, preserving the result set.
