### PR TITLE
ref(formula) Add SnQL visitor for Formula

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,13 @@
 Changelog and versioning
 ==========================
 
+2.0.9
+-----
+
+- Add a basic version of Formula SnQL translator
+    - This translator is not meant to be permanent, it should be replaced with a MQL translator
+
+
 2.0.8
 -----
 

--- a/snuba_sdk/__init__.py
+++ b/snuba_sdk/__init__.py
@@ -7,6 +7,7 @@ from snuba_sdk.column import Column
 from snuba_sdk.conditions import And, BooleanCondition, BooleanOp, Condition, Op, Or
 from snuba_sdk.entity import Entity
 from snuba_sdk.expressions import Granularity, Limit, Offset, Totals
+from snuba_sdk.formula import ArithmeticOperator, Formula
 from snuba_sdk.function import CurriedFunction, Function, Identifier, Lambda
 from snuba_sdk.metrics_query import MetricsQuery
 from snuba_sdk.orderby import Direction, LimitBy, OrderBy
@@ -18,6 +19,7 @@ from snuba_sdk.timeseries import Metric, MetricsScope, Rollup, Timeseries
 __all__ = [
     "AliasedExpression",
     "And",
+    "ArithmeticOperator",
     "BooleanCondition",
     "BooleanOp",
     "Column",
@@ -26,6 +28,7 @@ __all__ = [
     "Direction",
     "Entity",
     "Flags",
+    "Formula",
     "Function",
     "Granularity",
     "Identifier",

--- a/snuba_sdk/dsl/dsl.py
+++ b/snuba_sdk/dsl/dsl.py
@@ -135,7 +135,7 @@ class MQLlVisitor(NodeVisitor):  # type: ignore
         then merge them into a single Formula with the operator.
         """
         term, zero_or_more_others = children
-        assert isinstance(term, (Formula, Timeseries, float, int))
+        assert isinstance(term, (Timeseries, float, int))
         if zero_or_more_others:
             _, term_operator, _, coefficient, *_ = zero_or_more_others[0]
             return Formula(term_operator, [term, coefficient])

--- a/snuba_sdk/formula.py
+++ b/snuba_sdk/formula.py
@@ -62,9 +62,10 @@ class Formula:
                             "Formulas can only operate on a single entity"
                         )
 
+                    to_check = set(param.groupby) if param.groupby is not None else None
                     if groupby is None:
-                        groupby = param.groupby
-                    elif groupby != param.groupby:
+                        groupby = to_check
+                    elif groupby != to_check:
                         raise InvalidFormulaError(
                             "Formula parameters must group by the same columns"
                         )

--- a/snuba_sdk/metrics_query_visitors.py
+++ b/snuba_sdk/metrics_query_visitors.py
@@ -12,6 +12,7 @@ from snuba_sdk.conditions import Condition, Op
 from snuba_sdk.expressions import Limit, Offset
 from snuba_sdk.formula import Formula
 from snuba_sdk.metrics_visitors import (
+    FormulaSnQLVisitor,
     RollupSnQLPrinter,
     ScopeSnQLPrinter,
     TimeseriesSnQLPrinter,
@@ -79,6 +80,7 @@ class SnQLPrinter(MetricsQueryVisitor[str]):
         self.timeseries_visitor = TimeseriesSnQLPrinter(self.expression_visitor)
         self.rollup_visitor = RollupSnQLPrinter(self.expression_visitor)
         self.scope_visitor = ScopeSnQLPrinter(self.expression_visitor)
+        self.formula_visitor = FormulaSnQLVisitor()
         self.separator = "\n" if self.pretty else " "
         self.match_clause = "MATCH ({entity})"
         self.select_clause = "SELECT {select_columns}"
@@ -91,13 +93,13 @@ class SnQLPrinter(MetricsQueryVisitor[str]):
     def _combine(
         self, query: main.MetricsQuery, returns: Mapping[str, str | Mapping[str, str]]
     ) -> str:
-        timeseries_data = returns["query"]
-        assert isinstance(timeseries_data, dict)
+        query_data = returns["query"]
+        assert isinstance(query_data, dict)
 
-        entity = timeseries_data["entity"]
+        entity = query_data["entity"]
 
         select_columns = []
-        select_columns.append(timeseries_data["aggregate"])
+        select_columns.append(query_data["aggregate"])
 
         rollup_data = returns["rollup"]
         assert isinstance(rollup_data, dict)
@@ -117,12 +119,13 @@ class SnQLPrinter(MetricsQueryVisitor[str]):
             orderby_columns.append(rollup_data["orderby"])
         where_clauses.append(rollup_data["filter"])
 
-        if timeseries_data["groupby"]:
-            groupby_columns.append(timeseries_data["groupby"])
+        if query_data["groupby"]:
+            groupby_columns.append(query_data["groupby"])
 
-        where_clauses.append(timeseries_data["metric_filter"])
-        if timeseries_data["filters"]:
-            where_clauses.append(timeseries_data["filters"])
+        if "metric_filter" in query_data:
+            where_clauses.append(query_data["metric_filter"])
+        if "filters" in query_data and query_data["filters"]:
+            where_clauses.append(query_data["filters"])
 
         where_clauses.append(returns["scope"])
         where_clauses.append(returns["start"])
@@ -168,9 +171,8 @@ class SnQLPrinter(MetricsQueryVisitor[str]):
         if query is None:
             raise InvalidMetricsQueryError("MetricQuery.query must not be None")
         if isinstance(query, Formula):
-            raise InvalidMetricsQueryError(
-                "Serializing a Formula in MetricQuery.query is unsupported"
-            )
+            return self.formula_visitor.visit(query)
+
         return self.timeseries_visitor.visit(query)
 
     def _visit_start(self, start: datetime | None) -> str:

--- a/snuba_sdk/metrics_visitors.py
+++ b/snuba_sdk/metrics_visitors.py
@@ -4,8 +4,15 @@ from abc import ABC, abstractmethod
 from typing import Any, Generic, Mapping, TypeVar
 
 from snuba_sdk.column import Column
-from snuba_sdk.conditions import And, Condition, ConditionGroup, Op
+from snuba_sdk.conditions import (
+    OPERATOR_TO_FUNCTION,
+    And,
+    Condition,
+    ConditionGroup,
+    Op,
+)
 from snuba_sdk.expressions import InvalidExpressionError, Totals
+from snuba_sdk.formula import Formula
 from snuba_sdk.function import CurriedFunction, Function
 from snuba_sdk.orderby import Direction, OrderBy
 from snuba_sdk.timeseries import Metric, MetricsScope, Rollup, Timeseries
@@ -229,3 +236,141 @@ class ScopeSnQLPrinter(ScopeVisitor[str]):
         )
 
         return self.translator.visit(condition)
+
+
+# Normally this would be a visitor class, but this is itself a hack to get derived metrics off the ground
+# This can be better codified when we write a visitor that converts Formulas to MQL.
+class FormulaSnQLVisitor:
+    def __init__(
+        self, timeseries_visitor: TimeseriesFormulaSnQLPrinter | None = None
+    ) -> None:
+        self.timeseries_visitor = timeseries_visitor or TimeseriesFormulaSnQLPrinter()
+        self.expression_visitor = self.timeseries_visitor.expression_visitor
+
+    def _visit_parameter(
+        self, side: Timeseries | int | float, filters: ConditionGroup | None
+    ) -> Mapping[str, str]:
+        if isinstance(side, (float, int)):
+            return {"select": f"{side}"}
+        assert isinstance(
+            side, Timeseries
+        )  # This is guaranteed by the Formula validator
+
+        if filters:
+            if side.filters is not None:
+                side = side.set_filters(
+                    [*side.filters, *filters]
+                )  # Push formula filters down into timeseries
+            else:
+                side = side.set_filters(filters)
+
+        tdata = self.timeseries_visitor.visit(side)
+        ret = {
+            "entity": str(tdata["entity"]),
+            "groupby": str(tdata["groupby"]),
+            "select": str(tdata["aggregate"]),
+        }
+
+        return ret
+
+    def visit(self, formula: Formula) -> Mapping[str, str]:
+        parameters = []
+        if formula.parameters is not None:
+            parameters = [
+                self._visit_parameter(p, formula.filters) for p in formula.parameters
+            ]
+
+        entity = None
+        for p in parameters:
+            if isinstance(p, dict):
+                if "entity" in p:
+                    if entity is None:
+                        entity = p["entity"]
+                    elif entity != p["entity"]:
+                        raise InvalidExpressionError(
+                            "Formulas can only operate on a single entity"
+                        )
+        assert entity is not None  # This is guaranteed by the Formula validator
+        ret = {"entity": entity}
+
+        # collect all the group bys
+        groupbys = []
+        if formula.groupby:
+            for g in formula.groupby:
+                groupbys.append(self.expression_visitor.visit(g))
+
+        for p in parameters:
+            if isinstance(p, dict) and "groupby" in p:
+                groupbys.append(p["groupby"])
+                break  # The validator guarantees all the groupbys are equal, so we only need one
+
+        ret["groupby"] = ", ".join([g for g in groupbys if g != ""])
+
+        # Collect select statements
+        parameters = ", ".join(p["select"] for p in parameters)
+        ret[
+            "aggregate"
+        ] = f"{formula.operator.value}({parameters}) AS {AGGREGATE_ALIAS}"
+
+        return ret
+
+
+class TimeseriesFormulaSnQLPrinter(TimeseriesVisitor[str]):
+    def __init__(
+        self,
+        expression_visitor: Translation | None = None,
+        metrics_visitor: MetricSnQLPrinter | None = None,
+    ) -> None:
+        self.expression_visitor = expression_visitor or Translation()
+        self.metrics_visitor = metrics_visitor or MetricSnQLPrinter(expression_visitor)
+
+    def _combine(
+        self,
+        timeseries: Timeseries,
+        returns: Mapping[str, str | Mapping[str, str]],
+    ) -> Mapping[str, str]:
+        metric_data = self.metrics_visitor.visit(timeseries.metric)
+        assert isinstance(metric_data, Mapping)  # mypy
+
+        ret = {
+            "entity": metric_data["entity"],
+        }
+
+        metric_filter = Function("equals", [Column("metric_id"), timeseries.metric.id])
+
+        # In Formulas, the filters need to be built into the aggregate as infix functions
+        filters = []
+        if timeseries.filters:
+            for cond in timeseries.filters:
+                assert isinstance(cond.op, Op)  # BooleanOp is not a valid function
+                op = OPERATOR_TO_FUNCTION[cond.op]
+                filters.append(Function(op.value, [cond.lhs, cond.rhs]))
+
+        and_filters = Function("and", [metric_filter, *filters])
+        aggregate = CurriedFunction(
+            f"{timeseries.aggregate}If",
+            timeseries.aggregate_params,
+            [Column("value"), and_filters],
+        )
+        ret["aggregate"] = self.expression_visitor.visit(aggregate)
+
+        if returns["groupby"] is not None:
+            ret["groupby"] = str(returns["groupby"])
+
+        return ret
+
+    def _visit_metric(self, metric: Metric) -> Mapping[str, str]:
+        return {}
+
+    def _visit_aggregate(
+        self, aggregate: str, aggregate_params: list[Any] | None
+    ) -> str:
+        return ""
+
+    def _visit_filters(self, filters: ConditionGroup | None) -> str:
+        return ""
+
+    def _visit_groupby(self, groupby: list[Column] | None) -> str:
+        if groupby is not None:
+            return ", ".join(self.expression_visitor.visit(c) for c in groupby)
+        return ""

--- a/tests/test_dsl.py
+++ b/tests/test_dsl.py
@@ -240,7 +240,7 @@ def test_multi_terms() -> None:
         query=Formula(
             ArithmeticOperator.DIVIDE,
             [
-                Formula(
+                Formula(  # type: ignore
                     ArithmeticOperator.MULTIPLY,
                     [
                         Timeseries(
@@ -437,7 +437,7 @@ def test_complex_nested_terms() -> None:
         query=Formula(
             operator=ArithmeticOperator.MULTIPLY,
             parameters=[
-                Formula(
+                Formula(  # type: ignore
                     ArithmeticOperator.DIVIDE,
                     [
                         Timeseries(

--- a/tests/test_formula.py
+++ b/tests/test_formula.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import re
 from typing import Any, Callable, Optional
 
@@ -6,19 +8,28 @@ import pytest
 from snuba_sdk.column import Column
 from snuba_sdk.conditions import Condition, Op
 from snuba_sdk.formula import ArithmeticOperator, InvalidFormulaError
+from snuba_sdk.metrics_visitors import FormulaSnQLVisitor
 from snuba_sdk.timeseries import Metric, Timeseries
 from tests import formula
 
 tests = [
-    pytest.param(
-        formula(ArithmeticOperator.PLUS, [1, 1], None, None),
-        None,
-        id="basic formula test",
-    ),
+    # This might be possible in the future, but if the formula doesn't contain a metric
+    # then it's not possible to infer the entity
+    # pytest.param(
+    #     formula(ArithmeticOperator.PLUS, [1, 1], None, None),
+    #     None,
+    #     id="basic formula test",
+    # ),
     pytest.param(
         formula(
             ArithmeticOperator.PLUS,
-            [Timeseries(metric=Metric(public_name="foo"), aggregate="sum"), 1],
+            [
+                Timeseries(
+                    metric=Metric(public_name="foo", entity="metrics_sets"),
+                    aggregate="sum",
+                ),
+                1,
+            ],
             None,
             None,
         ),
@@ -28,7 +39,13 @@ tests = [
     pytest.param(
         formula(
             ArithmeticOperator.PLUS,
-            [Timeseries(metric=Metric(public_name="foo"), aggregate="sum"), 1],
+            [
+                Timeseries(
+                    metric=Metric(public_name="foo", entity="metrics_sets"),
+                    aggregate="sum",
+                ),
+                1,
+            ],
             [Condition(Column("tags[transaction]"), Op.EQ, "foo")],
             None,
         ),
@@ -38,7 +55,13 @@ tests = [
     pytest.param(
         formula(
             ArithmeticOperator.PLUS,
-            [Timeseries(metric=Metric(public_name="foo"), aggregate="sum"), 1],
+            [
+                Timeseries(
+                    metric=Metric(public_name="foo", entity="metrics_sets"),
+                    aggregate="sum",
+                ),
+                1,
+            ],
             None,
             [Column("tags[status_code]")],
         ),
@@ -49,8 +72,14 @@ tests = [
         formula(
             ArithmeticOperator.PLUS,
             [
-                Timeseries(metric=Metric(public_name="foo"), aggregate="sum"),
-                Timeseries(metric=Metric(public_name="bar"), aggregate="sum"),
+                Timeseries(
+                    metric=Metric(public_name="foo", entity="metrics_sets"),
+                    aggregate="sum",
+                ),
+                Timeseries(
+                    metric=Metric(public_name="bar", entity="metrics_sets"),
+                    aggregate="sum",
+                ),
             ],
             None,
             None,
@@ -61,7 +90,13 @@ tests = [
     pytest.param(
         formula(
             42,
-            [Timeseries(metric=Metric(public_name="foo"), aggregate="sum"), 1],
+            [
+                Timeseries(
+                    metric=Metric(public_name="foo", entity="metrics_sets"),
+                    aggregate="sum",
+                ),
+                1,
+            ],
             None,
             None,
         ),
@@ -76,12 +111,94 @@ tests = [
     pytest.param(
         formula(
             ArithmeticOperator.MULTIPLY,
-            [Timeseries(metric=Metric(public_name="foo"), aggregate="sum"), "foo"],
+            [
+                Timeseries(
+                    metric=Metric(public_name="foo", entity="metrics_sets"),
+                    aggregate="sum",
+                ),
+                "foo",
+            ],
             None,
             None,
         ),
         InvalidFormulaError("parameter 'foo' of formula multiply is an invalid type"),
         id="unsupported parameter for operator",
+    ),
+    pytest.param(
+        formula(
+            ArithmeticOperator.PLUS,
+            [
+                Timeseries(
+                    metric=Metric(
+                        "transaction.duration",
+                        "d:transactions/duration@millisecond",
+                        1123,
+                        "metrics_sets",
+                    ),
+                    aggregate="sum",
+                    filters=[Condition(Column("tags[referrer]"), Op.EQ, "foo")],
+                    groupby=[Column("tags[status_code]")],
+                ),
+                Timeseries(
+                    metric=Metric(
+                        "transaction.duration",
+                        "d:transactions/duration@millisecond",
+                        123,
+                        "metrics_distributions",
+                    ),
+                    aggregate="sum",
+                    filters=[Condition(Column("tags[referrer]"), Op.EQ, "bar")],
+                    groupby=[Column("tags[status_code]")],
+                ),
+            ],
+            [Condition(Column("tags[status_code]"), Op.EQ, 200)],
+            [Column("tags[release]")],
+        ),
+        InvalidFormulaError("Formulas can only operate on a single entity"),
+        id="different entities",
+    ),
+    pytest.param(
+        formula(
+            ArithmeticOperator.PLUS,
+            [
+                Timeseries(
+                    metric=Metric(
+                        "transaction.duration",
+                        "d:transactions/duration@millisecond",
+                        1123,
+                        "metrics_sets",
+                    ),
+                    aggregate="sum",
+                    filters=[Condition(Column("tags[referrer]"), Op.EQ, "foo")],
+                    groupby=[Column("tags[status_code]")],
+                ),
+                Timeseries(
+                    metric=Metric(
+                        "transaction.duration",
+                        "d:transactions/duration@millisecond",
+                        123,
+                        "metrics_sets",
+                    ),
+                    aggregate="sum",
+                    filters=[Condition(Column("tags[referrer]"), Op.EQ, "bar")],
+                    groupby=[Column("tags[platform]")],
+                ),
+            ],
+            [Condition(Column("tags[status_code]"), Op.EQ, 200)],
+            [Column("tags[release]")],
+        ),
+        InvalidFormulaError("Formula parameters must group by the same columns"),
+        id="different groupby",
+    ),
+    pytest.param(
+        formula(
+            ArithmeticOperator.PLUS,
+            [100, 100],
+            [Condition(Column("tags[status_code]"), Op.EQ, 200)],
+            [Column("tags[release]")],
+        ),
+        InvalidFormulaError("Formulas must have an an entity"),
+        id="no simple math",
     ),
 ]
 
@@ -98,3 +215,161 @@ def test_formulas(
         with pytest.raises(type(exception), match=re.escape(str(exception))):
             formula = func_wrapper()
             formula.validate()
+
+
+formula_snql_tests = [
+    pytest.param(
+        formula(
+            ArithmeticOperator.MULTIPLY,
+            [
+                Timeseries(
+                    metric=Metric(
+                        "transaction.duration",
+                        "d:transactions/duration@millisecond",
+                        1123,
+                        "metrics_sets",
+                    ),
+                    aggregate="sum",
+                    filters=[Condition(Column("tags[referrer]"), Op.EQ, "foo")],
+                ),
+                100,
+            ],
+            None,
+            None,
+        ),
+        {
+            "entity": "metrics_sets",
+            "groupby": "",
+            "aggregate": "multiply(sumIf(value, and(equals(metric_id, 1123), equals(tags[referrer], 'foo'))), 100) AS aggregate_value",
+        },
+        None,
+        id="basic formula",
+    ),
+    pytest.param(
+        formula(
+            ArithmeticOperator.PLUS,
+            [
+                Timeseries(
+                    metric=Metric(
+                        "transaction.duration",
+                        "d:transactions/duration@millisecond",
+                        1123,
+                        "metrics_sets",
+                    ),
+                    aggregate="sum",
+                    filters=[Condition(Column("tags[referrer]"), Op.EQ, "foo")],
+                ),
+                Timeseries(
+                    metric=Metric(
+                        "transaction.duration",
+                        "d:transactions/duration@millisecond",
+                        123,
+                        "metrics_sets",
+                    ),
+                    aggregate="sum",
+                    filters=[Condition(Column("tags[referrer]"), Op.EQ, "bar")],
+                ),
+            ],
+            None,
+            None,
+        ),
+        {
+            "entity": "metrics_sets",
+            "groupby": "",
+            "aggregate": "plus(sumIf(value, and(equals(metric_id, 1123), equals(tags[referrer], 'foo'))), sumIf(value, and(equals(metric_id, 123), equals(tags[referrer], 'bar')))) AS aggregate_value",
+        },
+        None,
+        id="basic timeseries formula",
+    ),
+    pytest.param(
+        formula(
+            ArithmeticOperator.PLUS,
+            [
+                Timeseries(
+                    metric=Metric(
+                        "transaction.duration",
+                        "d:transactions/duration@millisecond",
+                        1123,
+                        "metrics_sets",
+                    ),
+                    aggregate="sum",
+                    filters=[Condition(Column("tags[referrer]"), Op.EQ, "foo")],
+                ),
+                Timeseries(
+                    metric=Metric(
+                        "transaction.duration",
+                        "d:transactions/duration@millisecond",
+                        123,
+                        "metrics_sets",
+                    ),
+                    aggregate="sum",
+                    filters=[Condition(Column("tags[referrer]"), Op.EQ, "bar")],
+                ),
+            ],
+            [Condition(Column("tags[status_code]"), Op.EQ, 200)],
+            None,
+        ),
+        {
+            "entity": "metrics_sets",
+            "groupby": "",
+            "aggregate": "plus(sumIf(value, and(equals(metric_id, 1123), equals(tags[referrer], 'foo'), equals(tags[status_code], 200))), sumIf(value, and(equals(metric_id, 123), equals(tags[referrer], 'bar'), equals(tags[status_code], 200)))) AS aggregate_value",
+        },
+        None,
+        id="formula with filters",
+    ),
+    pytest.param(
+        formula(
+            ArithmeticOperator.PLUS,
+            [
+                Timeseries(
+                    metric=Metric(
+                        "transaction.duration",
+                        "d:transactions/duration@millisecond",
+                        1123,
+                        "metrics_sets",
+                    ),
+                    aggregate="sum",
+                    filters=[Condition(Column("tags[referrer]"), Op.EQ, "foo")],
+                    groupby=[Column("tags[status_code]")],
+                ),
+                Timeseries(
+                    metric=Metric(
+                        "transaction.duration",
+                        "d:transactions/duration@millisecond",
+                        123,
+                        "metrics_sets",
+                    ),
+                    aggregate="sum",
+                    filters=[Condition(Column("tags[referrer]"), Op.EQ, "bar")],
+                    groupby=[Column("tags[status_code]")],
+                ),
+            ],
+            [Condition(Column("tags[status_code]"), Op.EQ, 200)],
+            [Column("tags[release]")],
+        ),
+        {
+            "entity": "metrics_sets",
+            "groupby": "tags[release], tags[status_code]",
+            "aggregate": "plus(sumIf(value, and(equals(metric_id, 1123), equals(tags[referrer], 'foo'), equals(tags[status_code], 200))), sumIf(value, and(equals(metric_id, 123), equals(tags[referrer], 'bar'), equals(tags[status_code], 200)))) AS aggregate_value",
+        },
+        None,
+        id="group bys",
+    ),
+]
+
+
+TRANSLATOR = FormulaSnQLVisitor()
+
+
+@pytest.mark.parametrize("formula_func, translated, exception", formula_snql_tests)
+def test_formula_translate(
+    formula_func: Callable[[], Any],
+    translated: dict[str, str],
+    exception: Optional[Exception],
+) -> None:
+    if exception is not None:
+        with pytest.raises(type(exception), match=re.escape(str(exception))):
+            formula_func()
+    else:
+        formula = formula_func()
+        assert TRANSLATOR.visit(formula) == translated


### PR DESCRIPTION
First off, note that this is a temporary measure. Formulas don't encode nicely
into SnQL. The main issue with encoding MetricsQuery into SnQL is that the
visitor pattern assumes each component of a query can be encoded into a string,
and then combined together neatly into a query. That's not true of a
MetricsQuery, and especially a Formula, where the encoding of a single
component can impact multiple parts of a query. For example encoding a Metric
object influences the WHERE clause (metric_id filter) and the MATCH clause (for
the entity).

This assumption works much better when encoding MetricsQuery into MQL, since
the components can be encoded and combined together in a seamless way. Until
then, these visitors will have to hack around the restrictions.

This adds a simple SnQL visitor for the Formula class. This only works for the
most basic Formulas: no nested Formulas as allowed, and the groupby and entity
of any Timeseries parameters must match.
