### PR TITLE
bug(MQL): Allow any name for aggregate or curried aggregate in MQL

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,7 @@
 Changelog and versioning
 ==========================
 
-2.0.19
+2.0.20
 ------
 
 - Allow arbitrary name for aggregate or curried aggreate in MQL

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,11 @@
 Changelog and versioning
 ==========================
 
+2.0.19
+------
+
+- Allow arbitrary name for aggregate or curried aggreate in MQL
+
 
 2.0.19
 ------

--- a/snuba_sdk/mql/mql.py
+++ b/snuba_sdk/mql/mql.py
@@ -54,14 +54,14 @@ variable = "$" ~r"[a-zA-Z0-9_.]+"
 nested_expression = open_paren _ expression _ close_paren
 
 function = (aggregate / curried_aggregate / arbitrary_function) (group_by)?
-aggregate = aggregate_name (open_paren _ expression (_ comma _ expression)* _ close_paren)
-curried_aggregate = curried_aggregate_name (open_paren _ aggregate_list? _ close_paren) (open_paren _ expression (_ comma _ expression)* _ close_paren)
-arbitrary_function = arbitrary_function_name (open_paren ( _ expression _ ) (_ comma _ param_expression)* close_paren)
+aggregate = aggregate_name (open_paren _ filter _ close_paren)
+curried_aggregate = curried_aggregate_name (open_paren _ aggregate_list? _ close_paren) (open_paren _ filter _ close_paren)
+arbitrary_function = arbitrary_function_name (open_paren ( _ filter _ ) (_ comma _ param_expression)* close_paren)
 aggregate_list = param* (param_expression)
 param = param_expression _ comma _
 param_expression = number / quoted_string / unquoted_string
-aggregate_name = "avg" / "count" / "max" / "min" / "sum" / "last" / "uniq"
-curried_aggregate_name = "quantiles" / "histogram"
+aggregate_name = ~r"[a-zA-Z0-9_]+"
+curried_aggregate_name = ~r"[a-zA-Z0-9_]+"
 arbitrary_function_name = ~r"[a-zA-Z0-9_]+"
 
 group_by = _ "by" _ (group_by_name / group_by_name_tuple)

--- a/tests/test_mql.py
+++ b/tests/test_mql.py
@@ -550,6 +550,16 @@ base_tests = [
         id="test group by 4",
     ),
     pytest.param(
+        "p90(`d:transactions/duration@millisecond`)",
+        MetricsQuery(
+            query=Timeseries(
+                metric=Metric(mri="d:transactions/duration@millisecond"),
+                aggregate="p90",
+            )
+        ),
+        id="test percentile function",
+    ),
+    pytest.param(
         "quantiles(0.5)(`d:transactions/duration@millisecond`)",
         MetricsQuery(
             query=Timeseries(
@@ -963,33 +973,6 @@ arbitrary_function_tests = [
             ),
         ),
         id="test arbitrary function with filters and groupby",
-    ),
-    pytest.param(
-        'apdex(sum(foo) / sum(bar), 500){tag:"tag_value"} by transaction',
-        MetricsQuery(
-            query=Formula(
-                function_name="apdex",
-                parameters=[
-                    Formula(
-                        function_name=ArithmeticOperator.DIVIDE.value,
-                        parameters=[
-                            Timeseries(
-                                metric=Metric(public_name="foo"),
-                                aggregate="sum",
-                            ),
-                            Timeseries(
-                                metric=Metric(public_name="bar"),
-                                aggregate="sum",
-                            ),
-                        ],
-                    ),
-                    500,
-                ],
-                filters=[Condition(Column("tag"), Op.EQ, "tag_value")],
-                groupby=[Column("transaction")],
-            )
-        ),
-        id="test arbitrary function with inner terms",
     ),
 ]
 


### PR DESCRIPTION
### Overview
This PR is responsible for allowing arbitrary names for aggregate and curried_aggregate functions. Although sentry metrics layer resolves aliased aggregates (`p90`, `p75`, `count_uniq`) into valid functions, the MQL translations happens before the resolution. Therefore, we need to allow any name.