### PR TITLE
ref(mql): Use `Formula` for aliased aggregates and arbitrary functions

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,13 @@ Changelog and versioning
 2.0.20
 ------
 
+- Support curried arbitrary functions in MQL
+- Use tighter rules around aggregates, curried_aggregates, arbitrary_functions, and curried_arbitrary_functions in MQL
+
+
+2.0.20
+------
+
 - Allow arbitrary name for aggregate or curried aggreate in MQL
 - Fix bug in how the groupby in Formulas was being compared to their parameters
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,7 +2,7 @@ Changelog and versioning
 ==========================
 
 
-2.0.20
+2.0.21
 ------
 
 - Support curried arbitrary functions in MQL

--- a/snuba_sdk/formula.py
+++ b/snuba_sdk/formula.py
@@ -58,7 +58,8 @@ class Formula:
             if isinstance(param, Formula):
                 entity, found_gpby = param.__validate_consistency()
                 entities.add(entity)
-                groupbys.append(tuple(found_gpby))
+                if found_gpby:
+                    groupbys.append(tuple(found_gpby))
             elif isinstance(param, Timeseries):
                 if param.metric.entity is not None:
                     entities.add(param.metric.entity)
@@ -71,7 +72,6 @@ class Formula:
             raise InvalidFormulaError(
                 "Formula parameters must group by the same columns"
             )
-
         return entities.pop(), list(groupbys[0])
 
     def validate(self) -> None:

--- a/snuba_sdk/formula.py
+++ b/snuba_sdk/formula.py
@@ -7,7 +7,7 @@ from typing import Any, Optional, Sequence, Union
 from snuba_sdk.aliased_expression import AliasedExpression
 from snuba_sdk.column import Column
 from snuba_sdk.conditions import BooleanCondition, Condition, ConditionGroup
-from snuba_sdk.expressions import InvalidExpressionError, is_literal, list_type
+from snuba_sdk.expressions import InvalidExpressionError, list_type
 from snuba_sdk.timeseries import Timeseries
 
 

--- a/snuba_sdk/formula.py
+++ b/snuba_sdk/formula.py
@@ -89,15 +89,6 @@ class Formula:
                 raise InvalidFormulaError(
                     f"parameter '{param}' of formula {self.function_name} is an invalid type"
                 )
-        # TODO: Restrict which specific aggregates are allowed
-        if self.aggregate_params is not None:
-            if not isinstance(self.aggregate_params, list):
-                raise InvalidFormulaError("aggregate_params must be a list")
-            for p in self.aggregate_params:
-                if not is_literal(p):
-                    raise InvalidFormulaError(
-                        "aggregate_params can only be literal types"
-                    )
         self.__validate_consistency()
 
     def _replace(self, field: str, value: Any) -> Formula:

--- a/snuba_sdk/metrics_visitors.py
+++ b/snuba_sdk/metrics_visitors.py
@@ -219,6 +219,11 @@ class FormulaMQLPrinter:
 
         return {"mql_string": str(parameter)}
 
+    def _visit_aggregate_params(self, aggregate_params: list[Any] | None) -> str:
+        if aggregate_params:
+            return "(" + ", ".join(str(param) for param in aggregate_params) + ")"
+        return ""
+
     def _visit_filters(self, filters: ConditionGroup | None) -> str:
         return _visit_mql_filters(filters, self.expression_visitor)
 
@@ -238,7 +243,7 @@ class FormulaMQLPrinter:
             separator = f" {PREFIX_TO_INFIX[formula.function_name]} "
             mql_string = f"({separator.join(p['mql_string'] for p in parameters)})"
         else:
-            mql_string = f"{formula.function_name}({', '.join(p['mql_string'] for p in parameters)})"
+            mql_string = f"{formula.function_name}{self._visit_aggregate_params(formula.aggregate_params)}({', '.join(p['mql_string'] for p in parameters)})"
 
         mql_string += f"{self._visit_filters(formula.filters)}"
         mql_string += f"{self._visit_groupby(formula.groupby)}"

