### PR TITLE
feat(mql): Support encoding Formulas to MQL

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,10 +1,15 @@
 Changelog and versioning
 ==========================
 
-2.0.17
+2.0.18
 ------
 
-### Various fixes & improvements
+- Support serializing Formula objects into MQL
+- Enable all the tests for deserializing MQL into Formulas
+
+
+2.0.17
+------
 
 - fix(ddm): Add support for . in the tag keys (#153) by @iambriccardo
 

--- a/snuba_sdk/formula.py
+++ b/snuba_sdk/formula.py
@@ -26,6 +26,14 @@ class ArithmeticOperator(Enum):
     DIVIDE = "divide"
 
 
+PREFIX_TO_INFIX: dict[ArithmeticOperator, str] = {
+    ArithmeticOperator.PLUS: "+",
+    ArithmeticOperator.MINUS: "-",
+    ArithmeticOperator.MULTIPLY: "*",
+    ArithmeticOperator.DIVIDE: "/",
+}
+
+
 @dataclass(frozen=True)
 class Formula:
     operator: ArithmeticOperator
@@ -33,45 +41,56 @@ class Formula:
     filters: Optional[ConditionGroup] = None
     groupby: Optional[list[Column | AliasedExpression]] = None
 
+    def __validate_consistency(self) -> tuple[str, list[Column | AliasedExpression]]:
+        """
+        Ensure that the entity and groupby columns are consistent across all Timeseries
+        and Formulas within this Formula."""
+        if self.parameters is None:
+            raise InvalidFormulaError("Formula must have parameters")
+
+        entities = set()
+        groupbys = []
+        groupbys.append(
+            tuple(g for g in self.groupby) if self.groupby is not None else tuple()
+        )
+        for param in self.parameters:
+            if isinstance(param, Formula):
+                entity, found_gpby = param.__validate_consistency()
+                entities.add(entity)
+                groupbys.append(tuple(found_gpby))
+            elif isinstance(param, Timeseries):
+                if param.metric.entity is not None:
+                    entities.add(param.metric.entity)
+                if param.groupby is not None:
+                    groupbys.append(tuple(param.groupby))
+
+        if len(entities) != 1:
+            raise InvalidFormulaError("Formulas must operate on a single entity")
+        if len(set(groupbys)) != 1:
+            raise InvalidFormulaError(
+                "Formula parameters must group by the same columns"
+            )
+
+        return entities.pop(), list(groupbys[0])
+
     def validate(self) -> None:
         if not isinstance(self.operator, ArithmeticOperator):
             raise InvalidFormulaError(
                 f"formula '{self.operator}' must be a ArithmeticOperator"
             )
-        if self.parameters is not None:
-            if not isinstance(self.parameters, Sequence):
+        if self.parameters is None:
+            raise InvalidFormulaError("Formula must have parameters")
+        elif not isinstance(self.parameters, Sequence):
+            raise InvalidFormulaError(
+                f"parameters of formula {self.operator.value} must be a Sequence"
+            )
+
+        for param in self.parameters:
+            if not isinstance(param, tuple(FormulaParameter)):
                 raise InvalidFormulaError(
-                    f"parameters of formula {self.operator.value} must be a Sequence"
+                    f"parameter '{param}' of formula {self.operator.value} is an invalid type"
                 )
-
-            # - Must have the same entities, and must have an entity (no formulas on just literals)
-            # - Must have the same groupbys
-            entity = None
-            groupby = None
-            for param in self.parameters:
-                if not isinstance(param, (Timeseries, float, int)):
-                    raise InvalidFormulaError(
-                        f"parameter '{param}' of formula {self.operator.value} is an invalid type"
-                    )
-
-                if isinstance(param, Timeseries):
-                    if entity is None:
-                        entity = param.metric.entity
-                    elif entity != param.metric.entity:
-                        raise InvalidFormulaError(
-                            "Formulas can only operate on a single entity"
-                        )
-
-                    to_check = set(param.groupby) if param.groupby is not None else None
-                    if groupby is None:
-                        groupby = to_check
-                    elif groupby != to_check:
-                        raise InvalidFormulaError(
-                            "Formula parameters must group by the same columns"
-                        )
-
-            if not entity:
-                raise InvalidFormulaError("Formulas must have an an entity")
+        self.__validate_consistency()
 
     def _replace(self, field: str, value: Any) -> Formula:
         new = replace(self, **{field: value})
@@ -99,4 +118,5 @@ class Formula:
         return self._replace("groupby", groupby)
 
 
-FormulaParameterGroup = Union[Timeseries, float, int]
+FormulaParameterGroup = Union[Formula, Timeseries, float, int]
+FormulaParameter = {Formula, Timeseries, float, int}

--- a/snuba_sdk/mql/mql.py
+++ b/snuba_sdk/mql/mql.py
@@ -142,7 +142,6 @@ class MQLVisitor(NodeVisitor):  # type: ignore
         return expr
 
     def visit_expr_op(self, node: Node, children: Sequence[Any]) -> Any:
-        # raise InvalidQueryError("Arithmetic function not supported yet")
         return EXPRESSION_OPERATORS[node.text]
 
     def visit_term(
@@ -161,7 +160,6 @@ class MQLVisitor(NodeVisitor):  # type: ignore
         return term
 
     def visit_term_op(self, node: Node, children: Sequence[Any]) -> Any:
-        # raise InvalidQueryError("Arithmetic function not supported yet")
         return TERM_OPERATORS[node.text]
 
     def visit_coefficient(

--- a/snuba_sdk/mql/mql.py
+++ b/snuba_sdk/mql/mql.py
@@ -153,7 +153,8 @@ class MQLVisitor(NodeVisitor):  # type: ignore
         then merge them into a single Formula with the operator.
         """
         term, zero_or_more_others = children
-        assert isinstance(term, (Timeseries, float, int))
+        assert isinstance(term, (Formula, Timeseries, float, int))
+
         if zero_or_more_others:
             _, term_operator, _, coefficient, *_ = zero_or_more_others[0]
             return Formula(term_operator, [term, coefficient])
@@ -213,7 +214,7 @@ class MQLVisitor(NodeVisitor):  # type: ignore
             elif operator == BooleanOp.OR:
                 return Or(conditions=filters)
             else:
-                return BooleanCondition(op=operator, conditions=filters)
+                raise InvalidQueryError(f"Invalid boolean operator {operator}")
 
     def visit_filter_expr(
         self, node: Node, children: Sequence[Any]

--- a/tests/test_formula.py
+++ b/tests/test_formula.py
@@ -154,7 +154,7 @@ tests = [
             [Condition(Column("tags[status_code]"), Op.EQ, 200)],
             [Column("tags[release]")],
         ),
-        InvalidFormulaError("Formulas can only operate on a single entity"),
+        InvalidFormulaError("Formulas must operate on a single entity"),
         id="different entities",
     ),
     pytest.param(
@@ -197,7 +197,7 @@ tests = [
             [Condition(Column("tags[status_code]"), Op.EQ, 200)],
             [Column("tags[release]")],
         ),
-        InvalidFormulaError("Formulas must have an an entity"),
+        InvalidFormulaError("Formulas must operate on a single entity"),
         id="no simple math",
     ),
 ]

--- a/tests/test_formula_printer.py
+++ b/tests/test_formula_printer.py
@@ -1,0 +1,313 @@
+from __future__ import annotations
+
+import pytest
+
+from snuba_sdk.column import Column
+from snuba_sdk.conditions import Condition, Op
+from snuba_sdk.formula import ArithmeticOperator, Formula
+from snuba_sdk.metrics_visitors import FormulaMQLPrinter
+from snuba_sdk.mql.mql import parse_mql
+from snuba_sdk.timeseries import Metric, Timeseries
+
+formula_tests = [
+    pytest.param(
+        Formula(
+            ArithmeticOperator.DIVIDE,
+            [
+                Timeseries(
+                    metric=Metric(
+                        public_name="foo", entity="generic_metrics_distributions"
+                    ),
+                    aggregate="sum",
+                ),
+                1000,
+            ],
+        ),
+        "(sum(foo) / 1000)",
+        id="test_terms",
+    ),
+    pytest.param(
+        Formula(
+            ArithmeticOperator.MULTIPLY,
+            [
+                Timeseries(
+                    metric=Metric(
+                        public_name="foo", entity="generic_metrics_distributions"
+                    ),
+                    aggregate="sum",
+                ),
+                Timeseries(
+                    metric=Metric(
+                        public_name="bar", entity="generic_metrics_distributions"
+                    ),
+                    aggregate="max",
+                ),
+            ],
+        ),
+        "(sum(foo) * max(bar))",
+    ),
+    pytest.param(
+        Formula(
+            ArithmeticOperator.DIVIDE,
+            [
+                Formula(
+                    ArithmeticOperator.MULTIPLY,
+                    [
+                        Timeseries(
+                            metric=Metric(
+                                public_name="foo",
+                                entity="generic_metrics_distributions",
+                            ),
+                            aggregate="sum",
+                        ),
+                        Timeseries(
+                            metric=Metric(
+                                public_name="bar",
+                                entity="generic_metrics_distributions",
+                            ),
+                            aggregate="sum",
+                        ),
+                    ],
+                ),
+                1000.0,
+            ],
+        ),
+        "((sum(foo) * sum(bar)) / 1000.0)",
+    ),
+    pytest.param(
+        Formula(
+            ArithmeticOperator.DIVIDE,
+            [
+                Timeseries(
+                    metric=Metric(
+                        public_name="foo", entity="generic_metrics_distributions"
+                    ),
+                    aggregate="sum",
+                ),
+                Timeseries(
+                    metric=Metric(
+                        public_name="bar", entity="generic_metrics_distributions"
+                    ),
+                    aggregate="sum",
+                ),
+            ],
+            filters=[Condition(Column("tag"), Op.EQ, "tag_value")],
+        ),
+        '(sum(foo) / sum(bar)){tag:"tag_value"}',
+    ),
+    pytest.param(
+        Formula(
+            ArithmeticOperator.DIVIDE,
+            [
+                Timeseries(
+                    metric=Metric(
+                        public_name="foo", entity="generic_metrics_distributions"
+                    ),
+                    aggregate="sum",
+                    filters=[Condition(Column("tag"), Op.EQ, "tag_value")],
+                ),
+                Timeseries(
+                    metric=Metric(
+                        public_name="bar", entity="generic_metrics_distributions"
+                    ),
+                    aggregate="sum",
+                    filters=[Condition(Column("tag"), Op.EQ, "tag_value")],
+                ),
+            ],
+        ),
+        '(sum(foo){tag:"tag_value"} / sum(bar){tag:"tag_value"})',
+    ),
+    pytest.param(
+        Formula(
+            ArithmeticOperator.DIVIDE,
+            [
+                Timeseries(
+                    metric=Metric(
+                        public_name="foo", entity="generic_metrics_distributions"
+                    ),
+                    aggregate="sum",
+                ),
+                Timeseries(
+                    metric=Metric(
+                        public_name="bar", entity="generic_metrics_distributions"
+                    ),
+                    aggregate="sum",
+                ),
+            ],
+            filters=[Condition(Column("tag"), Op.EQ, "tag_value")],
+            groupby=[Column("transaction")],
+        ),
+        # '(sum(foo) / sum(bar)){tag:"tag_value"} by transaction',
+        '(sum(foo) / sum(bar)){tag:"tag_value"} by (transaction)',
+    ),
+    pytest.param(
+        Formula(
+            ArithmeticOperator.DIVIDE,
+            [
+                Timeseries(
+                    metric=Metric(
+                        public_name="foo", entity="generic_metrics_distributions"
+                    ),
+                    aggregate="sum",
+                    groupby=[Column("transaction")],
+                ),
+                Timeseries(
+                    metric=Metric(
+                        public_name="bar", entity="generic_metrics_distributions"
+                    ),
+                    aggregate="sum",
+                    groupby=[Column("transaction")],
+                ),
+            ],
+        ),
+        "(sum(foo) by (transaction) / sum(bar) by (transaction))",
+    ),
+    pytest.param(
+        Formula(
+            ArithmeticOperator.DIVIDE,
+            [
+                Timeseries(
+                    metric=Metric(
+                        public_name="foo", entity="generic_metrics_distributions"
+                    ),
+                    aggregate="sum",
+                    groupby=[Column("transaction")],
+                ),
+                Timeseries(
+                    metric=Metric(
+                        public_name="bar", entity="generic_metrics_distributions"
+                    ),
+                    aggregate="sum",
+                    groupby=[Column("transaction")],
+                ),
+            ],
+            filters=[Condition(Column("tag"), Op.EQ, "tag_value")],
+        ),
+        '(sum(foo) by (transaction) / sum(bar) by (transaction)){tag:"tag_value"}',
+    ),
+    pytest.param(
+        Formula(
+            ArithmeticOperator.DIVIDE,
+            [
+                Timeseries(
+                    metric=Metric(
+                        public_name="foo", entity="generic_metrics_distributions"
+                    ),
+                    aggregate="sum",
+                    filters=[Condition(Column("tag"), Op.EQ, "tag_value")],
+                    groupby=[Column("transaction")],
+                ),
+                Timeseries(
+                    metric=Metric(
+                        public_name="bar", entity="generic_metrics_distributions"
+                    ),
+                    aggregate="sum",
+                    filters=[Condition(Column("tag"), Op.EQ, "tag_value")],
+                    groupby=[Column("transaction")],
+                ),
+            ],
+        ),
+        '(sum(foo){tag:"tag_value"} by (transaction) / sum(bar){tag:"tag_value"} by (transaction))',
+    ),
+    pytest.param(
+        Formula(
+            ArithmeticOperator.DIVIDE,
+            [
+                Timeseries(
+                    metric=Metric(
+                        public_name="foo", entity="generic_metrics_distributions"
+                    ),
+                    aggregate="sum",
+                    filters=[Condition(Column("tag"), Op.EQ, "tag_value")],
+                    groupby=[Column("transaction")],
+                ),
+                Timeseries(
+                    metric=Metric(
+                        public_name="bar", entity="generic_metrics_distributions"
+                    ),
+                    aggregate="sum",
+                    filters=[Condition(Column("tag"), Op.EQ, "tag_value")],
+                    groupby=[Column("transaction")],
+                ),
+            ],
+        ),
+        '(sum(foo){tag:"tag_value"} by (transaction) / sum(bar){tag:"tag_value"} by (transaction))',
+    ),
+    pytest.param(
+        Formula(
+            ArithmeticOperator.DIVIDE,
+            [
+                Timeseries(
+                    metric=Metric(
+                        public_name="foo", entity="generic_metrics_distributions"
+                    ),
+                    aggregate="sum",
+                ),
+                Timeseries(
+                    metric=Metric(
+                        public_name="bar", entity="generic_metrics_distributions"
+                    ),
+                    aggregate="sum",
+                ),
+            ],
+            filters=[Condition(Column("tag"), Op.EQ, "tag_value")],
+            groupby=[Column("transaction")],
+        ),
+        '(sum(foo) / sum(bar)){tag:"tag_value"} by (transaction)',
+    ),
+    pytest.param(
+        Formula(
+            operator=ArithmeticOperator.MULTIPLY,
+            parameters=[
+                Formula(
+                    ArithmeticOperator.DIVIDE,
+                    [
+                        Timeseries(
+                            metric=Metric(
+                                public_name="foo",
+                                entity="generic_metrics_distributions",
+                            ),
+                            aggregate="sum",
+                            filters=[
+                                Condition(Column("tag2"), Op.EQ, "tag_value2"),
+                                Condition(Column("tag"), Op.EQ, "tag_value"),
+                            ],
+                        ),
+                        Timeseries(
+                            metric=Metric(
+                                public_name="bar",
+                                entity="generic_metrics_distributions",
+                            ),
+                            aggregate="sum",
+                        ),
+                    ],
+                    filters=[Condition(Column("tag3"), Op.EQ, "tag_value3")],
+                ),
+                Timeseries(
+                    metric=Metric(
+                        public_name="pop", entity="generic_metrics_distributions"
+                    ),
+                    aggregate="sum",
+                ),
+            ],
+            groupby=[Column("transaction")],
+        ),
+        '((sum(foo){tag2:"tag_value2" AND tag:"tag_value"} / sum(bar)){tag3:"tag_value3"} * sum(pop)) by (transaction)',
+    ),
+]
+
+FORMULA_PRINTER = FormulaMQLPrinter()
+
+
+@pytest.mark.parametrize("formula, mql", formula_tests)
+def test_metrics_query_to_mql_formula(formula: Formula, mql: str) -> None:
+    output = FORMULA_PRINTER.visit(formula)
+    assert output["mql_string"] == mql
+
+    # TODO: We can't simply assert the whole query, because we need an Entity in order to serialize the formula,
+    # but when we parse the MQL the entity is None. Once SnQL support is removed, we can change this.
+    # assert parse_mql(output["mql_string"]).query == formula
+    parsed = parse_mql(output["mql_string"])
+    assert parsed.query is not None
+    assert parsed.query.groupby == formula.groupby
+    assert parsed.query.filters == formula.filters

--- a/tests/test_mql.py
+++ b/tests/test_mql.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 from snuba_sdk.column import Column
@@ -637,7 +639,6 @@ def test_parse_mql(mql_string: str, metrics_query: MetricsQuery) -> None:
     assert result == metrics_query
 
 
-@pytest.mark.xfail(reason="Not supported")
 def test_terms() -> None:
     mql = "sum(foo) / 1000"
     result = parse_mql(mql)
@@ -654,7 +655,7 @@ def test_terms() -> None:
         )
     )
 
-    mql = "sum(foo) * bar"
+    mql = "sum(foo) * max(bar)"
     result = parse_mql(mql)
     assert result == MetricsQuery(
         query=Formula(
@@ -666,14 +667,13 @@ def test_terms() -> None:
                 ),
                 Timeseries(
                     metric=Metric(public_name="bar"),
-                    aggregate="sum",
+                    aggregate="max",
                 ),
             ],
         )
     )
 
 
-@pytest.mark.xfail(reason="Not supported")
 def test_multi_terms() -> None:
     mql = "(sum(foo) * sum(bar)) / 1000"
     result = parse_mql(mql)
@@ -681,7 +681,7 @@ def test_multi_terms() -> None:
         query=Formula(
             ArithmeticOperator.DIVIDE,
             [
-                Formula(  # type: ignore
+                Formula(
                     ArithmeticOperator.MULTIPLY,
                     [
                         Timeseries(
@@ -700,9 +700,8 @@ def test_multi_terms() -> None:
     )
 
 
-@pytest.mark.xfail(reason="Not supported")
 def test_terms_with_filters() -> None:
-    mql = '(sum(foo) / sum(bar)){tag="tag_value"}'
+    mql = '(sum(foo) / sum(bar)){tag:"tag_value"}'
     result = parse_mql(mql)
     assert result == MetricsQuery(
         query=Formula(
@@ -721,7 +720,7 @@ def test_terms_with_filters() -> None:
         ),
     )
 
-    mql = 'sum(foo{tag="tag_value"}) / sum(bar{tag="tag_value"})'
+    mql = 'sum(foo{tag:"tag_value"}) / sum(bar{tag:"tag_value"})'
     result = parse_mql(mql)
     assert result == MetricsQuery(
         query=Formula(
@@ -742,9 +741,8 @@ def test_terms_with_filters() -> None:
     )
 
 
-@pytest.mark.xfail(reason="Not supported")
 def test_terms_with_groupby() -> None:
-    mql = '(sum(foo) / sum(bar)){tag="tag_value"} by transaction'
+    mql = '(sum(foo) / sum(bar)){tag:"tag_value"} by transaction'
     result = parse_mql(mql)
     assert result == MetricsQuery(
         query=Formula(
@@ -784,7 +782,7 @@ def test_terms_with_groupby() -> None:
         ),
     )
 
-    mql = '(sum(foo) by transaction / sum(bar) by transaction){tag="tag_value"}'
+    mql = '(sum(foo) by transaction / sum(bar) by transaction){tag:"tag_value"}'
     result = parse_mql(mql)
     assert result == MetricsQuery(
         query=Formula(
@@ -805,7 +803,7 @@ def test_terms_with_groupby() -> None:
         ),
     )
 
-    mql = '(sum(foo{tag="tag_value"}) by transaction) / (sum(bar{tag="tag_value"}) by transaction)'
+    mql = '(sum(foo{tag:"tag_value"}) by transaction) / (sum(bar{tag:"tag_value"}) by transaction)'
     result = parse_mql(mql)
     assert result == MetricsQuery(
         query=Formula(
@@ -827,7 +825,7 @@ def test_terms_with_groupby() -> None:
         ),
     )
 
-    mql = '(sum(foo){tag="tag_value"}) by transaction / (sum(bar){tag="tag_value"}) by transaction'
+    mql = '(sum(foo){tag:"tag_value"}) by transaction / (sum(bar){tag:"tag_value"}) by transaction'
     result = parse_mql(mql)
     assert result == MetricsQuery(
         query=Formula(
@@ -849,7 +847,7 @@ def test_terms_with_groupby() -> None:
         ),
     )
 
-    mql = '(sum(foo) / sum(bar)){tag="tag_value"} by transaction'
+    mql = '(sum(foo) / sum(bar)){tag:"tag_value"} by transaction'
     result = parse_mql(mql)
     assert result == MetricsQuery(
         query=Formula(
@@ -870,15 +868,14 @@ def test_terms_with_groupby() -> None:
     )
 
 
-@pytest.mark.xfail(reason="Not supported")
 def test_complex_nested_terms() -> None:
-    mql = '((sum(foo{tag="tag_value"}){tag2="tag_value2"} / sum(bar)){tag3="tag_value3"} * sum(pop)) by transaction'
+    mql = '((sum(foo{tag:"tag_value"}){tag2:"tag_value2"} / sum(bar)){tag3:"tag_value3"} * sum(pop)) by transaction'
     result = parse_mql(mql)
     assert result == MetricsQuery(
         query=Formula(
             operator=ArithmeticOperator.MULTIPLY,
             parameters=[
-                Formula(  # type: ignore
+                Formula(
                     ArithmeticOperator.DIVIDE,
                     [
                         Timeseries(


### PR DESCRIPTION
This PR adds a visitor that will encode a Formula to MQL. It supports nested
Formulas as well.

Also, even though the parser supported parsing Formulas from MQL, the tests
were all disabled. The tests were enabled, and used as a basis for all the
other test for serializing Formulas.

For testing, when a Formula is serialized to MQL, the test also checks that the
output MQL can be deserialized back to an SDK object.

An explicit decision was made to not do reverse testing when deserializing MQL.
That's because the range of possible inputs that can be correctly deserialized
is much broader than the set of possible outputs from serializing. For example,
`((((((sum(foo)))))))` is valid input, but when that is serialized it won't
match.
