### PR TITLE
feat(mql): Support unquoted tag values and space delimiters in MQL filter

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,13 @@
 Changelog and versioning
 ==========================
 
+2.0.10
+-----
+
+- Extend the MQL grammar to support unquoted tag values and the usage of spaces as delimiters
+  in the filter string
+
+
 2.0.9
 -----
 

--- a/snuba_sdk/dsl/dsl.py
+++ b/snuba_sdk/dsl/dsl.py
@@ -38,8 +38,8 @@ condition_op = "!"
 tag_key = ~r"[a-zA-Z0-9_]+"
 tag_value = quoted_string / unquoted_string / string_tuple / variable
 
-quoted_string = quote unquoted_string quote
-unquoted_string = ~r"[a-zA-Z0-9_]+"
+quoted_string = ~r'"([^"\\]*(?:\\.[^"\\]*)*)"'
+unquoted_string = ~r'[^,\[\]\"}}{{\s]+'
 string_tuple = open_square_bracket _ (quoted_string / unquoted_string) (_ comma _ (quoted_string / unquoted_string))* _ close_square_bracket
 
 target = variable / nested_expression / function / metric
@@ -228,6 +228,11 @@ class MQLVisitor(NodeVisitor):  # type: ignore
         return tag_value
 
     def visit_unquoted_string(self, node: Node, children: Sequence[Any]) -> str:
+        print("visited unquoted string")
+        return str(node.text)
+
+    def visit_test_string(self, node: Node, children: Sequence[Any]) -> str:
+        print("visited test string")
         return str(node.text)
 
     def visit_quoted_string(self, node: Node, children: Sequence[Any]) -> str:

