### PR TITLE
fix(ddm): Fix MQL grammar handling of single filter nested expressions

### DIFF
--- a/snuba_sdk/mql/mql.py
+++ b/snuba_sdk/mql/mql.py
@@ -229,7 +229,7 @@ class MQLVisitor(NodeVisitor):  # type: ignore
         self, node: Node, children: Sequence[Any]
     ) -> Union[Condition, BooleanCondition]:
         factor, *_ = children
-        # A nested filter can be both a boolean condition but also a single condition, since we allow (condition).
+        # A nested filter can be both a boolean condition but also a single condition, since we allow `(condition)`.
         if isinstance(factor, BooleanCondition) or isinstance(factor, Condition):
             # If we have a parenthesized expression, we just return it.
             return factor

--- a/snuba_sdk/mql/mql.py
+++ b/snuba_sdk/mql/mql.py
@@ -229,7 +229,8 @@ class MQLVisitor(NodeVisitor):  # type: ignore
         self, node: Node, children: Sequence[Any]
     ) -> Union[Condition, BooleanCondition]:
         factor, *_ = children
-        if isinstance(factor, BooleanCondition):
+        # A nested filter can be both a boolean condition but also a single condition, since we allow (condition).
+        if isinstance(factor, BooleanCondition) or isinstance(factor, Condition):
             # If we have a parenthesized expression, we just return it.
             return factor
         else:

--- a/tests/test_mql.py
+++ b/tests/test_mql.py
@@ -283,7 +283,7 @@ tests = [
         id="test multiple filters with AND operator",
     ),
     pytest.param(
-        'sum(user{bar:"baz" OR foo:"foz" AND hee:"haw"})',
+        'sum(user{bar:"baz" OR foo:"foz" AND (hee:"haw")})',
         MetricsQuery(
             query=Timeseries(
                 metric=Metric(public_name="user"),


### PR DESCRIPTION
This PR fixes a small edge case in which the grammar visitor didn't handle the case in which a single condition was inside parentheses.