--- a/snuba_sdk/mql/mql.py
+++ b/snuba_sdk/mql/mql.py
@@ -383,7 +383,7 @@ class MQLVisitor(NodeVisitor):  # type: ignore
 
     def visit_curried_arbitrary_function(
         self, node: Node, children: Sequence[Any]
-    ) -> Formula:
+    ) -> Union[Timeseries, Formula]:
         """
         Returns a Fomula with the arbitrary curried function name and parameters.
         topK(10)(sum(mri)) -> Formula(topK, (Timeseries(sum), 10))

--- a/snuba_sdk/mql/mql.py
+++ b/snuba_sdk/mql/mql.py
@@ -134,9 +134,7 @@ class MQLVisitor(NodeVisitor):  # type: ignore
         except Exception as e:
             raise e
 
-    def visit_expression(
-        self, node: Node, children: Sequence[Any]
-    ) -> Union[Formula, Timeseries]:
+    def visit_expression(self, node: Node, children: Sequence[Any]) -> Any:
         """
         Top level node, simply returns the expression.
         """
@@ -148,7 +146,7 @@ class MQLVisitor(NodeVisitor):  # type: ignore
 
     def visit_term(
         self, node: Node, children: Sequence[Any]
-    ) -> Union[Formula, Timeseries, float, int]:
+    ) -> Union[Formula, Timeseries, float, int, str]:
         """
         Checks if the current node contains two term children, if so
         then merge them into a single Formula with the operator.
@@ -337,7 +335,9 @@ class MQLVisitor(NodeVisitor):  # type: ignore
         assert isinstance(children[2], (Timeseries, Formula))
         return children[2]
 
-    def visit_aggregate(self, node: Node, children: Sequence[Any]) -> Timeseries:
+    def visit_aggregate(
+        self, node: Node, children: Sequence[Any]
+    ) -> Union[Timeseries, Formula]:
         """
         Given a target (which is either a Formula or Timeseries object),
         set the aggregate on it.

--- a/snuba_sdk/mql/mql.py
+++ b/snuba_sdk/mql/mql.py
@@ -53,11 +53,13 @@ target = variable / nested_expression / function / metric
 variable = "$" ~r"[a-zA-Z0-9_.]+"
 nested_expression = open_paren _ expression _ close_paren
 
-function = (curried_arbitrary_function / aggregate / arbitrary_function) (group_by)?
+function = (curried_aggregate / curried_arbitrary_function / aggregate / arbitrary_function) (group_by)?
 aggregate = aggregate_name (open_paren _ inner_filter _ close_paren)
 aggregate_name = ~r"[a-zA-Z0-9_]+"
 arbitrary_function = arbitrary_function_name (open_paren ( _ expression _ ) (_ comma _ expression)* close_paren)
 arbitrary_function_name = ~r"[a-zA-Z0-9_]+"
+curried_aggregate = curried_aggregate_name (open_paren _ aggregate_list? _ close_paren) (open_paren _ inner_filter _ close_paren)
+curried_aggregate_name = ~r"[a-zA-Z0-9_]+"
 curried_arbitrary_function = curried_arbitrary_function_name (open_paren _ aggregate_list? _ close_paren) (open_paren _ ( _ expression _ ) _ close_paren)
 curried_arbitrary_function_name = ~r"[a-zA-Z0-9_]+"
 
@@ -355,6 +357,20 @@ class MQLVisitor(NodeVisitor):  # type: ignore
             # e.g. `sum(count(mri))` -> Formula(sum, (Timeseries(count),)
             return Formula(function_name=aggregate_name, parameters=[target])
 
+    def visit_curried_aggregate(
+        self, node: Node, children: Sequence[Any]
+    ) -> Timeseries:
+        """
+        Given a target (which is either a Formula or Timeseries object),
+        set the aggregate and aggregate params on it.
+        """
+        aggregate_name, agg_params, zero_or_one = children
+        _, _, target, _, *_ = zero_or_one
+        _, _, agg_param_list, *_ = agg_params
+        aggregate_params = agg_param_list[0] if agg_param_list else []
+        assert isinstance(target, Timeseries)
+        return target.set_aggregate(aggregate_name, aggregate_params)
+
     def visit_arbitrary_function(self, node: Node, children: Sequence[Any]) -> Formula:
         """
         Returns a Fomula with the arbitrary function name and parameters.
@@ -447,6 +463,9 @@ class MQLVisitor(NodeVisitor):  # type: ignore
         return agg_params
 
     def visit_aggregate_name(self, node: Node, children: Sequence[Any]) -> str:
