### PR TITLE
feat(ddm): Add support for numbers in mri

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog and versioning
 2.0.25
 ------
 - Add support for `or` and `and` lowercase boolean operators in the MQL grammar.
+- Align MRI representation with backend, by allowing numbers in the metric name.
 
 2.0.24
 ------

--- a/snuba_sdk/mql/mql.py
+++ b/snuba_sdk/mql/mql.py
@@ -18,10 +18,12 @@ from snuba_sdk.query_visitors import InvalidQueryError
 from snuba_sdk.timeseries import Metric, Timeseries
 
 AGGREGATE_PLACEHOLDER_NAME = "AGGREGATE_PLACEHOLDER"
+
 METRIC_TYPE_REGEX = r"(c|s|d|g|e)"
-NAMESPACE_REGEX = r"[a-zA-Z0-9_]+"
-MRI_NAME_REGEX = r"([a-z_]+(?:\.[a-z_]+)*)"
-UNIT_REGEX = r"([\w.]*)"
+METRIC_NAMESPACE_REGEX = r"[a-zA-Z0-9_]+"
+METRIC_NAME_REGEX = r"([a-z0-9_]+(?:\.[a-z0-9_]+)*)"
+METRIC_UNIT_REGEX = r"([\w.]*)"
+
 MQL_GRAMMAR = Grammar(
     rf"""
 expression = term (_ expr_op _ term)*
@@ -74,7 +76,7 @@ group_by_name_tuple = open_paren _ group_by_name (_ comma _ group_by_name)* _ cl
 inner_filter = metric open_brace? (_ filter_expr _)? close_brace? (group_by)?
 metric = quoted_mri / unquoted_mri / quoted_public_name / unquoted_public_name
 quoted_mri = backtick unquoted_mri backtick
-unquoted_mri = ~r"{METRIC_TYPE_REGEX}:{NAMESPACE_REGEX}/{MRI_NAME_REGEX}@{UNIT_REGEX}"
+unquoted_mri = ~r"{METRIC_TYPE_REGEX}:{METRIC_NAMESPACE_REGEX}/{METRIC_NAME_REGEX}@{METRIC_UNIT_REGEX}"
 quoted_public_name = backtick unquoted_public_name backtick
 unquoted_public_name = ~r"([a-z_]+(?:\.[a-z_]+)*)"
 

--- a/tests/test_mql.py
+++ b/tests/test_mql.py
@@ -614,10 +614,10 @@ base_tests = [
         id="test curried functions with random params",
     ),
     pytest.param(
-        "quantiles(0.5)(`d:transactions/duration@millisecond`{})",
+        "quantiles(0.5)(`d:transactions/duration.1@millisecond`{})",
         MetricsQuery(
             query=Timeseries(
-                metric=Metric(mri="d:transactions/duration@millisecond"),
+                metric=Metric(mri="d:transactions/duration.1@millisecond"),
                 aggregate="quantiles",
                 aggregate_params=[0.5],
             )
@@ -625,10 +625,10 @@ base_tests = [
         id="test curried functions with empty filter",
     ),
     pytest.param(
-        'quantiles(0.5)(`d:transactions/duration@millisecond`{foo:"foz"}){bar:baz} by (a, b)',
+        'quantiles(0.5)(`d:transactions/duration_2@millisecond`{foo:"foz"}){bar:baz} by (a, b)',
         MetricsQuery(
             query=Timeseries(
-                metric=Metric(mri="d:transactions/duration@millisecond"),
+                metric=Metric(mri="d:transactions/duration_2@millisecond"),
                 aggregate="quantiles",
                 aggregate_params=[0.5],
                 filters=[


### PR DESCRIPTION
This PR adds the support of numbers in the metric names in the MRI for the MQL grammar.