### PR TITLE
ref(metrics): Support serializing a Request to MQL

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,13 @@
 Changelog and versioning
 ==========================
 
+2.0.13
+-----
+
+- Expose a `serialize_to_mql` function on the `Request` object
+    - This function will serialize `MetricsQuery` objects to MQL strings
+
+
 2.0.12
 -----
 

--- a/snuba_sdk/metrics_query.py
+++ b/snuba_sdk/metrics_query.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, replace
 from datetime import datetime
-from typing import Any, Mapping
+from typing import Any
 
 from snuba_sdk.expressions import Limit, Offset
 from snuba_sdk.formula import Formula
@@ -89,7 +89,7 @@ class MetricsQuery(BaseQuery):
         assert isinstance(result, str)
         return result
 
-    def serialize_to_mql(self) -> Mapping[str, str]:
+    def serialize_to_mql(self) -> dict[str, str | dict[str, Any]]:
         # TODO: when the new MQL snuba endpoint is ready, this method will replace .serialize()
         self.validate()
         result = MQL_PRINTER.visit(self)

--- a/snuba_sdk/metrics_visitors.py
+++ b/snuba_sdk/metrics_visitors.py
@@ -159,7 +159,7 @@ class TimeseriesMQLPrinter(TimeseriesVisitor[str]):
             groupby = str(returns["groupby"])
             mql_string += f"{groupby}"
 
-        return {"mql_string": mql_string}
+        return {"mql_string": mql_string, "entity": metric_data["entity"]}
 
     def _visit_metric(self, metric: Metric) -> Mapping[str, str]:
         return self.metrics_visitor.visit(metric)
@@ -227,10 +227,12 @@ class MetricMQLPrinter(MetricVisitor[Mapping[str, str]]):
             raise InvalidExpressionError(
                 "metric.mri or metric.public is required for serialization"
             )
+        if metric.entity is None:
+            raise InvalidExpressionError("metric.entity is required for serialization")
         if metric.mri:
-            return {"metric_name": metric.mri}
+            return {"metric_name": metric.mri, "entity": metric.entity}
         assert metric.public_name is not None
-        return {"metric_name": metric.public_name}
+        return {"metric_name": metric.public_name, "entity": metric.entity}
 
 
 class RollupVisitor(ABC, Generic[TVisited]):

