### PR TITLE
fix(mql): Add support for `.` in the grammar

### DIFF
--- a/snuba_sdk/mql/mql.py
+++ b/snuba_sdk/mql/mql.py
@@ -50,7 +50,7 @@ unquoted_string = ~r'[^,\[\]\"}}{{\(\)\s]+'
 string_tuple = open_square_bracket _ (quoted_string / unquoted_string) (_ comma _ (quoted_string / unquoted_string))* _ close_square_bracket
 
 target = variable / nested_expression / function / metric
-variable = "$" ~r"[a-zA-Z0-9_]+"
+variable = "$" ~r"[a-zA-Z0-9_.]+"
 nested_expression = open_paren _ expression _ close_paren
 
 function = (curried_aggregate / aggregate) (group_by)?
@@ -62,7 +62,7 @@ param_expression = number / quoted_string / unquoted_string
 aggregate_name = ~r"[a-zA-Z0-9_]+"
 
 group_by = _ "by" _ (group_by_name / group_by_name_tuple)
-group_by_name = ~r"[a-zA-Z0-9_]+"
+group_by_name = ~r"[a-zA-Z0-9_.]+"
 group_by_name_tuple = open_paren _ group_by_name (_ comma _ group_by_name)* _ close_paren
 
 metric = quoted_mri / unquoted_mri / quoted_public_name / unquoted_public_name

--- a/tests/test_mql.py
+++ b/tests/test_mql.py
@@ -509,13 +509,13 @@ tests = [
         id="test group by 1",
     ),
     pytest.param(
-        "max(`d:transactions/duration@millisecond`{foo:foz} by transaction)",
+        "max(`d:transactions/duration@millisecond`{foo:foz} by http.status_code)",
         MetricsQuery(
             query=Timeseries(
                 metric=Metric(mri="d:transactions/duration@millisecond"),
                 aggregate="max",
                 filters=[Condition(Column("foo"), Op.EQ, "foz")],
-                groupby=[Column("transaction")],
+                groupby=[Column("http.status_code")],
             ),
         ),
         id="test group by 2",
@@ -533,7 +533,7 @@ tests = [
         id="test group by 3",
     ),
     pytest.param(
-        'max(`d:transactions/duration@millisecond`{foo:"foz"}){bar:baz} by (a, b)',
+        'max(`d:transactions/duration@millisecond`{foo:"foz"}){bar:baz} by (a.something, b.something)',
         MetricsQuery(
             query=Timeseries(
                 metric=Metric(mri="d:transactions/duration@millisecond"),
@@ -542,7 +542,7 @@ tests = [
                     Condition(Column("bar"), Op.EQ, "baz"),
                     Condition(Column("foo"), Op.EQ, "foz"),
                 ],
-                groupby=[Column("a"), Column("b")],
+                groupby=[Column("a.something"), Column("b.something")],
             )
         ),
         id="test group by 4",
@@ -633,7 +633,7 @@ def test_terms() -> None:
         )
     )
 
-    mql = "sum(foo) * sum(bar)"
+    mql = "sum(foo) * bar"
     result = parse_mql(mql)
     assert result == MetricsQuery(
         query=Formula(


### PR DESCRIPTION
This PR adds the support for `.` in the MQL grammar to handle cases such as `sum(something) by (http.status_code)`.