--- a/snuba_sdk/dsl/dsl.py
+++ b/snuba_sdk/dsl/dsl.py
@@ -35,29 +35,30 @@ filter = target (open_brace _ condition (_ comma _ condition)* _ close_brace)? (
 
 condition = condition_op? (variable / tag_key) _ colon _ tag_value
 condition_op = "!"
-tag_key = ~"[a-zA-Z0-9_]+"
-tag_value = quoted_string / quoted_string_tuple / variable
+tag_key = ~r"[a-zA-Z0-9_]+"
+tag_value = quoted_string / unquoted_string / string_tuple / variable
 
-quoted_string = ~r'"([^"\\]*(?:\\.[^"\\]*)*)"'
-quoted_string_tuple = open_square_bracket _ quoted_string (_ comma _ quoted_string)* _ close_square_bracket
+quoted_string = quote unquoted_string quote
+unquoted_string = ~r"[a-zA-Z0-9_]+"
+string_tuple = open_square_bracket _ (quoted_string / unquoted_string) (_ comma _ (quoted_string / unquoted_string))* _ close_square_bracket
 
 target = variable / nested_expression / function / metric
-variable = "$" ~"[a-zA-Z0-9_]+"
+variable = "$" ~r"[a-zA-Z0-9_]+"
 nested_expression = open_paren _ expression _ close_paren
 
 function = aggregate (group_by)?
 aggregate = aggregate_name (open_paren _ expression (_ comma _ expression)* _ close_paren)
-aggregate_name = ~"[a-zA-Z0-9_]+"
+aggregate_name = ~r"[a-zA-Z0-9_]+"
 
 group_by = _ "by" _ (group_by_name / group_by_name_tuple)
-group_by_name = ~"[a-zA-Z0-9_]+"
+group_by_name = ~r"[a-zA-Z0-9_]+"
 group_by_name_tuple = open_paren _ group_by_name (_ comma _ group_by_name)* _ close_paren
 
 metric = quoted_mri / unquoted_mri / quoted_public_name / unquoted_public_name
 quoted_mri = backtick unquoted_mri backtick
-unquoted_mri = ~r'{METRIC_TYPE_REGEX}:{NAMESPACE_REGEX}/{MRI_NAME_REGEX}@{UNIT_REGEX}'
+unquoted_mri = ~r"{METRIC_TYPE_REGEX}:{NAMESPACE_REGEX}/{MRI_NAME_REGEX}@{UNIT_REGEX}"
 quoted_public_name = backtick unquoted_public_name backtick
-unquoted_public_name = ~r'([a-z_]+(?:\.[a-z_]+)*)'
+unquoted_public_name = ~r"([a-z_]+(?:\.[a-z_]+)*)"
 
 open_paren = "("
 close_paren = ")"
@@ -68,6 +69,7 @@ close_brace = "}}"
 comma = ","
 backtick = "`"
 colon = ":"
+quote = "\""
 _ = ~r"\s*"
 """
 )
@@ -225,14 +227,15 @@ class MQLVisitor(NodeVisitor):  # type: ignore
         tag_value = children[0]
         return tag_value
 
+    def visit_unquoted_string(self, node: Node, children: Sequence[Any]) -> str:
+        return str(node.text)
+
     def visit_quoted_string(self, node: Node, children: Sequence[Any]) -> str:
         return str(node.text[1:-1])
 
-    def visit_quoted_string_tuple(
-        self, node: Node, children: Sequence[Any]
-    ) -> Sequence[str]:
+    def visit_string_tuple(self, node: Node, children: Sequence[Any]) -> Sequence[str]:
         _, _, first, zero_or_more_others, _, _ = children
-        return [first, *(v for _, _, _, v in zero_or_more_others)]
+        return [first[0], *(v[0] for _, _, _, v in zero_or_more_others)]
 
     def visit_group_by_name(self, node: Node, children: Sequence[Any]) -> Column:
         return Column(node.text)

--- a/snuba_sdk/dsl/dsl.py
+++ b/snuba_sdk/dsl/dsl.py
@@ -228,11 +228,9 @@ class MQLVisitor(NodeVisitor):  # type: ignore
         return tag_value
 
     def visit_unquoted_string(self, node: Node, children: Sequence[Any]) -> str:
-        print("visited unquoted string")
         return str(node.text)
 
     def visit_test_string(self, node: Node, children: Sequence[Any]) -> str:
-        print("visited test string")
         return str(node.text)
 
     def visit_quoted_string(self, node: Node, children: Sequence[Any]) -> str:

--- a/snuba_sdk/dsl/dsl.py
+++ b/snuba_sdk/dsl/dsl.py
@@ -31,7 +31,7 @@ term_op = "*" / "/"
 coefficient = number / filter
 
 number = ~r"[0-9]+" ("." ~r"[0-9]+")?
-filter = target (open_brace _ condition (_ comma _ condition)* _ close_brace)? (group_by)?
+filter = target (open_brace _ condition (_ comma? _ condition)* _ close_brace)? (group_by)?
 
 condition = condition_op? (variable / tag_key) _ colon _ tag_value
 condition_op = "!"

--- a/tests/test_mql.py
+++ b/tests/test_mql.py
@@ -97,6 +97,28 @@ tests = [
         id="test filter with unquoted value",
     ),
     pytest.param(
+        'sum(foo){bar:"2023-01-03T10:00:00"}',
+        MetricsQuery(
+            query=Timeseries(
+                metric=Metric(public_name="foo"),
+                aggregate="sum",
+                filters=[Condition(Column("bar"), Op.EQ, "2023-01-03T10:00:00")],
+            )
+        ),
+        id="test filter with quoted value with special characters",
+    ),
+    pytest.param(
+        "sum(foo){bar:2023-01-03T10:00:00}",
+        MetricsQuery(
+            query=Timeseries(
+                metric=Metric(public_name="foo"),
+                aggregate="sum",
+                filters=[Condition(Column("bar"), Op.EQ, "2023-01-03T10:00:00")],
+            )
+        ),
+        id="test filter with unquoted value with special characters",
+    ),
+    pytest.param(
         'sum(foo){!bar:"baz"}',
         MetricsQuery(
             query=Timeseries(

--- a/tests/test_mql.py
+++ b/tests/test_mql.py
@@ -221,6 +221,35 @@ tests = [
         id="test multiple filters",
     ),
     pytest.param(
+        'sum(user{bar:"baz" foo:"foz"})',
+        MetricsQuery(
+            query=Timeseries(
+                metric=Metric(public_name="user"),
+                aggregate="sum",
+                filters=[
+                    Condition(Column("bar"), Op.EQ, "baz"),
+                    Condition(Column("foo"), Op.EQ, "foz"),
+                ],
+            )
+        ),
+        id="test multiple filters with space delimiter",
+    ),
+    pytest.param(
+        'sum(user{bar:"baz" foo:"foz", hee:"haw"})',
+        MetricsQuery(
+            query=Timeseries(
+                metric=Metric(public_name="user"),
+                aggregate="sum",
+                filters=[
+                    Condition(Column("bar"), Op.EQ, "baz"),
+                    Condition(Column("foo"), Op.EQ, "foz"),
+                    Condition(Column("hee"), Op.EQ, "haw"),
+                ],
+            )
+        ),
+        id="test multiple filters with space and comma delimiter",
+    ),
+    pytest.param(
         "sum(user{bar:baz, foo:foz})",
         MetricsQuery(
             query=Timeseries(
@@ -235,6 +264,35 @@ tests = [
         id="test multiple filters with unquoted values",
     ),
     pytest.param(
+        "sum(user{bar:baz foo:foz})",
+        MetricsQuery(
+            query=Timeseries(
+                metric=Metric(public_name="user"),
+                aggregate="sum",
+                filters=[
+                    Condition(Column("bar"), Op.EQ, "baz"),
+                    Condition(Column("foo"), Op.EQ, "foz"),
+                ],
+            )
+        ),
+        id="test multiple filters with unquoted values with space delimiter",
+    ),
+    pytest.param(
+        "sum(user{bar:baz foo:foz, hee:haw})",
+        MetricsQuery(
+            query=Timeseries(
+                metric=Metric(public_name="user"),
+                aggregate="sum",
+                filters=[
+                    Condition(Column("bar"), Op.EQ, "baz"),
+                    Condition(Column("foo"), Op.EQ, "foz"),
+                    Condition(Column("hee"), Op.EQ, "haw"),
+                ],
+            )
+        ),
+        id="test multiple filters with unquoted values with space and comma delimiter",
+    ),
+    pytest.param(
         'sum(user{bar:"baz", foo:foz})',
         MetricsQuery(
             query=Timeseries(
@@ -247,6 +305,50 @@ tests = [
             )
         ),
         id="test multiple filters with quoted and unquoted values",
+    ),
+    pytest.param(
+        'sum(user{bar:"baz" foo:foz})',
+        MetricsQuery(
+            query=Timeseries(
+                metric=Metric(public_name="user"),
+                aggregate="sum",
+                filters=[
+                    Condition(Column("bar"), Op.EQ, "baz"),
+                    Condition(Column("foo"), Op.EQ, "foz"),
+                ],
+            )
+        ),
+        id="test multiple filters with quoted and unquoted values with space delimiter",
+    ),
+    pytest.param(
+        'sum(user{bar:"baz" foo:foz, hee:"haw"})',
+        MetricsQuery(
+            query=Timeseries(
+                metric=Metric(public_name="user"),
+                aggregate="sum",
+                filters=[
+                    Condition(Column("bar"), Op.EQ, "baz"),
+                    Condition(Column("foo"), Op.EQ, "foz"),
+                    Condition(Column("hee"), Op.EQ, "haw"),
+                ],
+            )
+        ),
+        id="test multiple filters with quoted and unquoted values with space and comma delimiter",
+    ),
+    pytest.param(
+        'sum(user{bar:baz foo:"foz", !hee:["haw", hoo]})',
+        MetricsQuery(
+            query=Timeseries(
+                metric=Metric(public_name="user"),
+                aggregate="sum",
+                filters=[
+                    Condition(Column("bar"), Op.EQ, "baz"),
+                    Condition(Column("foo"), Op.EQ, "foz"),
+                    Condition(Column("hee"), Op.NOT_IN, ["haw", "hoo"]),
+                ],
+            )
+        ),
+        id="test complex filters",
     ),
     pytest.param(
         'sum(`d:transactions/duration@millisecond`{foo:"foz", hee:"haw"}){bar:"baz"}',
@@ -276,7 +378,7 @@ tests = [
         id="test group by 1",
     ),
     pytest.param(
-        'max(`d:transactions/duration@millisecond`{foo:"foz"} by transaction)',
+        "max(`d:transactions/duration@millisecond`{foo:foz} by transaction)",
         MetricsQuery(
             query=Timeseries(
                 metric=Metric(mri="d:transactions/duration@millisecond"),
@@ -300,7 +402,7 @@ tests = [
         id="test group by 3",
     ),
     pytest.param(
-        'max(`d:transactions/duration@millisecond`{foo:"foz"}){bar:"baz"} by (a, b)',
+        'max(`d:transactions/duration@millisecond`{foo:"foz"}){bar:baz} by (a, b)',
         MetricsQuery(
             query=Timeseries(
                 metric=Metric(mri="d:transactions/duration@millisecond"),
@@ -319,7 +421,6 @@ tests = [
 
 @pytest.mark.parametrize("mql_string, metrics_query", tests)
 def test_parse_mql(mql_string: str, metrics_query: MetricsQuery) -> None:
-    print(mql_string)
     result = parse_mql(mql_string)
     assert result == metrics_query
 

--- a/tests/test_mql.py
+++ b/tests/test_mql.py
@@ -86,6 +86,17 @@ tests = [
         id="test filter",
     ),
     pytest.param(
+        "sum(foo){bar:baz}",
+        MetricsQuery(
+            query=Timeseries(
+                metric=Metric(public_name="foo"),
+                aggregate="sum",
+                filters=[Condition(Column("bar"), Op.EQ, "baz")],
+            )
+        ),
+        id="test filter with unquoted value",
+    ),
+    pytest.param(
         'sum(foo){!bar:"baz"}',
         MetricsQuery(
             query=Timeseries(
@@ -95,6 +106,17 @@ tests = [
             )
         ),
         id="test not filter",
+    ),
+    pytest.param(
+        "sum(foo){!bar:baz}",
+        MetricsQuery(
+            query=Timeseries(
+                metric=Metric(public_name="foo"),
+                aggregate="sum",
+                filters=[Condition(Column("bar"), Op.NEQ, "baz")],
+            )
+        ),
+        id="test not filter with unquoted value",
     ),
     pytest.param(
         'sum(foo){bar:["baz", "bap"]}',
@@ -108,6 +130,28 @@ tests = [
         id="test in filter",
     ),
     pytest.param(
+        'sum(foo){bar:["baz", bap]}',
+        MetricsQuery(
+            query=Timeseries(
+                metric=Metric(public_name="foo"),
+                aggregate="sum",
+                filters=[Condition(Column("bar"), Op.IN, ["baz", "bap"])],
+            )
+        ),
+        id="test in filter with unquoted values",
+    ),
+    pytest.param(
+        "sum(foo){bar:[baz, bap]}",
+        MetricsQuery(
+            query=Timeseries(
+                metric=Metric(public_name="foo"),
+                aggregate="sum",
+                filters=[Condition(Column("bar"), Op.IN, ["baz", "bap"])],
+            )
+        ),
+        id="test in filter with quoted and unquoted values",
+    ),
+    pytest.param(
         'sum(foo){!bar:["baz", "bap"]}',
         MetricsQuery(
             query=Timeseries(
@@ -119,6 +163,28 @@ tests = [
         id="test not in filter",
     ),
     pytest.param(
+        "sum(foo){!bar:[baz, bap]}",
+        MetricsQuery(
+            query=Timeseries(
+                metric=Metric(public_name="foo"),
+                aggregate="sum",
+                filters=[Condition(Column("bar"), Op.NOT_IN, ["baz", "bap"])],
+            )
+        ),
+        id="test not in filter with unquoted values",
+    ),
+    pytest.param(
+        'sum(foo){!bar:["baz", bap]}',
+        MetricsQuery(
+            query=Timeseries(
+                metric=Metric(public_name="foo"),
+                aggregate="sum",
+                filters=[Condition(Column("bar"), Op.NOT_IN, ["baz", "bap"])],
+            )
+        ),
+        id="test not in filter with quoted and unquoted values",
+    ),
+    pytest.param(
         'sum(foo{bar:"baz"})',
         MetricsQuery(
             query=Timeseries(
@@ -128,6 +194,17 @@ tests = [
             )
         ),
         id="test filter inside aggregate",
+    ),
+    pytest.param(
+        "sum(foo{bar:baz})",
+        MetricsQuery(
+            query=Timeseries(
+                metric=Metric(public_name="foo"),
+                aggregate="sum",
+                filters=[Condition(Column("bar"), Op.EQ, "baz")],
+            )
+        ),
+        id="test filter inside aggregate with unquoted value",
     ),
     pytest.param(
         'sum(user{bar:"baz", foo:"foz"})',
@@ -142,6 +219,34 @@ tests = [
             )
         ),
         id="test multiple filters",
+    ),
+    pytest.param(
+        "sum(user{bar:baz, foo:foz})",
+        MetricsQuery(
+            query=Timeseries(
+                metric=Metric(public_name="user"),
+                aggregate="sum",
+                filters=[
+                    Condition(Column("bar"), Op.EQ, "baz"),
+                    Condition(Column("foo"), Op.EQ, "foz"),
+                ],
+            )
+        ),
+        id="test multiple filters with unquoted values",
+    ),
+    pytest.param(
+        'sum(user{bar:"baz", foo:foz})',
+        MetricsQuery(
+            query=Timeseries(
+                metric=Metric(public_name="user"),
+                aggregate="sum",
+                filters=[
+                    Condition(Column("bar"), Op.EQ, "baz"),
+                    Condition(Column("foo"), Op.EQ, "foz"),
+                ],
+            )
+        ),
+        id="test multiple filters with quoted and unquoted values",
     ),
     pytest.param(
         'sum(`d:transactions/duration@millisecond`{foo:"foz", hee:"haw"}){bar:"baz"}',
@@ -214,6 +319,7 @@ tests = [
 
 @pytest.mark.parametrize("mql_string, metrics_query", tests)
 def test_parse_mql(mql_string: str, metrics_query: MetricsQuery) -> None:
+    print(mql_string)
     result = parse_mql(mql_string)
     assert result == metrics_query
 


### PR DESCRIPTION
This PR is responsible for extending the MQL grammar to support unquoted tag values and the usage of spaces as delimiters in the filter string. The purpose of doing this is to bring MQL closer to the discover grammar in order to provide a cohesive user experience across the sentry product. 