### PR TITLE
fix(mql) Quotes were not being properly escaped in MQL strings

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,13 @@
 Changelog and versioning
 ==========================
 
+
+2.0.19
+------
+
+- Fix escaping quotes in MQL strings
+
+
 2.0.18
 ------
 

--- a/snuba_sdk/mql/mql.py
+++ b/snuba_sdk/mql/mql.py
@@ -295,7 +295,11 @@ class MQLVisitor(NodeVisitor):  # type: ignore
         return str(node.text)
 
     def visit_quoted_string(self, node: Node, children: Sequence[Any]) -> str:
-        return str(node.text[1:-1])
+        # The quoted string might have escaped double quotes in it. Replace
+        # these with regular quotes.
+        text = str(node.text[1:-1])
+        match = text.replace('\\"', '"')
+        return match
 
     def visit_string_tuple(self, node: Node, children: Sequence[Any]) -> Sequence[str]:
         _, _, first, zero_or_more_others, _, _ = children

--- a/snuba_sdk/visitors.py
+++ b/snuba_sdk/visitors.py
@@ -146,11 +146,13 @@ class Translation(ExpressionVisitor[str]):
             # The ' and \ character are escaped in the string to ensure
             # the query is valid. They are de-escaped in the SnQL parser.
             # Also escape newlines since they break the SnQL grammar.
+            quote_char = '"' if self.is_mql else "'"
             decoded = (
-                decoded.replace("\\", "\\\\").replace("'", "\\'").replace("\n", "\\n")
+                decoded.replace("\\", "\\\\")
+                .replace(quote_char, f"\\{quote_char}")
+                .replace("\n", "\\n")
             )
 
-            quote_char = '"' if self.is_mql else "'"
             return f"{quote_char}{decoded}{quote_char}"
         elif isinstance(value, (int, float)):
             return f"{value}"

--- a/tests/test_metrics_mql_query.py
+++ b/tests/test_metrics_mql_query.py
@@ -483,6 +483,58 @@ metrics_query_to_mql_tests = [
         },
         id="test_terms",
     ),
+    pytest.param(
+        MetricsQuery(
+            query=Timeseries(
+                metric=Metric(
+                    mri="d:transactions/duration@millisecond",
+                    entity="generic_metrics_distributions",
+                ),
+                aggregate="max",
+                aggregate_params=None,
+                filters=[
+                    Condition(
+                        Column("bar"),
+                        Op.EQ,
+                        " !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~",
+                    )
+                ],
+                groupby=[Column("transaction")],
+            ),
+            start=NOW,
+            end=NOW + timedelta(days=14),
+            rollup=Rollup(interval=3600, totals=None, granularity=3600),
+            scope=MetricsScope(
+                org_ids=[1], project_ids=[11], use_case_id="transactions"
+            ),
+            limit=Limit(100),
+            offset=Offset(5),
+            indexer_mappings={},
+        ),
+        {
+            "mql": 'max(d:transactions/duration@millisecond){bar:" !\\"#$%&\'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\\\]^_`abcdefghijklmnopqrstuvwxyz{|}~"} by (transaction)',
+            "mql_context": {
+                "entity": "generic_metrics_distributions",
+                "start": "2023-01-02T03:04:05+00:00",
+                "end": "2023-01-16T03:04:05+00:00",
+                "rollup": {
+                    "orderby": None,
+                    "granularity": 3600,
+                    "interval": 3600,
+                    "with_totals": None,
+                },
+                "scope": {
+                    "org_ids": [1],
+                    "project_ids": [11],
+                    "use_case_id": "transactions",
+                },
+                "limit": 100,
+                "offset": 5,
+                "indexer_mappings": {},
+            },
+        },
+        id="test_crazy_characters",
+    ),
 ]
 
 

--- a/tests/test_mql.py
+++ b/tests/test_mql.py
@@ -630,6 +630,24 @@ base_tests = [
         ),
         id="test quotes parsing",
     ),
+    pytest.param(
+        'max(d:transactions/duration@millisecond){bar:" !\\"#$%&\'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\\\]^_`abcdefghijklmnopqrstuvwxyz{|}~"} by (transaction)',
+        MetricsQuery(
+            query=Timeseries(
+                metric=Metric(mri="d:transactions/duration@millisecond"),
+                aggregate="max",
+                filters=[
+                    Condition(
+                        Column("bar"),
+                        Op.EQ,
+                        " !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\\\]^_`abcdefghijklmnopqrstuvwxyz{|}~",
+                    ),
+                ],
+                groupby=[Column("transaction")],
+            )
+        ),
+        id="test terms with crazy characters",
+    ),
 ]
 
 


### PR DESCRIPTION
The double quote character needs to be escaped when a string is encoded in MQL,
and needs to be decoded when a string is parsed in MQL.
