### PR TITLE
feat(mql) Support curried functions in MQL

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,12 @@
 Changelog and versioning
 ==========================
 
+2.0.12
+-----
+
+- Support curried functions in the MQL grammar
+
+
 2.0.11
 -----
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,17 +1,12 @@
 Changelog and versioning
 ==========================
 
-2.0.12
------
-
-- Support curried functions in the MQL grammar
-
-
 2.0.11
 -----
 
 - Add MQLContext to capture addition query information that cannot be expressed in MQL string
     - Add visitors to support MQLContext serialization
+- Support curried functions in the MQL grammar
 
 
 2.0.10

--- a/snuba_sdk/mql/mql.py
+++ b/snuba_sdk/mql/mql.py
@@ -2,6 +2,7 @@
 Contains the definition of MQL, the Metrics Query Language.
 Use `parse_mql()` to parse an MQL string into a MetricsQuery.
 """
+from __future__ import annotations
 
 from typing import Any, Mapping, Sequence, Union
 
@@ -39,15 +40,19 @@ tag_key = ~r"[a-zA-Z0-9_]+"
 tag_value = quoted_string / unquoted_string / string_tuple / variable
 
 quoted_string = ~r'"([^"\\]*(?:\\.[^"\\]*)*)"'
-unquoted_string = ~r'[^,\[\]\"}}{{\s]+'
+unquoted_string = ~r'[^,\[\]\"}}{{\(\)\s]+'
 string_tuple = open_square_bracket _ (quoted_string / unquoted_string) (_ comma _ (quoted_string / unquoted_string))* _ close_square_bracket
 
 target = variable / nested_expression / function / metric
 variable = "$" ~r"[a-zA-Z0-9_]+"
 nested_expression = open_paren _ expression _ close_paren
 
-function = aggregate (group_by)?
+function = (curried_aggregate / aggregate) (group_by)?
 aggregate = aggregate_name (open_paren _ expression (_ comma _ expression)* _ close_paren)
+curried_aggregate = aggregate_name (open_paren _ aggregate_list? _ close_paren) (open_paren _ expression (_ comma _ expression)* _ close_paren)
+aggregate_list = param* (param_expression)
+param = param_expression _ comma _
+param_expression = number / quoted_string / unquoted_string
 aggregate_name = ~r"[a-zA-Z0-9_]+"
 
 group_by = _ "by" _ (group_by_name / group_by_name_tuple)
@@ -199,7 +204,8 @@ class MQLVisitor(NodeVisitor):  # type: ignore
         """
         Given an Timeseries target, set its children groupbys.
         """
-        target, packed_groupbys = children
+        targets, packed_groupbys = children
+        target = targets[0]
         assert isinstance(target, Timeseries)
         if packed_groupbys:
             group_by = packed_groupbys[0]
@@ -267,7 +273,6 @@ class MQLVisitor(NodeVisitor):  # type: ignore
 
     def visit_variable(self, node: Node, children: Sequence[Any]) -> Any:
         raise InvalidQueryError("Variables are not supported yet")
-        return None
 
     def visit_nested_expression(
         self, node: Node, children: Sequence[Any]
@@ -284,6 +289,47 @@ class MQLVisitor(NodeVisitor):  # type: ignore
         _, _, target, zero_or_more_others, *_ = zero_or_one
         assert isinstance(target, Timeseries)
         return target.set_aggregate(aggregate_name)
+
+    def visit_curried_aggregate(
+        self, node: Node, children: Sequence[Any]
+    ) -> Timeseries:
+        """
+        Given a target (which is either a Formula or Timeseries object),
+        set the aggregate and aggregate params on it.
+        """
+        aggregate_name, agg_params, zero_or_one = children
+        _, _, target, _, *_ = zero_or_one
+        _, _, agg_param_list, *_ = agg_params
+        aggregate_params = agg_param_list[0] if agg_param_list else []
+        assert isinstance(target, Timeseries)
+        return target.set_aggregate(aggregate_name, aggregate_params)
+
+    def visit_param(self, node: Node, children: Sequence[Any]) -> str | int | float:
+        """
+        Discard the comma and return the aggregate param for the curried aggregate function.
+        """
+        param, *_ = children
+        assert isinstance(param, (str, int, float))
+        return param
+
+    def visit_param_expression(
+        self, node: Node, children: Sequence[Any]
+    ) -> str | int | float:
+        """
+        Return the aggregate param for the curried aggregate function.
+        """
+        (param,) = children
+        assert isinstance(param, (str, int, float))
+        return param
+
+    def visit_aggregate_list(
+        self, node: Node, children: Sequence[Any]
+    ) -> list[str | int | float]:
+        agg_params, param = children
+        if param is not None:
+            agg_params.append(param)
+        assert isinstance(agg_params, list)
+        return agg_params
 
     def visit_aggregate_name(self, node: Node, children: Sequence[Any]) -> str:
         return node.text

--- a/tests/test_mql.py
+++ b/tests/test_mql.py
@@ -2,9 +2,9 @@ import pytest
 
 from snuba_sdk.column import Column
 from snuba_sdk.conditions import Condition, Op
-from snuba_sdk.dsl.dsl import parse_mql
 from snuba_sdk.formula import ArithmeticOperator, Formula
 from snuba_sdk.metrics_query import MetricsQuery
+from snuba_sdk.mql.mql import parse_mql
 from snuba_sdk.timeseries import Metric, Timeseries
 
 tests = [
@@ -438,6 +438,66 @@ tests = [
         ),
         id="test group by 4",
     ),
+    pytest.param(
+        "quantiles(0.5)(`d:transactions/duration@millisecond`)",
+        MetricsQuery(
+            query=Timeseries(
+                metric=Metric(mri="d:transactions/duration@millisecond"),
+                aggregate="quantiles",
+                aggregate_params=[0.5],
+            )
+        ),
+        id="test curried functions",
+    ),
+    pytest.param(
+        "quantiles(0.5, 0.95)(`d:transactions/duration@millisecond`)",
+        MetricsQuery(
+            query=Timeseries(
+                metric=Metric(mri="d:transactions/duration@millisecond"),
+                aggregate="quantiles",
+                aggregate_params=[0.5, 0.95],
+            )
+        ),
+        id="test curried functions with multiple params",
+    ),
+    pytest.param(
+        "topK()(`d:transactions/duration@millisecond`)",
+        MetricsQuery(
+            query=Timeseries(
+                metric=Metric(mri="d:transactions/duration@millisecond"),
+                aggregate="topK",
+                aggregate_params=[],
+            )
+        ),
+        id="test curried functions with no params",
+    ),
+    pytest.param(
+        'test(0.5, "random", other, 9)(`d:transactions/duration@millisecond`)',
+        MetricsQuery(
+            query=Timeseries(
+                metric=Metric(mri="d:transactions/duration@millisecond"),
+                aggregate="test",
+                aggregate_params=[0.5, "random", "other", 9],
+            )
+        ),
+        id="test curried functions with random params",
+    ),
+    pytest.param(
+        'quantiles(0.5)(`d:transactions/duration@millisecond`{foo:"foz"}){bar:baz} by (a, b)',
+        MetricsQuery(
+            query=Timeseries(
+                metric=Metric(mri="d:transactions/duration@millisecond"),
+                aggregate="quantiles",
+                aggregate_params=[0.5],
+                filters=[
+                    Condition(Column("bar"), Op.EQ, "baz"),
+                    Condition(Column("foo"), Op.EQ, "foz"),
+                ],
+                groupby=[Column("a"), Column("b")],
+            )
+        ),
+        id="test curried functions with filters and group by",
+    ),
 ]
 
 
@@ -449,8 +509,8 @@ def test_parse_mql(mql_string: str, metrics_query: MetricsQuery) -> None:
 
 @pytest.mark.xfail(reason="Not supported")
 def test_terms() -> None:
-    dsl = "sum(foo) / 1000"
-    result = parse_mql(dsl)
+    mql = "sum(foo) / 1000"
+    result = parse_mql(mql)
     assert result == MetricsQuery(
         query=Formula(
             ArithmeticOperator.DIVIDE,
@@ -464,8 +524,8 @@ def test_terms() -> None:
         )
     )
 
-    dsl = "sum(foo) * sum(bar)"
-    result = parse_mql(dsl)
+    mql = "sum(foo) * sum(bar)"
+    result = parse_mql(mql)
     assert result == MetricsQuery(
         query=Formula(
             ArithmeticOperator.MULTIPLY,
@@ -485,8 +545,8 @@ def test_terms() -> None:
 
 @pytest.mark.xfail(reason="Not supported")
 def test_multi_terms() -> None:
-    dsl = "(sum(foo) * sum(bar)) / 1000"
-    result = parse_mql(dsl)
+    mql = "(sum(foo) * sum(bar)) / 1000"
+    result = parse_mql(mql)
     assert result == MetricsQuery(
         query=Formula(
             ArithmeticOperator.DIVIDE,
@@ -512,8 +572,8 @@ def test_multi_terms() -> None:
 
 @pytest.mark.xfail(reason="Not supported")
 def test_terms_with_filters() -> None:
-    dsl = '(sum(foo) / sum(bar)){tag="tag_value"}'
-    result = parse_mql(dsl)
+    mql = '(sum(foo) / sum(bar)){tag="tag_value"}'
+    result = parse_mql(mql)
     assert result == MetricsQuery(
         query=Formula(
             ArithmeticOperator.DIVIDE,
@@ -531,8 +591,8 @@ def test_terms_with_filters() -> None:
         ),
     )
 
-    dsl = 'sum(foo{tag="tag_value"}) / sum(bar{tag="tag_value"})'
-    result = parse_mql(dsl)
+    mql = 'sum(foo{tag="tag_value"}) / sum(bar{tag="tag_value"})'
+    result = parse_mql(mql)
     assert result == MetricsQuery(
         query=Formula(
             ArithmeticOperator.DIVIDE,
@@ -554,8 +614,8 @@ def test_terms_with_filters() -> None:
 
 @pytest.mark.xfail(reason="Not supported")
 def test_terms_with_groupby() -> None:
-    dsl = '(sum(foo) / sum(bar)){tag="tag_value"} by transaction'
-    result = parse_mql(dsl)
+    mql = '(sum(foo) / sum(bar)){tag="tag_value"} by transaction'
+    result = parse_mql(mql)
     assert result == MetricsQuery(
         query=Formula(
             ArithmeticOperator.DIVIDE,
@@ -574,8 +634,8 @@ def test_terms_with_groupby() -> None:
         ),
     )
 
-    dsl = "(sum(foo) by transaction / sum(bar) by transaction)"
-    result = parse_mql(dsl)
+    mql = "(sum(foo) by transaction / sum(bar) by transaction)"
+    result = parse_mql(mql)
     assert result == MetricsQuery(
         query=Formula(
             ArithmeticOperator.DIVIDE,
@@ -594,8 +654,8 @@ def test_terms_with_groupby() -> None:
         ),
     )
 
-    dsl = '(sum(foo) by transaction / sum(bar) by transaction){tag="tag_value"}'
-    result = parse_mql(dsl)
+    mql = '(sum(foo) by transaction / sum(bar) by transaction){tag="tag_value"}'
+    result = parse_mql(mql)
     assert result == MetricsQuery(
         query=Formula(
             ArithmeticOperator.DIVIDE,
@@ -615,8 +675,8 @@ def test_terms_with_groupby() -> None:
         ),
     )
 
-    dsl = '(sum(foo{tag="tag_value"}) by transaction) / (sum(bar{tag="tag_value"}) by transaction)'
-    result = parse_mql(dsl)
+    mql = '(sum(foo{tag="tag_value"}) by transaction) / (sum(bar{tag="tag_value"}) by transaction)'
+    result = parse_mql(mql)
     assert result == MetricsQuery(
         query=Formula(
             ArithmeticOperator.DIVIDE,
@@ -637,8 +697,8 @@ def test_terms_with_groupby() -> None:
         ),
     )
 
-    dsl = '(sum(foo){tag="tag_value"}) by transaction / (sum(bar){tag="tag_value"}) by transaction'
-    result = parse_mql(dsl)
+    mql = '(sum(foo){tag="tag_value"}) by transaction / (sum(bar){tag="tag_value"}) by transaction'
+    result = parse_mql(mql)
     assert result == MetricsQuery(
         query=Formula(
             ArithmeticOperator.DIVIDE,
@@ -659,8 +719,8 @@ def test_terms_with_groupby() -> None:
         ),
     )
 
-    dsl = '(sum(foo) / sum(bar)){tag="tag_value"} by transaction'
-    result = parse_mql(dsl)
+    mql = '(sum(foo) / sum(bar)){tag="tag_value"} by transaction'
+    result = parse_mql(mql)
     assert result == MetricsQuery(
         query=Formula(
             ArithmeticOperator.DIVIDE,
@@ -682,8 +742,8 @@ def test_terms_with_groupby() -> None:
 
 @pytest.mark.xfail(reason="Not supported")
 def test_complex_nested_terms() -> None:
-    dsl = '((sum(foo{tag="tag_value"}){tag2="tag_value2"} / sum(bar)){tag3="tag_value3"} * sum(pop)) by transaction'
-    result = parse_mql(dsl)
+    mql = '((sum(foo{tag="tag_value"}){tag2="tag_value2"} / sum(bar)){tag3="tag_value3"} * sum(pop)) by transaction'
+    result = parse_mql(mql)
     assert result == MetricsQuery(
         query=Formula(
             operator=ArithmeticOperator.MULTIPLY,


### PR DESCRIPTION
One of the main uses for metrics is currently quantiles. Those are curried
functions, so MQL needs to support curried functions if it is going to be used
to encode queries being sent to Snuba.

Add curried functions to the MQL grammar that support arbitrary params. The
only use case at the moment is quantiles but it doesn't hurt to be a little
more open in the grammar.

Also rename `dsl` to `mql` to be more consistent.
Also add `(` and `)` to the excluded characters in unquoted strings.