### PR TITLE
feat(mql): Support arbitrary functions in MQL Grammar

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ Changelog and versioning
 
 - Support serializing Formula objects into MQL
 - Enable all the tests for deserializing MQL into Formulas
+- Support arbitrary functions in MQL
 
 
 2.0.17

--- a/snuba_sdk/formula.py
+++ b/snuba_sdk/formula.py
@@ -26,7 +26,7 @@ class ArithmeticOperator(Enum):
     DIVIDE = "divide"
 
 
-PREFIX_TO_INFIX: dict[ArithmeticOperator, str] = {
+PREFIX_TO_INFIX: dict[str, str] = {
     ArithmeticOperator.PLUS.value: "+",
     ArithmeticOperator.MINUS.value: "-",
     ArithmeticOperator.MULTIPLY.value: "*",
@@ -116,5 +116,5 @@ class Formula:
         return self._replace("groupby", groupby)
 
 
-FormulaParameterGroup = Union[Formula, Timeseries, float, int]
+FormulaParameterGroup = Union[Formula, Timeseries, float, int, str]
 FormulaParameter = {Formula, Timeseries, float, int}

--- a/snuba_sdk/formula.py
+++ b/snuba_sdk/formula.py
@@ -27,10 +27,10 @@ class ArithmeticOperator(Enum):
 
 
 PREFIX_TO_INFIX: dict[ArithmeticOperator, str] = {
-    ArithmeticOperator.PLUS: "+",
-    ArithmeticOperator.MINUS: "-",
-    ArithmeticOperator.MULTIPLY: "*",
-    ArithmeticOperator.DIVIDE: "/",
+    ArithmeticOperator.PLUS.value: "+",
+    ArithmeticOperator.MINUS.value: "-",
+    ArithmeticOperator.MULTIPLY.value: "*",
+    ArithmeticOperator.DIVIDE.value: "/",
 }
 
 
@@ -80,13 +80,13 @@ class Formula:
             raise InvalidFormulaError("Formula must have parameters")
         elif not isinstance(self.parameters, Sequence):
             raise InvalidFormulaError(
-                f"parameters of formula {self.function_name.value} must be a Sequence"
+                f"parameters of formula {self.function_name} must be a Sequence"
             )
 
         for param in self.parameters:
             if not isinstance(param, tuple(FormulaParameter)):
                 raise InvalidFormulaError(
-                    f"parameter '{param}' of formula {self.function_name.value} is an invalid type"
+                    f"parameter '{param}' of formula {self.function_name} is an invalid type"
                 )
         self.__validate_consistency()
 

--- a/snuba_sdk/formula.py
+++ b/snuba_sdk/formula.py
@@ -36,7 +36,7 @@ PREFIX_TO_INFIX: dict[ArithmeticOperator, str] = {
 
 @dataclass(frozen=True)
 class Formula:
-    operator: ArithmeticOperator
+    function_name: str
     parameters: Optional[Sequence[FormulaParameterGroup]] = None
     filters: Optional[ConditionGroup] = None
     groupby: Optional[list[Column | AliasedExpression]] = None
@@ -74,21 +74,19 @@ class Formula:
         return entities.pop(), list(groupbys[0])
 
     def validate(self) -> None:
-        if not isinstance(self.operator, ArithmeticOperator):
-            raise InvalidFormulaError(
-                f"formula '{self.operator}' must be a ArithmeticOperator"
-            )
+        if not isinstance(self.function_name, str):
+            raise InvalidFormulaError(f"formula '{self.function_name}' must be a str")
         if self.parameters is None:
             raise InvalidFormulaError("Formula must have parameters")
         elif not isinstance(self.parameters, Sequence):
             raise InvalidFormulaError(
-                f"parameters of formula {self.operator.value} must be a Sequence"
+                f"parameters of formula {self.function_name.value} must be a Sequence"
             )
 
         for param in self.parameters:
             if not isinstance(param, tuple(FormulaParameter)):
                 raise InvalidFormulaError(
-                    f"parameter '{param}' of formula {self.operator.value} is an invalid type"
+                    f"parameter '{param}' of formula {self.function_name.value} is an invalid type"
                 )
         self.__validate_consistency()
 

--- a/snuba_sdk/metrics_visitors.py
+++ b/snuba_sdk/metrics_visitors.py
@@ -402,7 +402,9 @@ class FormulaSnQLVisitor:
         self.expression_visitor = self.timeseries_visitor.expression_visitor
 
     def _visit_parameter(
-        self, side: Formula | Timeseries | int | float, filters: ConditionGroup | None
+        self,
+        side: Formula | Timeseries | int | float | str,
+        filters: ConditionGroup | None,
     ) -> Mapping[str, str]:
         if isinstance(side, (float, int)):
             return {"select": f"{side}"}

--- a/snuba_sdk/metrics_visitors.py
+++ b/snuba_sdk/metrics_visitors.py
@@ -234,11 +234,11 @@ class FormulaMQLPrinter:
         # TODO: Formulas currently only support simple math, however in the future they could support
         # arbitrary functions (e.g. failure_rate(sum(...), 50)). In that case, they could be represented
         # as prefix functions.
-        if formula.operator in PREFIX_TO_INFIX:
-            separator = f" {PREFIX_TO_INFIX[formula.operator]} "
+        if formula.function_name in PREFIX_TO_INFIX:
+            separator = f" {PREFIX_TO_INFIX[formula.function_name]} "
             mql_string = f"({separator.join(p['mql_string'] for p in parameters)})"
         else:
-            mql_string = f"{formula.operator.value}({', '.join(p['mql_string'] for p in parameters)})"
+            mql_string = f"{formula.function_name}({', '.join(p['mql_string'] for p in parameters)})"
 
         mql_string += f"{self._visit_filters(formula.filters)}"
         mql_string += f"{self._visit_groupby(formula.groupby)}"
@@ -462,9 +462,7 @@ class FormulaSnQLVisitor:
 
         # Collect select statements
         parameters = ", ".join(p["select"] for p in parameters)
-        ret[
-            "aggregate"
-        ] = f"{formula.operator.value}({parameters}) AS {AGGREGATE_ALIAS}"
+        ret["aggregate"] = f"{formula.function_name}({parameters}) AS {AGGREGATE_ALIAS}"
 
         return ret
 

--- a/snuba_sdk/mql/mql.py
+++ b/snuba_sdk/mql/mql.py
@@ -60,8 +60,8 @@ arbitrary_function = arbitrary_function_name (open_paren ( _ expression _ ) (_ c
 aggregate_list = param* (param_expression)
 param = param_expression _ comma _
 param_expression = number / quoted_string / unquoted_string
-aggregate_name = "avg" / "count" / "max" / "min" / "sum"
-curried_aggregate_name = "quantiles"
+aggregate_name = "avg" / "count" / "max" / "min" / "sum" / "last" / "uniq"
+curried_aggregate_name = "quantiles" / "histogram"
 arbitrary_function_name = ~r"[a-zA-Z0-9_]+"
 
 group_by = _ "by" _ (group_by_name / group_by_name_tuple)
@@ -99,16 +99,6 @@ TERM_OPERATORS: Mapping[str, str] = {
     "*": ArithmeticOperator.MULTIPLY.value,
     "/": ArithmeticOperator.DIVIDE.value,
 }
-
-AGGREGATION_FUNCTIONS: set[str] = {
-    "avg",
-    "count",
-    "max",
-    "min",
-    "sum",
-}
-
-CURRIED_AGGREGATION_FUNCTIONS: set[str] = {"quantiles"}
 
 
 def parse_mql(mql: str) -> MetricsQuery:

--- a/snuba_sdk/mql/mql.py
+++ b/snuba_sdk/mql/mql.py
@@ -90,12 +90,12 @@ _ = ~r"\s*"
 """
 )
 
-EXPRESSION_OPERATORS: Mapping[str, ArithmeticOperator] = {
+EXPRESSION_OPERATORS: Mapping[str, str] = {
     "+": ArithmeticOperator.PLUS.value,
     "-": ArithmeticOperator.MINUS.value,
 }
 
-TERM_OPERATORS: Mapping[str, ArithmeticOperator] = {
+TERM_OPERATORS: Mapping[str, str] = {
     "*": ArithmeticOperator.MULTIPLY.value,
     "/": ArithmeticOperator.DIVIDE.value,
 }

--- a/tests/test_formula.py
+++ b/tests/test_formula.py
@@ -16,13 +16,13 @@ tests = [
     # This might be possible in the future, but if the formula doesn't contain a metric
     # then it's not possible to infer the entity
     # pytest.param(
-    #     formula(ArithmeticOperator.PLUS, [1, 1], None, None),
+    #     formula(ArithmeticOperator.PLUS.value, [1, 1], None, None),
     #     None,
     #     id="basic formula test",
     # ),
     pytest.param(
         formula(
-            ArithmeticOperator.PLUS,
+            ArithmeticOperator.PLUS.value,
             [
                 Timeseries(
                     metric=Metric(public_name="foo", entity="metrics_sets"),
@@ -38,7 +38,7 @@ tests = [
     ),
     pytest.param(
         formula(
-            ArithmeticOperator.PLUS,
+            ArithmeticOperator.PLUS.value,
             [
                 Timeseries(
                     metric=Metric(public_name="foo", entity="metrics_sets"),
@@ -54,7 +54,7 @@ tests = [
     ),
     pytest.param(
         formula(
-            ArithmeticOperator.PLUS,
+            ArithmeticOperator.PLUS.value,
             [
                 Timeseries(
                     metric=Metric(public_name="foo", entity="metrics_sets"),
@@ -70,7 +70,7 @@ tests = [
     ),
     pytest.param(
         formula(
-            ArithmeticOperator.PLUS,
+            ArithmeticOperator.PLUS.value,
             [
                 Timeseries(
                     metric=Metric(public_name="foo", entity="metrics_sets"),
@@ -100,17 +100,17 @@ tests = [
             None,
             None,
         ),
-        InvalidFormulaError("formula '42' must be a ArithmeticOperator"),
+        InvalidFormulaError("formula '42' must be a str"),
         id="invalid operator type",
     ),
     pytest.param(
-        formula(ArithmeticOperator.PLUS, 42, None, None),
+        formula(ArithmeticOperator.PLUS.value, 42, None, None),
         InvalidFormulaError("parameters of formula plus must be a Sequence"),
         id="invalid parameters",
     ),
     pytest.param(
         formula(
-            ArithmeticOperator.MULTIPLY,
+            ArithmeticOperator.MULTIPLY.value,
             [
                 Timeseries(
                     metric=Metric(public_name="foo", entity="metrics_sets"),
@@ -126,7 +126,7 @@ tests = [
     ),
     pytest.param(
         formula(
-            ArithmeticOperator.PLUS,
+            ArithmeticOperator.PLUS.value,
             [
                 Timeseries(
                     metric=Metric(
@@ -159,7 +159,7 @@ tests = [
     ),
     pytest.param(
         formula(
-            ArithmeticOperator.PLUS,
+            ArithmeticOperator.PLUS.value,
             [
                 Timeseries(
                     metric=Metric(
@@ -192,7 +192,7 @@ tests = [
     ),
     pytest.param(
         formula(
-            ArithmeticOperator.PLUS,
+            ArithmeticOperator.PLUS.value,
             [100, 100],
             [Condition(Column("tags[status_code]"), Op.EQ, 200)],
             [Column("tags[release]")],
@@ -220,7 +220,7 @@ def test_formulas(
 formula_snql_tests = [
     pytest.param(
         formula(
-            ArithmeticOperator.MULTIPLY,
+            ArithmeticOperator.MULTIPLY.value,
             [
                 Timeseries(
                     metric=Metric(
@@ -247,7 +247,7 @@ formula_snql_tests = [
     ),
     pytest.param(
         formula(
-            ArithmeticOperator.PLUS,
+            ArithmeticOperator.PLUS.value,
             [
                 Timeseries(
                     metric=Metric(
@@ -283,7 +283,7 @@ formula_snql_tests = [
     ),
     pytest.param(
         formula(
-            ArithmeticOperator.PLUS,
+            ArithmeticOperator.PLUS.value,
             [
                 Timeseries(
                     metric=Metric(
@@ -319,7 +319,7 @@ formula_snql_tests = [
     ),
     pytest.param(
         formula(
-            ArithmeticOperator.PLUS,
+            ArithmeticOperator.PLUS.value,
             [
                 Timeseries(
                     metric=Metric(

--- a/tests/test_formula_printer.py
+++ b/tests/test_formula_printer.py
@@ -12,7 +12,7 @@ from snuba_sdk.timeseries import Metric, Timeseries
 formula_tests = [
     pytest.param(
         Formula(
-            ArithmeticOperator.DIVIDE,
+            ArithmeticOperator.DIVIDE.value,
             [
                 Timeseries(
                     metric=Metric(
@@ -28,7 +28,7 @@ formula_tests = [
     ),
     pytest.param(
         Formula(
-            ArithmeticOperator.MULTIPLY,
+            ArithmeticOperator.MULTIPLY.value,
             [
                 Timeseries(
                     metric=Metric(
@@ -48,10 +48,10 @@ formula_tests = [
     ),
     pytest.param(
         Formula(
-            ArithmeticOperator.DIVIDE,
+            ArithmeticOperator.DIVIDE.value,
             [
                 Formula(
-                    ArithmeticOperator.MULTIPLY,
+                    ArithmeticOperator.MULTIPLY.value,
                     [
                         Timeseries(
                             metric=Metric(
@@ -76,7 +76,7 @@ formula_tests = [
     ),
     pytest.param(
         Formula(
-            ArithmeticOperator.DIVIDE,
+            ArithmeticOperator.DIVIDE.value,
             [
                 Timeseries(
                     metric=Metric(
@@ -97,7 +97,7 @@ formula_tests = [
     ),
     pytest.param(
         Formula(
-            ArithmeticOperator.DIVIDE,
+            ArithmeticOperator.DIVIDE.value,
             [
                 Timeseries(
                     metric=Metric(
@@ -119,7 +119,7 @@ formula_tests = [
     ),
     pytest.param(
         Formula(
-            ArithmeticOperator.DIVIDE,
+            ArithmeticOperator.DIVIDE.value,
             [
                 Timeseries(
                     metric=Metric(
@@ -141,7 +141,7 @@ formula_tests = [
     ),
     pytest.param(
         Formula(
-            ArithmeticOperator.DIVIDE,
+            ArithmeticOperator.DIVIDE.value,
             [
                 Timeseries(
                     metric=Metric(
@@ -163,7 +163,7 @@ formula_tests = [
     ),
     pytest.param(
         Formula(
-            ArithmeticOperator.DIVIDE,
+            ArithmeticOperator.DIVIDE.value,
             [
                 Timeseries(
                     metric=Metric(
@@ -186,7 +186,7 @@ formula_tests = [
     ),
     pytest.param(
         Formula(
-            ArithmeticOperator.DIVIDE,
+            ArithmeticOperator.DIVIDE.value,
             [
                 Timeseries(
                     metric=Metric(
@@ -210,7 +210,7 @@ formula_tests = [
     ),
     pytest.param(
         Formula(
-            ArithmeticOperator.DIVIDE,
+            ArithmeticOperator.DIVIDE.value,
             [
                 Timeseries(
                     metric=Metric(
@@ -234,7 +234,7 @@ formula_tests = [
     ),
     pytest.param(
         Formula(
-            ArithmeticOperator.DIVIDE,
+            ArithmeticOperator.DIVIDE.value,
             [
                 Timeseries(
                     metric=Metric(
@@ -256,10 +256,10 @@ formula_tests = [
     ),
     pytest.param(
         Formula(
-            operator=ArithmeticOperator.MULTIPLY,
+            function_name=ArithmeticOperator.MULTIPLY.value,
             parameters=[
                 Formula(
-                    ArithmeticOperator.DIVIDE,
+                    ArithmeticOperator.DIVIDE.value,
                     [
                         Timeseries(
                             metric=Metric(
@@ -295,10 +295,10 @@ formula_tests = [
     ),
     pytest.param(
         Formula(
-            operator=ArithmeticOperator.MULTIPLY,
+            function_name=ArithmeticOperator.MULTIPLY.value,
             parameters=[
                 Formula(
-                    ArithmeticOperator.DIVIDE,
+                    ArithmeticOperator.DIVIDE.value,
                     [
                         Timeseries(
                             metric=Metric(

--- a/tests/test_formula_printer.py
+++ b/tests/test_formula_printer.py
@@ -433,6 +433,26 @@ formula_tests = [
         '(apdex(sum(foo), 500) * apdex(sum(foo), 400)){tag:"tag_value"} by (transaction)',
         id="test arbitrary functions",
     ),
+    pytest.param(
+        Formula(
+            "apdex",
+            [
+                Timeseries(
+                    metric=Metric(
+                        public_name="foo",
+                        entity="generic_metrics_distributions",
+                    ),
+                    aggregate="quantiles",
+                    aggregate_params=[0.5],
+                ),
+                500,
+            ],
+            filters=[Condition(Column("tag"), Op.EQ, "tag_value")],
+            groupby=[Column("transaction")],
+        ),
+        'apdex(quantiles(0.5)(foo), 500){tag:"tag_value"} by (transaction)',
+        id="test arbitrary functions",
+    ),
 ]
 
 FORMULA_PRINTER = FormulaMQLPrinter()

--- a/tests/test_metrics_mql_query.py
+++ b/tests/test_metrics_mql_query.py
@@ -438,7 +438,7 @@ metrics_query_to_mql_tests = [
     pytest.param(
         MetricsQuery(
             query=Formula(
-                ArithmeticOperator.DIVIDE,
+                ArithmeticOperator.DIVIDE.value,
                 [
                     Timeseries(
                         metric=Metric(

--- a/tests/test_mql.py
+++ b/tests/test_mql.py
@@ -928,6 +928,26 @@ arbitrary_function_tests = [
         id="test arbitrary function with filters and groupby",
     ),
     pytest.param(
+        'topK(sum(transaction.duration), 500, "test", 4.2){tag:"tag_value"} by transaction',
+        MetricsQuery(
+            query=Formula(
+                function_name="topK",
+                parameters=[
+                    Timeseries(
+                        metric=Metric(public_name="transaction.duration"),
+                        aggregate="sum",
+                    ),
+                    500,
+                    "test",
+                    4.2,
+                ],
+                filters=[Condition(Column("tag"), Op.EQ, "tag_value")],
+                groupby=[Column("transaction")],
+            ),
+        ),
+        id="test arbitrary function with filters and groupby",
+    ),
+    pytest.param(
         'apdex(sum(foo) / sum(bar), 500){tag:"tag_value"} by transaction',
         MetricsQuery(
             query=Formula(

--- a/tests/test_mql.py
+++ b/tests/test_mql.py
@@ -928,7 +928,7 @@ arbitrary_function_tests = [
         id="test arbitrary function with filters and groupby",
     ),
     pytest.param(
-        'topK(sum(transaction.duration), 500, "test", 4.2){tag:"tag_value"} by transaction',
+        'topK(sum(transaction.duration), 500, test, 4.2){tag:"tag_value"} by transaction',
         MetricsQuery(
             query=Formula(
                 function_name="topK",

--- a/tests/test_mql.py
+++ b/tests/test_mql.py
@@ -928,6 +928,23 @@ arbitrary_function_tests = [
         id="test arbitrary function with filters and groupby",
     ),
     pytest.param(
+        "apdex(quantiles(0.5)(transaction.duration), 500)",
+        MetricsQuery(
+            query=Formula(
+                "apdex",
+                [
+                    Timeseries(
+                        metric=Metric(public_name="transaction.duration"),
+                        aggregate="quantiles",
+                        aggregate_params=[0.5],
+                    ),
+                    500,
+                ],
+            )
+        ),
+        id="test arbitrary function with curried aggregate",
+    ),
+    pytest.param(
         'topK(sum(transaction.duration), 500, test, 4.2){tag:"tag_value"} by transaction',
         MetricsQuery(
             query=Formula(


### PR DESCRIPTION
### Overview
This PR is responsible for supporting arbitrary functions names and parameters in MQL grammar. Since these functions are what the UI will interact with, they need to be encoded and parsed out of the MQL.
For example: `apdex(sum(transaction.duration), 500)` becomes

```
Formula(
    function_name="apdex",
    parameters=[
        Timeseries(metric=Metric("transaction.duration")),
        500
    ]
)
```

To accomplish this, `Formula.operator: ArithmeticOperator` was changed to `Formula.function_name: str` in order to extend the `Formula` class to handle arbitrary functions. This change also supports serializing back into MQL

### Testing
Unit tests for parsing MQL to MetricsQuery and MetricsQuery to MQL were added for arbitrary functions.