### PR TITLE
ref(docs): Switch from Sphinx to pdoc3

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,17 +19,17 @@ jobs:
       - name: Build docs
         run: |
           pip install virtualenv
-          make apidocs
+          make generate-docs
 
       - uses: peaceiris/actions-gh-pages@v3.7.3
         name: Publish to GitHub Pages
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: docs/_build
+          publish_dir: docs/_html
           force_orphan: true
 
       - name: Archive Docs
         uses: actions/upload-artifact@v3.1.1
         with:
           name: docs
-          path: docs/_build
+          path: docs/_html

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Build docs
         run: |
           pip install virtualenv
-          make generate-docs
+          make generate-pdocs
 
       - uses: peaceiris/actions-gh-pages@v3.7.3
         name: Publish to GitHub Pages

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ venv
 pip-wheel-metadata
 .mypy_cache
 docs/_build/*
+docs/_html/*

--- a/Makefile
+++ b/Makefile
@@ -63,3 +63,7 @@ apidocs-hotfix: apidocs
 	$(VENV_PATH)/bin/pip install ghp-import
 	$(VENV_PATH)/bin/ghp-import -pf docs/_build
 .PHONY: apidocs-hotfix
+
+make generate-pdocs: .venv
+	$(VENV_PATH)/bin/pip install -U -r ./docs-requirements.txt
+	$(VENV_PATH)/bin/pdoc --html --output-dir docs/_html --template-dir docs/_templates snuba_sdk

--- a/README.md
+++ b/README.md
@@ -1,0 +1,112 @@
+[<img
+src="https://sentry-brand.storage.googleapis.com/sentry-wordmark-dark-280x84.png"
+width="280" alt="image" />](https://sentry.io/?utm_source=github&utm_medium=logo)
+
+See here for the full
+[documentation](https://getsentry.github.io/snuba-sdk/).
+
+# Status
+
+[![image](https://img.shields.io/pypi/v/snuba-sdk.svg)](https://pypi.python.org/pypi/snuba-sdk)
+
+[![image](https://github.com/getsentry/snuba-sdk/workflows/tests/badge.svg)](https://github.com/getsentry/snuba-sdk/actions)
+
+[![image](https://img.shields.io/discord/621778831602221064)](https://discord.gg/cWnMQeA)
+
+# Examples
+
+Snuba SDK is a tool that allows requests to Snuba to be built
+programatically. A Request consists of a Query, the dataset the Query is
+targeting, the AppID of the Request, and any flags for the Request. A
+Query object is a code representation of a SnQL query, and has a number
+of attributes corresponding to different parts of the query.
+
+Requests and Queries can be created directly:
+
+``` python
+request = Request(
+    dataset = "discover",
+    app_id = "myappid",
+    tenant_ids = {"referrer": "my_referrer", "organization_id": 1234}
+    query = Query(
+        match=Entity("events"),
+        select=[
+            Column("title"),
+            Function("uniq", [Column("event_id")], "uniq_events"),
+        ],
+        groupby=[Column("title")],
+        where=[
+            Condition(Column("timestamp"), Op.GT, datetime.datetime(2021, 1, 1)),
+            Condition(Column("project_id"), Op.IN, Function("tuple", [1, 2, 3])),
+        ],
+        limit=Limit(10),
+        offset=Offset(0),
+        granularity=Granularity(3600),
+    ),
+    flags = Flags(debug=True)
+)
+```
+
+Queries can also be built incrementally:
+
+``` python
+query = (
+    Query("discover", Entity("events"))
+    .set_select(
+        [Column("title"), Function("uniq", [Column("event_id")], "uniq_events")]
+    )
+    .set_groupby([Column("title")])
+    .set_where(
+        [
+            Condition(Column("timestamp"), Op.GT, datetime.datetime.(2021, 1, 1)),
+            Condition(Column("project_id"), Op.IN, Function("tuple", [1, 2, 3])),
+        ]
+    )
+    .set_limit(10)
+    .set_offset(0)
+    .set_granularity(3600)
+)
+```
+
+Once the request is built, it can be translated into a Snuba request
+that can be sent to Snuba.
+
+``` python
+# Outputs a formatted Snuba request
+request.serialize()
+```
+
+It can also be printed in a more human readable format.
+
+``` python
+# Outputs a formatted Snuba request
+print(request.print())
+```
+
+This outputs:
+
+``` JSON
+{
+    "dataset": "discover",
+    "app_id": "myappid",
+    "query": "MATCH (events) SELECT title, uniq(event_id) AS uniq_events BY title WHERE timestamp > toDateTime('2021-01-01T00:00:00.000000') AND project_id IN tuple(1, 2, 3) LIMIT 10 OFFSET 0 GRANULARITY 3600",
+    "debug": true
+}
+```
+
+If an expression in the query is invalid (e.g. `Column(1)`) then an
+`InvalidExpressionError` exception will be thrown. If there is a problem
+with a query, it will throw an `InvalidQueryError` exception when
+`.validate()` or `.translate()` is called. If there is a problem with
+the Request or the Flags, an `InvalidRequestError` or `InvalidFlagError`
+will be thrown respectively.
+
+# Contributing to the SDK
+
+Please refer to
+[CONTRIBUTING.rst](https://github.com/getsentry/snuba-sdk/blob/master/CONTRIBUTING.rst).
+
+# License
+
+Licensed under MIT, see
+[LICENSE](https://github.com/getsentry/snuba-sdk/blob/master/LICENSE).

--- a/docs-requirements.txt
+++ b/docs-requirements.txt
@@ -1,5 +1,1 @@
-Jinja2<3.1
-sphinx==3.5.4
-sphinx-rtd-theme
-sphinx-autodoc-typehints[type_comments]>=1.8.0
-typing-extensions
+pdoc3==0.10.0

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,1 +1,2 @@
 _build
+_html

--- a/docs/_templates/config.mako
+++ b/docs/_templates/config.mako
@@ -1,0 +1,4 @@
+<%!
+    show_source_code = False
+    lunr_search = {'fuzziness': 1, 'index_docstrings': True}
+%>

--- a/docs/_templates/logo.mako
+++ b/docs/_templates/logo.mako
@@ -1,0 +1,5 @@
+<header>
+    <a class="homelink" rel="home" title="pdoc Home" href="https://getsentry.github.io/snuba-sdk/">
+        <img src="https://sentry-brand.storage.googleapis.com/sentry-wordmark-dark-280x84.png" alt="">
+    </a>
+</header>

--- a/snuba_sdk/__init__.py
+++ b/snuba_sdk/__init__.py
@@ -1,3 +1,7 @@
+"""
+.. include:: ../README.md
+"""
+
 from snuba_sdk.aliased_expression import AliasedExpression
 from snuba_sdk.column import Column
 from snuba_sdk.conditions import And, BooleanCondition, BooleanOp, Condition, Op, Or


### PR DESCRIPTION
Sphinx has a persistent bug in every version tested (including on Python 3.9):
https://github.com/sphinx-doc/sphinx/issues/9243

There seems to be no documented fix for this. Instead of fighting with this,
switch to a simpler documentation engine, [pdoc3](https://pdoc3.github.io/pdoc/doc/pdoc/#gsc.tab=0). This has definitely less
features than Sphinx but is way easier to use.

![Screenshot 2023-10-25 at 5 46 13 PM](https://github.com/getsentry/snuba-sdk/assets/2727124/02cf23ba-2f84-4ad7-8f73-6c106a68c318)

