### PR TITLE
ref(metrics): Add support for the TOTALS clause in MetricsQuery

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,13 @@
 Changelog and versioning
 ==========================
 
+
+2.0.5
+-----
+- Support the TOTALS clause in the Rollup of a MetricsQuery
+- Allow 10s granularity in MetricsQuery
+
+
 2.0.4
 -----
 - Fix a bug where the groupby on the MetricsQuery was not being serialized

--- a/snuba_sdk/metrics_query_visitors.py
+++ b/snuba_sdk/metrics_query_visitors.py
@@ -144,6 +144,10 @@ class SnQLPrinter(MetricsQueryVisitor[str]):
             else ""
         )
 
+        totals_clause = ""
+        if rollup_data["with_totals"]:
+            totals_clause = rollup_data["with_totals"]
+
         return self.separator.join(
             [
                 self.match_clause.format(entity=entity),
@@ -151,6 +155,7 @@ class SnQLPrinter(MetricsQueryVisitor[str]):
                 groupby_clause,
                 self.where_clause.format(where_clauses=" AND ".join(where_clauses)),
                 orderby_clause,
+                totals_clause,
             ]
         ).strip()
 

--- a/tests/test_metrics_expressions.py
+++ b/tests/test_metrics_expressions.py
@@ -20,6 +20,7 @@ rollup_tests = [
             "orderby": "time ASC",
             "filter": "granularity = 60",
             "interval": "toStartOfInterval(timestamp, toIntervalSecond(60), 'Universal') AS `time`",
+            "with_totals": "",
         },
         None,
         id="1",
@@ -33,6 +34,7 @@ rollup_tests = [
             "orderby": "time ASC",
             "filter": "granularity = 60",
             "interval": "toStartOfInterval(timestamp, toIntervalSecond(3600), 'Universal') AS `time`",
+            "with_totals": "",
         },
         None,
         id="2",
@@ -55,6 +57,7 @@ rollup_tests = [
             "orderby": "aggregate_value ASC",
             "filter": "granularity = 60",
             "interval": "",
+            "with_totals": "",
         },
         None,
         id="4",
@@ -79,13 +82,16 @@ rollup_tests = [
     ),
     pytest.param(
         60,
-        Totals(True),
+        True,
         None,
         60,
+        {
+            "orderby": "time ASC",
+            "filter": "granularity = 60",
+            "interval": "toStartOfInterval(timestamp, toIntervalSecond(60), 'Universal') AS `time`",
+            "with_totals": "TOTALS True",
+        },
         None,
-        InvalidExpressionError(
-            "Only one of interval and totals can be set: Timeseries can't be rolled up by an interval and by a total"
-        ),
         id="7",
     ),
     pytest.param(


### PR DESCRIPTION
If the `totals` parameter is true in the `Rollup` when an interval is
specified, the query will set the `TOTALS True` clause on the SnQL query which
will in turn use Clickhouse's WITH TOTALS clause to fetch an extra totals row.