--- a/snuba_sdk/mql_visitor.py
+++ b/snuba_sdk/mql_visitor.py
@@ -80,6 +80,7 @@ class MQLPrinter(MQLVisitor):
         assert isinstance(returns["query"], Mapping)  # mypy
         mql_string = returns["query"]["mql_string"]
         mql_context = MQLContext(
+            entity=returns["query"]["entity"],
             start=returns["start"],
             end=returns["end"],
             rollup=returns["rollup"],

--- a/tests/test_metrics_query.py
+++ b/tests/test_metrics_query.py
@@ -490,6 +490,7 @@ metrics_query_to_mql_tests = [
             query=Timeseries(
                 metric=Metric(
                     mri="d:transactions/duration@millisecond",
+                    entity="generic_metrics_distributions",
                 ),
                 aggregate="max",
                 aggregate_params=None,
@@ -506,6 +507,7 @@ metrics_query_to_mql_tests = [
         {
             "mql": "max(d:transactions/duration@millisecond)",
             "mql_context": {
+                "entity": "generic_metrics_distributions",
                 "start": "2023-01-02T03:04:05+00:00",
                 "end": "2023-01-16T03:04:05+00:00",
                 "rollup": {
@@ -531,6 +533,7 @@ metrics_query_to_mql_tests = [
             query=Timeseries(
                 metric=Metric(
                     public_name="transactions.duration",
+                    entity="generic_metrics_distributions",
                 ),
                 aggregate="max",
                 aggregate_params=None,
@@ -547,6 +550,7 @@ metrics_query_to_mql_tests = [
         {
             "mql": "max(transactions.duration)",
             "mql_context": {
+                "entity": "generic_metrics_distributions",
                 "start": "2023-01-02T03:04:05+00:00",
                 "end": "2023-01-16T03:04:05+00:00",
                 "rollup": {
@@ -572,6 +576,7 @@ metrics_query_to_mql_tests = [
             query=Timeseries(
                 metric=Metric(
                     mri="d:transactions/duration@millisecond",
+                    entity="generic_metrics_distributions",
                 ),
                 aggregate="max",
                 aggregate_params=None,
@@ -588,6 +593,7 @@ metrics_query_to_mql_tests = [
         {
             "mql": "max(d:transactions/duration@millisecond){bar:'baz'}",
             "mql_context": {
+                "entity": "generic_metrics_distributions",
                 "start": "2023-01-02T03:04:05+00:00",
                 "end": "2023-01-16T03:04:05+00:00",
                 "rollup": {
@@ -613,6 +619,7 @@ metrics_query_to_mql_tests = [
             query=Timeseries(
                 metric=Metric(
                     mri="d:transactions/duration@millisecond",
+                    entity="generic_metrics_distributions",
                 ),
                 aggregate="max",
                 aggregate_params=None,
@@ -629,6 +636,7 @@ metrics_query_to_mql_tests = [
         {
             "mql": "max(d:transactions/duration@millisecond){bar:['baz', 'bap']}",
             "mql_context": {
+                "entity": "generic_metrics_distributions",
                 "start": "2023-01-02T03:04:05+00:00",
                 "end": "2023-01-16T03:04:05+00:00",
                 "rollup": {
@@ -654,6 +662,7 @@ metrics_query_to_mql_tests = [
             query=Timeseries(
                 metric=Metric(
                     mri="d:transactions/duration@millisecond",
+                    entity="generic_metrics_distributions",
                 ),
                 aggregate="max",
                 aggregate_params=None,
@@ -687,6 +696,7 @@ metrics_query_to_mql_tests = [
         {
             "mql": "max(d:transactions/duration@millisecond){bar:'baz' AND foo:'foz' AND (foo:'foz' OR hee:'hez' OR (foo:'foz' AND hee:'hez'))}",
             "mql_context": {
+                "entity": "generic_metrics_distributions",
                 "start": "2023-01-02T03:04:05+00:00",
                 "end": "2023-01-16T03:04:05+00:00",
                 "rollup": {
@@ -712,6 +722,7 @@ metrics_query_to_mql_tests = [
             query=Timeseries(
                 metric=Metric(
                     mri="d:transactions/duration@millisecond",
+                    entity="generic_metrics_distributions",
                 ),
                 aggregate="max",
                 aggregate_params=None,
@@ -728,6 +739,7 @@ metrics_query_to_mql_tests = [
         {
             "mql": "max(d:transactions/duration@millisecond) by (transaction)",
             "mql_context": {
+                "entity": "generic_metrics_distributions",
                 "start": "2023-01-02T03:04:05+00:00",
                 "end": "2023-01-16T03:04:05+00:00",
                 "rollup": {
@@ -753,6 +765,7 @@ metrics_query_to_mql_tests = [
             query=Timeseries(
                 metric=Metric(
                     mri="d:transactions/duration@millisecond",
+                    entity="generic_metrics_distributions",
                 ),
                 aggregate="max",
                 aggregate_params=None,
@@ -769,6 +782,7 @@ metrics_query_to_mql_tests = [
         {
             "mql": "max(d:transactions/duration@millisecond) by (a, b)",
             "mql_context": {
+                "entity": "generic_metrics_distributions",
                 "start": "2023-01-02T03:04:05+00:00",
                 "end": "2023-01-16T03:04:05+00:00",
                 "rollup": {
@@ -794,6 +808,7 @@ metrics_query_to_mql_tests = [
             query=Timeseries(
                 metric=Metric(
                     mri="d:transactions/duration@millisecond",
+                    entity="generic_metrics_distributions",
                 ),
                 aggregate="max",
                 aggregate_params=None,
@@ -810,6 +825,7 @@ metrics_query_to_mql_tests = [
         {
             "mql": "max(d:transactions/duration@millisecond){bar:'baz'} by (transaction)",
             "mql_context": {
+                "entity": "generic_metrics_distributions",
                 "start": "2023-01-02T03:04:05+00:00",
                 "end": "2023-01-16T03:04:05+00:00",
                 "rollup": {

--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import json
 import re
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from typing import Mapping
 
 import pytest
@@ -10,15 +10,34 @@ import pytest
 from snuba_sdk.column import Column
 from snuba_sdk.conditions import Condition, Op
 from snuba_sdk.entity import Entity
+from snuba_sdk.metrics_query import MetricsQuery
 from snuba_sdk.query import Query
 from snuba_sdk.query_visitors import InvalidQueryError
 from snuba_sdk.request import Flags, InvalidFlagError, InvalidRequestError, Request
+from snuba_sdk.timeseries import Metric, MetricsScope, Rollup, Timeseries
 
 NOW = datetime(2021, 1, 2, 3, 4, 5, 6, timezone.utc)
 BASIC_QUERY = (
     Query(Entity("events"))
     .set_select([Column("event_id"), Column("title")])
     .set_where([Condition(Column("timestamp"), Op.GT, NOW)])
+)
+BASIC_METRICS_QUERY = MetricsQuery(
+    query=Timeseries(
+        metric=Metric(
+            mri="d:transactions/duration@millisecond",
+            id=11235813,
+            entity="generic_metrics_distributions",
+        ),
+        aggregate="max",
+        aggregate_params=None,
+        filters=[Condition(Column("bar"), Op.EQ, "baz")],
+        groupby=[Column("transaction")],
+    ),
+    start=NOW,
+    end=NOW + timedelta(days=14),
+    rollup=Rollup(interval=3600, totals=None, granularity=3600),
+    scope=MetricsScope(org_ids=[1], project_ids=[11], use_case_id="transactions"),
 )
 
 
@@ -32,6 +51,47 @@ tests = [
         "s/g",
         {
             "query": "MATCH (events) SELECT event_id, title WHERE timestamp > toDateTime('2021-01-02T03:04:05.000006')",
+            "consistent": True,
+            "turbo": True,
+            "debug": True,
+            "dry_run": True,
+            "dataset": "events",
+            "app_id": "default",
+            "tenant_ids": {"organization_id": 1, "referrer": "default"},
+            "parent_api": "s/g",
+            "legacy": True,
+        },
+        None,
+        id="flags",
+    ),
+    pytest.param(
+        "events",
+        "default",
+        {"organization_id": 1, "referrer": "default"},
+        BASIC_METRICS_QUERY,
+        Flags(consistent=True, turbo=True, dry_run=True, legacy=True, debug=True),
+        "s/g",
+        {
+            "query": "max(d:transactions/duration@millisecond){bar:'baz'} by (transaction)",
+            "mql_context": {
+                "start": "2021-01-02T03:04:05.000006+00:00",
+                "end": "2021-01-16T03:04:05.000006+00:00",
+                "entity": "generic_metrics_distributions",
+                "indexer_mappings": {},
+                "limit": "",
+                "offset": "",
+                "rollup": {
+                    "granularity": "3600",
+                    "interval": "3600",
+                    "orderby": {"column_name": "time", "direction": "ASC"},
+                    "with_totals": "",
+                },
+                "scope": {
+                    "org_ids": [1],
+                    "project_ids": [11],
+                    "use_case_id": "transactions",
+                },
+            },
             "consistent": True,
             "turbo": True,
             "debug": True,
@@ -145,8 +205,10 @@ def test_request(
     else:
         request = Request(dataset, app_id, query, flags, parent_api, tenant_ids)
         request.validate()
-        assert request.to_dict() == expected
-        assert request.print() == json.dumps(expected, sort_keys=True, indent=4 * " ")
+        assert request.to_dict(mql=True) == expected
+        assert request.print(mql=True) == json.dumps(
+            expected, sort_keys=True, indent=4 * " "
+        )
 
 
 def test_request_set_methods() -> None:


### PR DESCRIPTION
Add a `serialize_to_mql` function to the Request class. This is a temporary
function that we can use as we cut over Sentry/Snuba to use the new MQL based
Snuba endpoint. Having two functions just makes it slightly easier to roll
back/forward, the calling code can be changed instead of having to release new
SDK versions or roll back versions.

Once Sentry/Snuba are using the new endpoint, this functionality can be folded
into the default `serialize` function in a future version.