+        return node.text
+
+    def visit_curried_aggregate_name(self, node: Node, children: Sequence[Any]) -> str:
         return node.text
 
     def visit_arbitrary_function_name(self, node: Node, children: Sequence[Any]) -> str:

--- a/snuba_sdk/timeseries.py
+++ b/snuba_sdk/timeseries.py
@@ -84,7 +84,7 @@ class Timeseries:
     """
 
     metric: Metric
-    aggregate: str | None = None
+    aggregate: str
     aggregate_params: list[Any] | None = None
     filters: ConditionGroup | None = None
     groupby: list[Column | AliasedExpression] | None = None
@@ -103,17 +103,16 @@ class Timeseries:
 
         # TODO: Restrict which specific aggregates are allowed
         # TODO: Validate aggregate_params based on the aggregate supplied e.g. quantile needs a float
-        if self.aggregate is not None:
-            if not isinstance(self.aggregate, str):
-                raise InvalidTimeseriesError("aggregate must be a string")
-            if self.aggregate_params is not None:
-                if not isinstance(self.aggregate_params, list):
-                    raise InvalidTimeseriesError("aggregate_params must be a list")
-                for p in self.aggregate_params:
-                    if not is_literal(p):
-                        raise InvalidTimeseriesError(
-                            "aggregate_params can only be literal types"
-                        )
+        if not isinstance(self.aggregate, str):
+            raise InvalidTimeseriesError("aggregate must be a string")
+        if self.aggregate_params is not None:
+            if not isinstance(self.aggregate_params, list):
+                raise InvalidTimeseriesError("aggregate_params must be a list")
+            for p in self.aggregate_params:
+                if not is_literal(p):
+                    raise InvalidTimeseriesError(
+                        "aggregate_params can only be literal types"
+                    )
 
         # TODO: Validate these are tag conditions only
         # TODO: Validate these are simple conditions e.g. tag[x] op literal

--- a/snuba_sdk/timeseries.py
+++ b/snuba_sdk/timeseries.py
@@ -84,7 +84,7 @@ class Timeseries:
     """
 
     metric: Metric
-    aggregate: str
+    aggregate: str | None = None
     aggregate_params: list[Any] | None = None
     filters: ConditionGroup | None = None
     groupby: list[Column | AliasedExpression] | None = None
@@ -103,16 +103,17 @@ class Timeseries:
 
         # TODO: Restrict which specific aggregates are allowed
         # TODO: Validate aggregate_params based on the aggregate supplied e.g. quantile needs a float
-        if not isinstance(self.aggregate, str):
-            raise InvalidTimeseriesError("aggregate must be a string")
-        if self.aggregate_params is not None:
-            if not isinstance(self.aggregate_params, list):
-                raise InvalidTimeseriesError("aggregate_params must be a list")
-            for p in self.aggregate_params:
-                if not is_literal(p):
-                    raise InvalidTimeseriesError(
-                        "aggregate_params can only be literal types"
-                    )
+        if self.aggregate is not None:
+            if not isinstance(self.aggregate, str):
+                raise InvalidTimeseriesError("aggregate must be a string")
+            if self.aggregate_params is not None:
+                if not isinstance(self.aggregate_params, list):
+                    raise InvalidTimeseriesError("aggregate_params must be a list")
+                for p in self.aggregate_params:
+                    if not is_literal(p):
+                        raise InvalidTimeseriesError(
+                            "aggregate_params can only be literal types"
+                        )
 
         # TODO: Validate these are tag conditions only
         # TODO: Validate these are simple conditions e.g. tag[x] op literal

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -95,7 +95,12 @@ def formula(
     groupby: Any = None,
 ) -> Callable[[], Any]:
     def to_formula() -> Formula:
-        return Formula(operator, parameters, filters, groupby)
+        return Formula(
+            function_name=operator,
+            parameters=parameters,
+            filters=filters,
+            groupby=groupby,
+        )
 
     return to_formula
 

--- a/tests/test_mql.py
+++ b/tests/test_mql.py
@@ -1018,7 +1018,7 @@ arbitrary_function_tests = [
                 ],
             )
         ),
