### PR TITLE
feat(metrics): Add formula class

### DIFF
--- a/snuba_sdk/formula.py
+++ b/snuba_sdk/formula.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from enum import Enum
+from dataclasses import dataclass
+from typing import Optional, Sequence, Union
+
+from snuba_sdk.column import Column
+from snuba_sdk.expressions import Expression, InvalidExpressionError
+from snuba_sdk.aliased_expression import AliasedExpression
+from snuba_sdk.conditions import ConditionGroup
+from snuba_sdk.timeseries import Timeseries
+
+
+class InvalidArithmeticError(InvalidExpressionError):
+    pass
+
+
+class InvalidFormulaError(InvalidExpressionError):
+    pass
+
+
+class ArithmeticOperator(Enum):
+    PLUS = "plus"
+    MINUS = "minus"
+    MULTIPLY = "multiply"
+    DIVIDE = "divide"
+
+
+@dataclass(frozen=True)
+class Formula(Expression):
+    operator: str
+    parameters: Optional[
+        Sequence[
+            Union[Formula, Timeseries, float, int]
+        ]
+    ] = None
+    filters: Optional[ConditionGroup] = None
+    groupby: Optional[list[Column | AliasedExpression]] = None
+
+    def validate(self) -> None:
+        if not isinstance(self.operator, str):
+            raise InvalidFormulaError(f"formula '{self.operator}' must be a string")
+        if self.operator == "":
+            raise InvalidFormulaError("operator cannot be empty")
+        if self.operator not in [op.value for op in ArithmeticOperator]:
+            raise InvalidFormulaError(
+                f"operator '{self.operator}' is not supported"
+            )
+
+        if self.parameters is not None:
+            if not isinstance(self.parameters, Sequence):
+                raise InvalidFormulaError(
+                    f"parameters of formula {self.operator} must be a Sequence"
+                )
+            for param in self.parameters:
+                if not isinstance(param, (Formula, Timeseries, float, int)):
+                    raise InvalidFormulaError(
+                        f"parameter '{param}' of formula {self.operator} is an invalid type"
+                    )
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, Formula):
+            return False
+
+        return (
+            self.operator == other.operator
+            and self.parameters == other.parameters
+            and self.filters == other.filters
+            and self.groupby == other.groupby
+        )

--- a/snuba_sdk/formula.py
+++ b/snuba_sdk/formula.py
@@ -27,7 +27,7 @@ class ArithmeticOperator(Enum):
 
 
 @dataclass(frozen=True)
