### PR TITLE
feat(metrics): Add Experimental Formula Query Support

### DIFF
--- a/snuba_sdk/dsl/dsl.py
+++ b/snuba_sdk/dsl/dsl.py
@@ -124,7 +124,6 @@ class MQLlVisitor(NodeVisitor):  # type: ignore
         return expr
 
     def visit_expr_op(self, node: Node, children: Sequence[Any]) -> Any:
-        # raise InvalidQueryError("Arithmetic function not supported yet")
         return EXPRESSION_OPERATORS[node.text]
 
     def visit_term(
@@ -142,7 +141,6 @@ class MQLlVisitor(NodeVisitor):  # type: ignore
         return term
 
     def visit_term_op(self, node: Node, children: Sequence[Any]) -> Any:
-        # raise InvalidQueryError("Arithmetic function not supported yet")
         return TERM_OPERATORS[node.text]
 
     def visit_coefficient(

--- a/snuba_sdk/formula.py
+++ b/snuba_sdk/formula.py
@@ -83,11 +83,10 @@ class Formula:
 FormulaParameterGroup = Union[Formula, Timeseries, float, int]
 
 
-@dataclass(frozen=True)
 class FormulaSnQL:
     """
     Temporary class to represent a Formula in SnQL. This will be removed once
     we properly support formulas in Snuba API.
     """
-    operator: ArithmeticOperator
-    parameters: Optional[Sequence[Union[FormulaSnQL, SnQLString]]] = None
+    operator: Optional[ArithmeticOperator] = None
+    parameters: Optional[Sequence[Union[FormulaSnQL, SnQLString, int, float]]] = None

--- a/snuba_sdk/formula.py
+++ b/snuba_sdk/formula.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from dataclasses import dataclass, replace
+from dataclasses import dataclass, fields, replace
 from enum import Enum
 from typing import Any, Optional, Sequence, Union
 
@@ -8,6 +8,7 @@ from snuba_sdk.aliased_expression import AliasedExpression
 from snuba_sdk.column import Column
 from snuba_sdk.conditions import BooleanCondition, Condition, ConditionGroup
 from snuba_sdk.expressions import InvalidExpressionError, list_type
+from snuba_sdk.query import SnQLString
 from snuba_sdk.timeseries import Timeseries
 
 
@@ -32,6 +33,10 @@ class Formula:
     parameters: Optional[Sequence[FormulaParameterGroup]] = None
     filters: Optional[ConditionGroup] = None
     groupby: Optional[list[Column | AliasedExpression]] = None
+
+    def get_fields(self) -> Sequence[str]:
+        self_fields = fields(self)  # Verified the order in the Python source
+        return tuple(f.name for f in self_fields)
 
     def validate(self) -> None:
         if not isinstance(self.operator, ArithmeticOperator):
@@ -76,3 +81,13 @@ class Formula:
 
 
 FormulaParameterGroup = Union[Formula, Timeseries, float, int]
+
+
+@dataclass(frozen=True)
+class FormulaSnQL:
+    """
+    Temporary class to represent a Formula in SnQL. This will be removed once
+    we properly support formulas in Snuba API.
+    """
+    operator: ArithmeticOperator
+    parameters: Optional[Sequence[Union[FormulaSnQL, SnQLString]]] = None

--- a/snuba_sdk/formula.py
+++ b/snuba_sdk/formula.py
@@ -101,3 +101,6 @@ class FormulaSnQL:
             else:
                 formatted.append(p)
         return formatted
+
+    def __str__(self) -> str:
+        return str(self.format())

--- a/snuba_sdk/formula.py
+++ b/snuba_sdk/formula.py
@@ -90,3 +90,14 @@ class FormulaSnQL:
     """
     operator: Optional[ArithmeticOperator] = None
     parameters: Optional[Sequence[Union[FormulaSnQL, SnQLString, int, float]]] = None
+
+    def format(self) -> list[ArithmeticOperator, Any]:
+        formatted = [self.operator]
+        for p in self.parameters:
+            if isinstance(p, FormulaSnQL):
+                formatted.append(p.format())
+            elif isinstance(p, SnQLString):
+                formatted.append(str(p))
+            else:
+                formatted.append(p)
+        return formatted

--- a/snuba_sdk/metrics_query.py
+++ b/snuba_sdk/metrics_query.py
@@ -2,12 +2,12 @@ from __future__ import annotations
 
 from dataclasses import dataclass, replace
 from datetime import datetime
-from typing import Any
+from typing import Any, Union
 
 from snuba_sdk.expressions import Limit, Offset
-from snuba_sdk.formula import Formula
+from snuba_sdk.formula import Formula, FormulaSnQL
 from snuba_sdk.metrics_query_visitors import SnQLPrinter, Validator
-from snuba_sdk.query import BaseQuery
+from snuba_sdk.query import BaseQuery, SnQLString
 from snuba_sdk.query_visitors import InvalidQueryError
 from snuba_sdk.timeseries import MetricsScope, Rollup, Timeseries
 
@@ -74,7 +74,7 @@ class MetricsQuery(BaseQuery):
     def __str__(self) -> str:
         return PRETTY_PRINTER.visit(self)
 
-    def serialize(self) -> str:
+    def serialize(self) -> Union[SnQLString, FormulaSnQL]:
         self.validate()
         return SNQL_PRINTER.visit(self)
 

--- a/snuba_sdk/metrics_query_visitors.py
+++ b/snuba_sdk/metrics_query_visitors.py
@@ -90,12 +90,14 @@ class SnQLPrinter(MetricsQueryVisitor[str]):
         query_data = returns["query"]
         assert isinstance(query_data, dict)
         if "operator" in query_data:
-            # it is a formula
+            # MetricsQuery.query is a formula
             formula_snql = FormulaSnQL()
             formula_snql.operator = query_data["operator"]
             params = []
             for parameter in query_data["parameters"]:
+                # Recursively traverse into formula until we get to a Timeseries or scalar
                 if isinstance(parameter, dict):
+                    # Copy the top-level returns so we can push context down
                     new_returns = copy.deepcopy(returns)
                     new_returns["query"] = parameter
                     params.append(self._combine(query, new_returns))

--- a/snuba_sdk/metrics_visitors.py
+++ b/snuba_sdk/metrics_visitors.py
@@ -65,17 +65,14 @@ class FormulaSnQLPrinter(FormulaVisitor[str]):
         returns: Mapping[str, str | Mapping[str, str]],
     ) -> Mapping[str, str]:
         # Collapse down the groupby and filters of formula to the timeseries
-        if 'parameters' in returns:
-            for parameter in returns['parameters']:
-                if isinstance(parameter, dict):
-                    # parameter is a timeseries
-                    if 'filters' in returns and returns["filters"] is not None and returns["filters"] != "":
-                        parameter["filters"] = " AND ".join([returns["filters"], parameter["filters"]])
-                        returns["filters"] = ""
-                    if 'groupby' in returns and returns["groupby"] is not None and returns["groupby"] != "":
-                        parameter["groupby"] = ", ".join([returns["groupby"], parameter["groupby"]])
-                        returns["groupby"] = ""
-
+        for parameter in returns['parameters']:
+            if isinstance(parameter, dict):
+                if returns["filters"] != "":
+                    parameter["filters"] = " AND ".join(filter(None, [returns["filters"], parameter["filters"]]))
+                if returns["groupby"] != "":
+                    parameter["groupby"] = ", ".join(filter(None, [returns["groupby"], parameter["groupby"]]))
+        returns["filters"] = ""
+        returns["groupby"] = ""
         return returns
 
     def _visit_operator(self, operator: str) -> str:

--- a/snuba_sdk/query.py
+++ b/snuba_sdk/query.py
@@ -187,7 +187,7 @@ class SnQLString:
         self.offset_clause = "OFFSET {offset}"
         self.totals_clause = ""
 
-    def get_string(self) -> str:
+    def __str__(self) -> str:
         return self.separator.join(filter(lambda x: x != "", [
             self.match_clause,
             self.select_clause,

--- a/snuba_sdk/query.py
+++ b/snuba_sdk/query.py
@@ -172,3 +172,29 @@ class Query(BaseQuery):
     def print(self) -> str:
         self.validate()
         return PRETTY_PRINTER.visit(self)
+
+
+class SnQLString:
+    def __init__(self, pretty: bool = False) -> None:
+        self.pretty = pretty
+        self.separator = "\n" if self.pretty else " "
+        self.match_clause = "MATCH ({entity})"
+        self.select_clause = "SELECT {select_columns}"
+        self.groupby_clause = "BY {groupby_columns}"
+        self.where_clause = "WHERE {where_clauses}"
+        self.orderby_clause = "ORDER BY {orderby_columns}"
+        self.limit_clause = "LIMIT {limit}"
+        self.offset_clause = "OFFSET {offset}"
+        self.totals_clause = ""
+
+    def get_string(self) -> str:
+        return self.separator.join(filter(lambda x: x != "", [
+            self.match_clause,
+            self.select_clause,
+            self.groupby_clause,
+            self.where_clause,
+            self.orderby_clause,
+            self.limit_clause,
+            self.offset_clause,
+            self.totals_clause,
+        ])).strip()

--- a/tests/test_dsl.py
+++ b/tests/test_dsl.py
@@ -196,7 +196,6 @@ def test_parse_mql(mql_string: str, metrics_query: MetricsQuery) -> None:
     assert result == metrics_query
 
 
-@pytest.mark.xfail(reason="Not supported")
 def test_terms() -> None:
     dsl = "sum(foo) / 1000"
     result = parse_mql(dsl)
@@ -232,7 +231,6 @@ def test_terms() -> None:
     )
 
 
-@pytest.mark.xfail(reason="Not supported")
 def test_multi_terms() -> None:
     dsl = "(sum(foo) * sum(bar)) / 1000"
     result = parse_mql(dsl)
@@ -259,7 +257,6 @@ def test_multi_terms() -> None:
     )
 
 
-@pytest.mark.xfail(reason="Not supported")
 def test_terms_with_filters() -> None:
     dsl = '(sum(foo) / sum(bar)){tag="tag_value"}'
     result = parse_mql(dsl)
@@ -301,7 +298,6 @@ def test_terms_with_filters() -> None:
     )
 
 
-@pytest.mark.xfail(reason="Not supported")
 def test_terms_with_groupby() -> None:
     dsl = '(sum(foo) / sum(bar)){tag="tag_value"} by transaction'
     result = parse_mql(dsl)
@@ -429,7 +425,6 @@ def test_terms_with_groupby() -> None:
     )
 
 
-@pytest.mark.xfail(reason="Not supported")
 def test_complex_nested_terms() -> None:
     dsl = '((sum(foo{tag="tag_value"}){tag2="tag_value2"} / sum(bar)){tag3="tag_value3"} * sum(pop)) by transaction'
     result = parse_mql(dsl)


### PR DESCRIPTION
### Overview
This PR is explores what needs to be done to support metric formula queries without needing to change the Snuba API. This is not meant to be a permanent solution as [creating a new Snuba endpoint which accepts a DSL string and parses the formula directly into an AST is the end goal](https://www.notion.so/sentry/Metrics-Query-Layer-91fc5a1e11274019a0d51985f7f91892?pvs=4#a3e4b8dbf3c844dc8c17cbf4d6b1b4cd). This PR is meant to explore how formula queries would work without needing Snuba changes and possibly grab some low hanging fruit that might make formula queries operational immediately.

This PR explores the following changes:
1. Decouples the SnQL string from the `SnQLPrinter` which is associated to one MetricsQuery. This is because with the introduction of Formula queries, it is possible to have one or more SnQL queries associate to one MetricsQuery. For example `sum(d:foo) / sum(d:bar) by transactions` requires two SnQL queries. To decouple this, we introduce `SnQLString` and `FormulaSnQL` class which get return from `SnQLPrinter._combine()`.
2. To support formula queries, a `FormulaSnQLPrinter` class was added which is responsible for recursively visiting its parameters and ultimately converting a `Formula` into a a mapping which can be transformed into a `FormulaSnQL`.
3. The `FormulaSnQLPrinter` is also responsible for collapsing all context attributes into the inner timeseries. For example:
```
`(sum(d:foo) / sum(d:bar)){tag: value} by transactions * 1000`
becomes
`(sum(d:foo{tag: value}) by transactions  / sum(d:bar{tag: value}) by transactions ) * 1000`
```
Similarly, attributes like start, end, rollup, limit, and etc. all get pushed into the inner timeseries SnQL. See `test_metrics_query.py::test_formula_query`


### What changes will be required in sentry?
Non-metric queries and timeseries metric queries will still serialize as normal. The serialization of a Formula within a MetricsQuery within a Request object is the complicated part. This is because serializing a Formula would generate multiple SnQLs which should produce multiple Requests. It feels like a strange pattern to call `serialize` on one request which generates multiple serialize requests. This still needs to be explored. For now, in the `MetricsQuery` class, we introduce a new method called `serialize_formula()` which returns a `FormulaSnQL`. On the sentry side, we would need to alter both the new metrics layer and `sentry/utils/snuba.py::_raw_snql_query()` to know when to call the new method, run the multiple snuba queries, and compute the arithmetics.