-        id="test arbitrary function with in arbitrary function",
+        id="test arbitrary function within arbitrary function",
     ),
     pytest.param(
         'topK(sum(transaction.duration), 500, 4.2){tag:"tag_value"} by transaction',
@@ -1274,7 +1274,7 @@ curried_arbitrary_function_tests = [
                 ],
             ),
         ),
-        id="test curried arbitrary function with arbitrary function",
+        id="test curried arbitrary function with inner arbitrary function",
     ),
 ]
 

--- a/tests/test_mql.py
+++ b/tests/test_mql.py
@@ -973,6 +973,21 @@ arbitrary_function_tests = [
         id="test arbitrary function with filters and groupby",
     ),
     pytest.param(
+        "cool_function(transaction.duration)",
+        MetricsQuery(
+            query=Formula(
+                "cool_function",
+                [
+                    Timeseries(
+                        metric=Metric(public_name="transaction.duration"),
+                        aggregate=None,
+                    ),
+                ],
+            )
+        ),
+        id="test arbitrary function with no aggregate",
+    ),
+    pytest.param(
         "apdex(quantiles(0.5)(transaction.duration), 500)",
         MetricsQuery(
             query=Formula(
@@ -1091,6 +1106,168 @@ arbitrary_function_tests = [
 
 @pytest.mark.parametrize("mql_string, metrics_query", arbitrary_function_tests)
 def test_parse_mql_arbitrary_functions(
+    mql_string: str, metrics_query: MetricsQuery
+) -> None:
+    result = parse_mql(mql_string)
+    assert result == metrics_query
+
+
+curried_arbitrary_function_tests = [
+    pytest.param(
+        "topK(10)(transaction.duration)",
+        MetricsQuery(
+            query=Timeseries(
+                metric=Metric(public_name="transaction.duration"),
+                aggregate="topK",
+                aggregate_params=[10],
+            )
+        ),
+        id="test simple curried arbitrary function",
+    ),
+    pytest.param(
+        "topK(10)(transaction.duration{bar:baz})",
+        MetricsQuery(
+            query=Timeseries(
+                metric=Metric(public_name="transaction.duration"),
+                aggregate="topK",
+                aggregate_params=[10],
+                filters=[Condition(Column("bar"), Op.EQ, "baz")],
+            )
+        ),
+        id="test curried arbitrary function with filter",
+    ),
+    pytest.param(
+        "topK(10)(transaction.duration{bar:baz} by transaction)",
+        MetricsQuery(
+            query=Timeseries(
+                metric=Metric(public_name="transaction.duration"),
+                aggregate="topK",
+                aggregate_params=[10],
+                filters=[Condition(Column("bar"), Op.EQ, "baz")],
+                groupby=[Column("transaction")],
+            )
+        ),
+        id="test curried arbitrary function with filter and groupby",
+    ),
+    pytest.param(
+        "topK(10)(transaction.duration)",
+        MetricsQuery(
+            query=Timeseries(
+                metric=Metric(public_name="transaction.duration"),
+                aggregate="topK",
+                aggregate_params=[10],
+            )
+        ),
+        id="test curried arbitrary function with args",
+    ),
+    pytest.param(
+        'topK(10)("test.duration")',
+        MetricsQuery(
+            query=Formula(
+                function_name="topK",
+                aggregate_params=[10],
+                parameters=["test.duration"],
+            )
+        ),
+        id="test curried arbitrary function with string param",
+    ),
+    pytest.param(
+        "topK(10)(sum(transaction.duration))",
+        MetricsQuery(
+            query=Formula(
+                function_name="topK",
+                aggregate_params=[10],
+                parameters=[
+                    Timeseries(
+                        metric=Metric(public_name="transaction.duration"),
+                        aggregate="sum",
+                    ),
+                ],
+            )
+        ),
+        id="test curried arbitrary function with inner aggregate",
+    ),
+    pytest.param(
+        "topK(10)(sum(transaction.duration) / count(transaction.duration))",
+        MetricsQuery(
+            query=Formula(
+                function_name="topK",
+                aggregate_params=[10],
+                parameters=[
+                    Formula(
+                        function_name="divide",
+                        parameters=[
+                            Timeseries(
+                                metric=Metric(public_name="transaction.duration"),
+                                aggregate="sum",
+                            ),
+                            Timeseries(
+                                metric=Metric(public_name="transaction.duration"),
+                                aggregate="count",
+                            ),
+                        ],
+                    ),
+                ],
+            )
+        ),
+        id="test curried arbitrary function with inner aggregate and terms",
+    ),
+    pytest.param(
+        "topK(10)(sum(transaction.duration{bar:baz}) / count(transaction.duration{foo:foz})) by transaction",
+        MetricsQuery(
+            query=Formula(
+                function_name="topK",
+                aggregate_params=[10],
+                parameters=[
+                    Formula(
+                        function_name="divide",
+                        parameters=[
+                            Timeseries(
+                                metric=Metric(public_name="transaction.duration"),
+                                aggregate="sum",
+                                filters=[Condition(Column("bar"), Op.EQ, "baz")],
+                            ),
+                            Timeseries(
+                                metric=Metric(public_name="transaction.duration"),
+                                aggregate="count",
+                                filters=[Condition(Column("foo"), Op.EQ, "foz")],
+                            ),
+                        ],
+                    ),
+                ],
+                groupby=[Column("transaction")],
+            ),
+        ),
+        id="test complex curried arbitrary function with inner terms",
+    ),
+    pytest.param(
+        "topK(10)(apdex(sum(transaction.duration), 500){bar:baz})",
+        MetricsQuery(
+            query=Formula(
+                function_name="topK",
+                aggregate_params=[10],
+                parameters=[
+                    Formula(
+                        function_name="apdex",
+                        parameters=[
+                            Timeseries(
+                                metric=Metric(public_name="transaction.duration"),
+                                aggregate="sum",
+                            ),
+                            500,
+                        ],
+                        filters=[Condition(Column("bar"), Op.EQ, "baz")],
+                    ),
+                ],
+            ),
+        ),
+        id="test curried arbitrary function with arbitrary function",
+    ),
+]
+
+
+@pytest.mark.parametrize("mql_string, metrics_query", curried_arbitrary_function_tests)
+def test_parse_mql_curried_arbitrary_functions(
     mql_string: str, metrics_query: MetricsQuery
 ) -> None:
     result = parse_mql(mql_string)

--- a/tests/test_mql.py
+++ b/tests/test_mql.py
@@ -927,30 +927,42 @@ def test_parse_mql_terms(mql_string: str, metrics_query: MetricsQuery) -> None:
 
 arbitrary_function_tests = [
     pytest.param(
-        "apdex(transaction.duration, 500)",
+        'cool_function("test", 500)',
         MetricsQuery(
             query=Formula(
-                "apdex",
+                "cool_function",
                 [
-                    Timeseries(
-                        metric=Metric(public_name="transaction.duration"),
-                        aggregate=None,
-                    ),
+                    "test",
                     500,
                 ],
             )
         ),
-        id="test simple arbitrary function",
+        id="test arbitrary function with string parameter",
     ),
     pytest.param(
-        'apdex(transaction.duration, 500){tag:"tag_value"} by transaction',
+        "sum(count(transaction.duration))",
+        MetricsQuery(
+            query=Formula(
+                "sum",
+                [
+                    Timeseries(
+                        metric=Metric(public_name="transaction.duration"),
+                        aggregate="count",
+                    ),
+                ],
+            )
+        ),
+        id="test arbitrary function with inner aggregate",
+    ),
+    pytest.param(
+        'apdex(sum(transaction.duration), 500){tag:"tag_value"} by transaction',
         MetricsQuery(
             query=Formula(
                 function_name="apdex",
                 parameters=[
                     Timeseries(
                         metric=Metric(public_name="transaction.duration"),
-                        aggregate=None,
+                        aggregate="sum",
                     ),
                     500,
                 ],
@@ -978,7 +990,7 @@ arbitrary_function_tests = [
         id="test arbitrary function with curried aggregate",
     ),
     pytest.param(
-        "apdex(failure_rate(transaction.duration), 500)",
+        "apdex(failure_rate(sum(transaction.duration)), 500)",
         MetricsQuery(
             query=Formula(
                 "apdex",
@@ -988,7 +1000,7 @@ arbitrary_function_tests = [
                         parameters=[
                             Timeseries(
                                 metric=Metric(public_name="transaction.duration"),
-                                aggregate=None,
+                                aggregate="sum",
                             )
                         ],
                     ),

--- a/tests/test_mql.py
+++ b/tests/test_mql.py
@@ -552,14 +552,9 @@ base_tests = [
     pytest.param(
         "p90(`d:transactions/duration@millisecond`)",
         MetricsQuery(
-            query=Formula(
-                function_name="p90",
-                parameters=[
-                    Timeseries(
-                        aggregate=None,
-                        metric=Metric(mri="d:transactions/duration@millisecond"),
-                    )
-                ],
+            query=Timeseries(
+                metric=Metric(mri="d:transactions/duration@millisecond"),
+                aggregate="p90",
             )
         ),
         id="test percentile function",
@@ -927,10 +922,25 @@ def test_parse_mql_terms(mql_string: str, metrics_query: MetricsQuery) -> None:
 
 arbitrary_function_tests = [
     pytest.param(
-        'cool_function("test", 500)',
+        "simple_function(sum(transaction.duration))",
         MetricsQuery(
             query=Formula(
-                "cool_function",
+                "simple_function",
+                [
+                    Timeseries(
+                        metric=Metric(public_name="transaction.duration"),
+                        aggregate="sum",
+                    ),
+                ],
+            )
+        ),
+        id="test simple arbitrary function",
+    ),
+    pytest.param(
+        'another_function("test", 500)',
+        MetricsQuery(
+            query=Formula(
+                "another_function",
                 [
                     "test",
                     500,
@@ -971,21 +981,6 @@ arbitrary_function_tests = [
             ),
         ),
         id="test arbitrary function with filters and groupby",
-    ),
-    pytest.param(
-        "cool_function(transaction.duration)",
-        MetricsQuery(
-            query=Formula(
-                "cool_function",
-                [
-                    Timeseries(
-                        metric=Metric(public_name="transaction.duration"),
-                        aggregate=None,
-                    ),
-                ],
-            )
-        ),
-        id="test arbitrary function with no aggregate",
     ),
     pytest.param(
         "apdex(quantiles(0.5)(transaction.duration), 500)",
@@ -1072,7 +1067,7 @@ arbitrary_function_tests = [
         id="test arbitrary function with inner terms",
     ),
     pytest.param(
-        "apdex(transaction.duration, 500) * failure_rate(transaction.duration)",
+        "apdex(sum(transaction.duration), 500) * failure_rate(sum(transaction.duration))",
         MetricsQuery(
             query=Formula(
                 function_name="multiply",
@@ -1082,7 +1077,7 @@ arbitrary_function_tests = [
                         parameters=[
                             Timeseries(
                                 metric=Metric(public_name="transaction.duration"),
-                                aggregate=None,
+                                aggregate="sum",
                             ),
                             500,
                         ],
@@ -1092,7 +1087,7 @@ arbitrary_function_tests = [
                         parameters=[
                             Timeseries(
                                 metric=Metric(public_name="transaction.duration"),
-                                aggregate=None,
+                                aggregate="sum",
                             )
                         ],
                     ),

--- a/tests/test_mql.py
+++ b/tests/test_mql.py
@@ -1236,6 +1236,24 @@ curried_arbitrary_function_tests = [
         id="test complex curried arbitrary function with inner terms",
     ),
     pytest.param(
+        "topK(10)(topK(5)(transaction.duration){bar:baz})",
+        MetricsQuery(
+            query=Formula(
+                function_name="topK",
+                aggregate_params=[10],
+                parameters=[
+                    Timeseries(
+                        metric=Metric(public_name="transaction.duration"),
+                        aggregate="topK",
+                        aggregate_params=[5],
+                        filters=[Condition(Column("bar"), Op.EQ, "baz")],
+                    ),
+                ],
+            ),
+        ),
+        id="test nested curried arbitrary function",
+    ),
+    pytest.param(
         "topK(10)(apdex(sum(transaction.duration), 500){bar:baz})",
         MetricsQuery(
             query=Formula(


### PR DESCRIPTION
### Overview
This PR is responsible the following changes:
* Make aggregates require a metric as a parameter
* Allow string params by using `""`
* Uses `Formula` to capture any function that **is not** an aggregate function (arbitrary functions).
* Adding curried arbitrary function support (e.g. `topK(10)(transaction.duration)`).

### Changes in sentry
Need to update the alias resolver in sentry metrics layer code to support this.

### Testing
See added test cases for what is now supported.