-class Formula(Expression):
+class Formula:
     operator: ArithmeticOperator
     parameters: Optional[
         Sequence[

--- a/snuba_sdk/formula.py
+++ b/snuba_sdk/formula.py
@@ -28,7 +28,7 @@ class ArithmeticOperator(Enum):
 
 @dataclass(frozen=True)
 class Formula(Expression):
-    operator: str
+    operator: ArithmeticOperator
     parameters: Optional[
         Sequence[
             Union[Formula, Timeseries, float, int]
@@ -38,15 +38,8 @@ class Formula(Expression):
     groupby: Optional[list[Column | AliasedExpression]] = None
 
     def validate(self) -> None:
-        if not isinstance(self.operator, str):
-            raise InvalidFormulaError(f"formula '{self.operator}' must be a string")
-        if self.operator == "":
-            raise InvalidFormulaError("operator cannot be empty")
-        if self.operator not in [op.value for op in ArithmeticOperator]:
-            raise InvalidFormulaError(
-                f"operator '{self.operator}' is not supported"
-            )
-
+        if not isinstance(self.operator, ArithmeticOperator):
+            raise InvalidFormulaError(f"formula '{self.operator}' must be a ArithmeticOperator")
         if self.parameters is not None:
             if not isinstance(self.parameters, Sequence):
                 raise InvalidFormulaError(
@@ -57,17 +50,6 @@ class Formula(Expression):
                     raise InvalidFormulaError(
                         f"parameter '{param}' of formula {self.operator} is an invalid type"
                     )
-
-    def __eq__(self, other: object) -> bool:
-        if not isinstance(other, Formula):
-            return False
-
-        return (
-            self.operator == other.operator
-            and self.parameters == other.parameters
-            and self.filters == other.filters
-            and self.groupby == other.groupby
-        )
 
     def _replace(self, field: str, value: Any) -> Formula:
         new = replace(self, **{field: value})

--- a/snuba_sdk/formula.py
+++ b/snuba_sdk/formula.py
@@ -43,12 +43,12 @@ class Formula:
         if self.parameters is not None:
             if not isinstance(self.parameters, Sequence):
                 raise InvalidFormulaError(
-                    f"parameters of formula {self.operator} must be a Sequence"
+                    f"parameters of formula {self.operator.value} must be a Sequence"
                 )
             for param in self.parameters:
                 if not isinstance(param, (Formula, Timeseries, float, int)):
                     raise InvalidFormulaError(
-                        f"parameter '{param}' of formula {self.operator} is an invalid type"
+                        f"parameter '{param}' of formula {self.operator.value} is an invalid type"
                     )
 
     def _replace(self, field: str, value: Any) -> Formula:

--- a/snuba_sdk/formula.py
+++ b/snuba_sdk/formula.py
@@ -1,13 +1,13 @@
 from __future__ import annotations
 
-from enum import Enum
 from dataclasses import dataclass
+from enum import Enum
 from typing import Optional, Sequence, Union
 
-from snuba_sdk.column import Column
-from snuba_sdk.expressions import Expression, InvalidExpressionError
 from snuba_sdk.aliased_expression import AliasedExpression
+from snuba_sdk.column import Column
 from snuba_sdk.conditions import ConditionGroup
+from snuba_sdk.expressions import Expression, InvalidExpressionError
 from snuba_sdk.timeseries import Timeseries
 
 

--- a/snuba_sdk/metrics_query_visitors.py
+++ b/snuba_sdk/metrics_query_visitors.py
@@ -11,6 +11,7 @@ from snuba_sdk.aliased_expression import AliasedExpression
 from snuba_sdk.column import Column
 from snuba_sdk.conditions import BooleanCondition, Condition, ConditionGroup, Op
 from snuba_sdk.expressions import list_type
+from snuba_sdk.formula import Formula
 from snuba_sdk.metrics_visitors import (
     RollupSnQLPrinter,
     ScopeSnQLPrinter,
@@ -210,11 +211,11 @@ class Validator(MetricsQueryVisitor[None]):
     ) -> None:
         pass
 
-    def _visit_query(self, query: Timeseries | None) -> Mapping[str, None]:
+    def _visit_query(self, query: Timeseries | Formula | None) -> Mapping[str, None]:
         if query is None:
             raise InvalidMetricsQueryError("query is required for a metrics query")
-        elif not isinstance(query, Timeseries):
-            raise InvalidMetricsQueryError("query must be a Timeseries")
+        elif not isinstance(query, (Timeseries, Formula)):
+            raise InvalidMetricsQueryError("query must be a Timeseries or Formula")
         query.validate()
         return {}  # Necessary for typing
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -6,6 +6,7 @@ from typing import Any, Callable, Optional
 from snuba_sdk.column import Column
 from snuba_sdk.conditions import And, BooleanCondition, Condition, Or
 from snuba_sdk.function import CurriedFunction, Function
+from snuba_sdk.formula import Formula
 from snuba_sdk.timeseries import Timeseries
 
 
@@ -85,6 +86,18 @@ def cur_func(
         return CurriedFunction(function, initers, params, alias)
 
     return to_func
+
+
+def formula(
+    operator: Any,
+    parameters: Any,
+    filters: Any = None,
+    groupby: Any = None,
+) -> Callable[[], Any]:
+    def to_formula() -> Formula:
+        return Formula(operator, parameters, filters, groupby)
+
+    return to_formula
 
 
 def timeseries(

--- a/tests/test_formula.py
+++ b/tests/test_formula.py
@@ -1,0 +1,84 @@
+import re
+from typing import Any, Callable, Optional
+
+import pytest
+
+from snuba_sdk.column import Column, InvalidColumnError
+from snuba_sdk.conditions import Condition, Op
+from snuba_sdk.formula import InvalidFormulaError
+from snuba_sdk.function import (
+    Function,
+    Identifier,
+    InvalidFunctionError,
+    Lambda,
+)
+from snuba_sdk.timeseries import Metric, Timeseries
+from snuba_sdk.visitors import Translation
+from tests import col, formula
+
+tests = [
+    pytest.param(
+        formula("plus", [1, 1], None, None),
+        None,
+        id="basic formula test",
+    ),
+    pytest.param(
+        formula("plus", [Timeseries(metric=Metric(public_name="foo"), aggregate="sum"), 1], None, None),
+        None,
+        id="timeseries and number formula test",
+    ),
+    pytest.param(
+        formula("plus", [Timeseries(metric=Metric(public_name="foo"), aggregate="sum"), 1], [Condition(Column("tags[transaction]"), Op.EQ, "foo")], None),
+        None,
+        id="filters in formula",
+    ),
+    pytest.param(
+        formula("plus", [Timeseries(metric=Metric(public_name="foo"), aggregate="sum"), 1], None, [Column("tags[status_code]")]),
+        None,
+        id="groupby in formula",
+    ),
+    pytest.param(
+        formula("plus", [Timeseries(metric=Metric(public_name="foo"), aggregate="sum"), Timeseries(metric=Metric(public_name="bar"), aggregate="sum")], None, None),
+        None,
+        id="timeseries in formula",
+    ),
+    pytest.param(
+        formula(42, [Timeseries(metric=Metric(public_name="foo"), aggregate="sum"), 1], None, None),
+        InvalidFormulaError("formula '42' must be a string"),
+        id="invalid operator type",
+    ),
+    pytest.param(
+        formula("", [Timeseries(metric=Metric(public_name="foo"), aggregate="sum"), 1], None, None),
+        InvalidFormulaError("operator cannot be empty"),
+        id="empty operator",
+    ),
+    pytest.param(
+        formula("impossible_operator", [Timeseries(metric=Metric(public_name="foo"), aggregate="sum"), 1], None, None),
+        InvalidFormulaError("operator 'impossible_operator' is not supported"),
+        id="unsupported operator",
+    ),
+    pytest.param(
+        formula("plus", 42, None, None),
+        InvalidFormulaError("parameters of formula plus must be a Sequence"),
+        id="invalid parameters",
+    ),
+    pytest.param(
+        formula("multiply", [Timeseries(metric=Metric(public_name="foo"), aggregate="sum"), "foo"], None, None),
+        InvalidFormulaError("parameter 'foo' of formula multiply is an invalid type"),
+        id="unsupported parameter for operator",
+    ),
+]
+
+
+@pytest.mark.parametrize("func_wrapper, exception", tests)
+def test_formulas(
+    func_wrapper: Callable[[], Any],
+    exception: Optional[Exception],
+) -> None:
+    if exception is None:
+        formula = func_wrapper()
+        formula.validate()
+    else:
+        with pytest.raises(type(exception), match=re.escape(str(exception))):
+            formula = func_wrapper()
+            formula.validate()

--- a/tests/test_formula.py
+++ b/tests/test_formula.py
@@ -5,58 +5,48 @@ from typing import Any, Callable, Optional
 
 from snuba_sdk.column import Column
 from snuba_sdk.conditions import Condition, Op
-from snuba_sdk.formula import InvalidFormulaError
+from snuba_sdk.formula import ArithmeticOperator, InvalidFormulaError
 from snuba_sdk.timeseries import Metric, Timeseries
 from tests import formula
 
 tests = [
     pytest.param(
-        formula("plus", [1, 1], None, None),
+        formula(ArithmeticOperator.PLUS, [1, 1], None, None),
         None,
         id="basic formula test",
     ),
     pytest.param(
-        formula("plus", [Timeseries(metric=Metric(public_name="foo"), aggregate="sum"), 1], None, None),
+        formula(ArithmeticOperator.PLUS, [Timeseries(metric=Metric(public_name="foo"), aggregate="sum"), 1], None, None),
         None,
         id="timeseries and number formula test",
     ),
     pytest.param(
-        formula("plus", [Timeseries(metric=Metric(public_name="foo"), aggregate="sum"), 1], [Condition(Column("tags[transaction]"), Op.EQ, "foo")], None),
+        formula(ArithmeticOperator.PLUS, [Timeseries(metric=Metric(public_name="foo"), aggregate="sum"), 1], [Condition(Column("tags[transaction]"), Op.EQ, "foo")], None),
         None,
         id="filters in formula",
     ),
     pytest.param(
-        formula("plus", [Timeseries(metric=Metric(public_name="foo"), aggregate="sum"), 1], None, [Column("tags[status_code]")]),
+        formula(ArithmeticOperator.PLUS, [Timeseries(metric=Metric(public_name="foo"), aggregate="sum"), 1], None, [Column("tags[status_code]")]),
         None,
         id="groupby in formula",
     ),
     pytest.param(
-        formula("plus", [Timeseries(metric=Metric(public_name="foo"), aggregate="sum"), Timeseries(metric=Metric(public_name="bar"), aggregate="sum")], None, None),
+        formula(ArithmeticOperator.PLUS, [Timeseries(metric=Metric(public_name="foo"), aggregate="sum"), Timeseries(metric=Metric(public_name="bar"), aggregate="sum")], None, None),
         None,
         id="timeseries in formula",
     ),
     pytest.param(
         formula(42, [Timeseries(metric=Metric(public_name="foo"), aggregate="sum"), 1], None, None),
-        InvalidFormulaError("formula '42' must be a string"),
+        InvalidFormulaError("formula '42' must be a ArithmeticOperator"),
         id="invalid operator type",
     ),
     pytest.param(
-        formula("", [Timeseries(metric=Metric(public_name="foo"), aggregate="sum"), 1], None, None),
-        InvalidFormulaError("operator cannot be empty"),
-        id="empty operator",
-    ),
-    pytest.param(
-        formula("impossible_operator", [Timeseries(metric=Metric(public_name="foo"), aggregate="sum"), 1], None, None),
-        InvalidFormulaError("operator 'impossible_operator' is not supported"),
-        id="unsupported operator",
-    ),
-    pytest.param(
-        formula("plus", 42, None, None),
+        formula(ArithmeticOperator.PLUS, 42, None, None),
         InvalidFormulaError("parameters of formula plus must be a Sequence"),
         id="invalid parameters",
     ),
     pytest.param(
-        formula("multiply", [Timeseries(metric=Metric(public_name="foo"), aggregate="sum"), "foo"], None, None),
+        formula(ArithmeticOperator.MULTIPLY, [Timeseries(metric=Metric(public_name="foo"), aggregate="sum"), "foo"], None, None),
         InvalidFormulaError("parameter 'foo' of formula multiply is an invalid type"),
         id="unsupported parameter for operator",
     ),

--- a/tests/test_formula.py
+++ b/tests/test_formula.py
@@ -1,20 +1,13 @@
+import pytest
 import re
+
 from typing import Any, Callable, Optional
 
-import pytest
-
-from snuba_sdk.column import Column, InvalidColumnError
+from snuba_sdk.column import Column
 from snuba_sdk.conditions import Condition, Op
 from snuba_sdk.formula import InvalidFormulaError
-from snuba_sdk.function import (
-    Function,
-    Identifier,
-    InvalidFunctionError,
-    Lambda,
-)
 from snuba_sdk.timeseries import Metric, Timeseries
-from snuba_sdk.visitors import Translation
-from tests import col, formula
+from tests import formula
 
 tests = [
     pytest.param(


### PR DESCRIPTION
This PR is responsible for adding a new `Formula` class (inherits Expression) which will be used to replace `Function` in MetricsQuery objects. Upon implementing the first iteration of the DSL parser (https://github.com/getsentry/snuba-sdk/pull/126), it was discovered that MetricsQuery, Timeseries and Function classes are not defined intuitively with relation to the new DSL grammar and how the nodes are parsed. Practically, it helps to reason about queries by having arbitrary levels of groupbys and filters. Although, in the AST itself, all filters and groupbys will be pushed down. This class aims to simplify the complexity of the `MetricsQuery` by moving those attributes here.