### PR TITLE
fix(mql): Have MQL use double instead of single quotes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,12 @@
 Changelog and versioning
 ==========================
 
+2.0.15
+-----
+
+- Fix a bug where quotes in MQL encoded strings were using single quotes instead of double quotes
+
+
 2.0.14
 -----
 

--- a/snuba_sdk/metrics_visitors.py
+++ b/snuba_sdk/metrics_visitors.py
@@ -136,7 +136,7 @@ class TimeseriesMQLPrinter(TimeseriesVisitor[str]):
         expression_visitor: Translation | None = None,
         metrics_visitor: MetricMQLPrinter | None = None,
     ) -> None:
-        self.expression_visitor = expression_visitor or Translation()
+        self.expression_visitor = expression_visitor or Translation(is_mql=True)
         self.metrics_visitor = metrics_visitor or MetricMQLPrinter()
 
     def _combine(

--- a/snuba_sdk/mql_visitor.py
+++ b/snuba_sdk/mql_visitor.py
@@ -73,7 +73,7 @@ class MQLVisitor(ABC):
 
 class MQLPrinter(MQLVisitor):
     def __init__(self) -> None:
-        self.expression_visitor = Translation()
+        self.expression_visitor = Translation(is_mql=True)
         self.timeseries_visitor = TimeseriesMQLPrinter(self.expression_visitor)
         self.rollup_visitor = RollupMQLPrinter()
         self.scope_visitor = ScopeMQLPrinter()

--- a/tests/test_mql.py
+++ b/tests/test_mql.py
@@ -607,6 +607,27 @@ tests = [
         ),
         id="test curried functions with filters and group by",
     ),
+    pytest.param(
+        "quantiles(0.5)(`d:transactions/duration@millisecond`{foo:'foz' AND hee:\"hoo\"}){bar:baz} by (a, b)",
+        MetricsQuery(
+            query=Timeseries(
+                metric=Metric(mri="d:transactions/duration@millisecond"),
+                aggregate="quantiles",
+                aggregate_params=[0.5],
+                filters=[
+                    Condition(Column("bar"), Op.EQ, "baz"),
+                    And(
+                        [
+                            Condition(Column("foo"), Op.EQ, "'foz'"),
+                            Condition(Column("hee"), Op.EQ, "hoo"),
+                        ]
+                    ),
+                ],
+                groupby=[Column("a"), Column("b")],
+            )
+        ),
+        id="test quotes parsing",
+    ),
 ]
 
 

--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -73,7 +73,7 @@ tests = [
         Flags(consistent=True, turbo=True, dry_run=True, legacy=True, debug=True),
         "s/g",
         {
-            "query": "max(d:transactions/duration@millisecond){bar:'baz'} by (transaction)",
+            "query": 'max(d:transactions/duration@millisecond){bar:"baz"} by (transaction)',
             "mql_context": {
                 "start": "2021-01-02T03:04:05.000006+00:00",
                 "end": "2021-01-16T03:04:05.000006+00:00",


### PR DESCRIPTION
MQL is meant to align with Discover syntax as much as possible. Discover uses
double quotes instead of single quotes, so when a MetricsQuery is serialized it
needs to be serialized using double quotes instead of single quotes.
