### PR TITLE
ref(MQL): Update MQL Grammar to align with Discover Filter Grammar

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,7 @@ Changelog and versioning
 - Support the `limit` and `offset` field in the MetricsQuery
     - This will set the appropriate LIMIT and OFFSET clauses in the resulting SQL query,
     allowing for pagination
+- Align MQL filters grammar with Discover filters grammar.
 
 
 2.0.7

--- a/snuba_sdk/conditions.py
+++ b/snuba_sdk/conditions.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Sequence, Mapping, Optional, Union
+from typing import Mapping, Optional, Sequence, Union
 
 from snuba_sdk.column import Column
 from snuba_sdk.expressions import (

--- a/snuba_sdk/dsl/dsl.py
+++ b/snuba_sdk/dsl/dsl.py
@@ -213,7 +213,7 @@ class MQLVisitor(NodeVisitor):  # type: ignore
         group_by_name = group_by[0]
         return group_by_name
 
-    def visit_condition_op(self, node: Node, children: Sequence[Any]) -> Op:
+    def visit_condition_op(self, node: Node, children: Sequence[Any]) -> str:
         return node.text
 
     def visit_tag_key(self, node: Node, children: Sequence[Any]) -> Column:

--- a/snuba_sdk/dsl/dsl.py
+++ b/snuba_sdk/dsl/dsl.py
@@ -33,13 +33,13 @@ coefficient = number / filter
 number = ~r"[0-9]+" ("." ~r"[0-9]+")?
 filter = target (open_brace _ condition (_ comma _ condition)* _ close_brace)? (group_by)?
 
-condition = (variable / tag_key) _ condition_op _ tag_value
-condition_op = "=" / "!=" / "~" / "!~" / "IN" / "NOT IN"
+condition = condition_op? (variable / tag_key) _ colon _ tag_value
+condition_op = "!"
 tag_key = ~"[a-zA-Z0-9_]+"
 tag_value = quoted_string / quoted_string_tuple / variable
 
 quoted_string = ~r'"([^"\\]*(?:\\.[^"\\]*)*)"'
-quoted_string_tuple = open_paren _ quoted_string (_ comma _ quoted_string)* _ close_paren
+quoted_string_tuple = open_square_bracket _ quoted_string (_ comma _ quoted_string)* _ close_square_bracket
 
 target = variable / nested_expression / function / metric
 variable = "$" ~"[a-zA-Z0-9_]+"
@@ -61,10 +61,13 @@ unquoted_public_name = ~r'([a-z_]+(?:\.[a-z_]+)*)'
 
 open_paren = "("
 close_paren = ")"
+open_square_bracket = "["
+close_square_bracket = "]"
 open_brace = "{{"
 close_brace = "}}"
 comma = ","
 backtick = "`"
+colon = ":"
 _ = ~r"\s*"
 """
 )
@@ -88,13 +91,13 @@ def parse_mql(mql: str) -> MetricsQuery:
         tree = GRAMMAR.parse(mql.strip())
     except ParseError as e:
         raise InvalidQueryError("Invalid metrics syntax") from e
-    result = MQLlVisitor().visit(tree)
+    result = MQLVisitor().visit(tree)
     assert isinstance(result, (Timeseries, Formula))
     metrics_query = MetricsQuery(query=result)
     return metrics_query
 
 
-class MQLlVisitor(NodeVisitor):  # type: ignore
+class MQLVisitor(NodeVisitor):  # type: ignore
     def visit(self, node: Node) -> Any:
         """Walk a parse tree, transforming it into a MetricsQuery object.
 
@@ -179,7 +182,15 @@ class MQLlVisitor(NodeVisitor):  # type: ignore
         return target
 
     def visit_condition(self, node: Node, children: Sequence[Any]) -> Condition:
-        lhs, _, op, _, rhs = children
+        condition_op, lhs, _, _, _, rhs = children
+        op = Op.EQ
+        if not condition_op and isinstance(rhs, list):
+            op = Op.IN
+        elif len(condition_op) == 1 and condition_op[0] == "!":
+            if isinstance(rhs, str):
+                op = Op.NEQ
+            elif isinstance(rhs, list):
+                op = Op.NOT_IN
         return Condition(lhs[0], op, rhs)
 
     def visit_function(self, node: Node, children: Sequence[Any]) -> Timeseries:
@@ -203,7 +214,7 @@ class MQLlVisitor(NodeVisitor):  # type: ignore
         return group_by_name
 
     def visit_condition_op(self, node: Node, children: Sequence[Any]) -> Op:
-        return Op(node.text)
+        return node.text
 
     def visit_tag_key(self, node: Node, children: Sequence[Any]) -> Column:
         return Column(node.text)

--- a/tests/test_dsl.py
+++ b/tests/test_dsl.py
@@ -1,7 +1,7 @@
 import pytest
 
 from snuba_sdk.column import Column
-from snuba_sdk.conditions import Condition, Op, Or
+from snuba_sdk.conditions import Condition, Op
 from snuba_sdk.dsl.dsl import parse_mql
 from snuba_sdk.formula import ArithmeticOperator, Formula
 from snuba_sdk.metrics_query import MetricsQuery

--- a/tests/test_dsl.py
+++ b/tests/test_dsl.py
@@ -1,7 +1,7 @@
 import pytest
 
 from snuba_sdk.column import Column
-from snuba_sdk.conditions import Condition, Op
+from snuba_sdk.conditions import Condition, Op, Or
 from snuba_sdk.dsl.dsl import parse_mql
 from snuba_sdk.formula import ArithmeticOperator, Formula
 from snuba_sdk.metrics_query import MetricsQuery
@@ -75,7 +75,7 @@ tests = [
         id="test nested expressions 2",
     ),
     pytest.param(
-        'sum(foo){bar="baz"}',
+        'sum(foo){bar:"baz"}',
         MetricsQuery(
             query=Timeseries(
                 metric=Metric(public_name="foo"),
@@ -86,7 +86,18 @@ tests = [
         id="test filter",
     ),
     pytest.param(
-        'sum(foo){bar IN ("baz", "bap")}',
+        'sum(foo){!bar:"baz"}',
+        MetricsQuery(
+            query=Timeseries(
+                metric=Metric(public_name="foo"),
+                aggregate="sum",
+                filters=[Condition(Column("bar"), Op.NEQ, "baz")],
+            )
+        ),
+        id="test not filter",
+    ),
+    pytest.param(
+        'sum(foo){bar:["baz", "bap"]}',
         MetricsQuery(
             query=Timeseries(
                 metric=Metric(public_name="foo"),
@@ -97,7 +108,18 @@ tests = [
         id="test in filter",
     ),
     pytest.param(
-        'sum(foo{bar="baz"})',
+        'sum(foo){!bar:["baz", "bap"]}',
+        MetricsQuery(
+            query=Timeseries(
+                metric=Metric(public_name="foo"),
+                aggregate="sum",
+                filters=[Condition(Column("bar"), Op.NOT_IN, ["baz", "bap"])],
+            )
+        ),
+        id="test not in filter",
+    ),
+    pytest.param(
+        'sum(foo{bar:"baz"})',
         MetricsQuery(
             query=Timeseries(
                 metric=Metric(public_name="foo"),
@@ -108,7 +130,7 @@ tests = [
         id="test filter inside aggregate",
     ),
     pytest.param(
-        'sum(user{bar="baz", foo="foz"})',
+        'sum(user{bar:"baz", foo:"foz"})',
         MetricsQuery(
             query=Timeseries(
                 metric=Metric(public_name="user"),
@@ -122,7 +144,7 @@ tests = [
         id="test multiple filters",
     ),
     pytest.param(
-        'sum(`d:transactions/duration@millisecond`{foo="foz", hee="haw"}){bar="baz"}',
+        'sum(`d:transactions/duration@millisecond`{foo:"foz", hee:"haw"}){bar:"baz"}',
         MetricsQuery(
             query=Timeseries(
                 metric=Metric(mri="d:transactions/duration@millisecond"),
@@ -137,7 +159,7 @@ tests = [
         id="test multiple layer filters",
     ),
     pytest.param(
-        'max(`d:transactions/duration@millisecond`{foo="foz"}) by transaction',
+        'max(`d:transactions/duration@millisecond`{foo:"foz"}) by transaction',
         MetricsQuery(
             query=Timeseries(
                 metric=Metric(mri="d:transactions/duration@millisecond"),
@@ -149,7 +171,7 @@ tests = [
         id="test group by 1",
     ),
     pytest.param(
-        'max(`d:transactions/duration@millisecond`{foo="foz"} by transaction)',
+        'max(`d:transactions/duration@millisecond`{foo:"foz"} by transaction)',
         MetricsQuery(
             query=Timeseries(
                 metric=Metric(mri="d:transactions/duration@millisecond"),
@@ -161,7 +183,7 @@ tests = [
         id="test group by 2",
     ),
     pytest.param(
-        'max(`d:transactions/duration@millisecond`{foo="foz"}) by (transaction)',
+        'max(`d:transactions/duration@millisecond`{foo:"foz"}) by (transaction)',
         MetricsQuery(
             query=Timeseries(
                 metric=Metric(mri="d:transactions/duration@millisecond"),
@@ -173,7 +195,7 @@ tests = [
         id="test group by 3",
     ),
     pytest.param(
-        'max(`d:transactions/duration@millisecond`{foo="foz"}){bar="baz"} by (a, b)',
+        'max(`d:transactions/duration@millisecond`{foo:"foz"}){bar:"baz"} by (a, b)',
         MetricsQuery(
             query=Timeseries(
                 metric=Metric(mri="d:transactions/duration@millisecond"),


### PR DESCRIPTION
### Overview
The goal is to eventually unify all our metrics with a single method of querying. Right now, how we express filters is different between discover and metrics. We want to close this gap in order to provide a smooth experience across our product. This PR is responsible for updating the MQL grammar to more closely match how discover exposes filters to our users.

### What is not included in this PR
* OR filtering
* bracket filters