### PR TITLE
feat(metrics): Allow uppercase metric names

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ Changelog and versioning
 ------
 - Add support for `or` and `and` lowercase boolean operators in the MQL grammar.
 - Align MRI representation with backend, by allowing numbers in the metric name.
+- Add support for uppercase metric names.
 
 2.0.24
 ------

--- a/snuba_sdk/mql/mql.py
+++ b/snuba_sdk/mql/mql.py
@@ -21,7 +21,7 @@ AGGREGATE_PLACEHOLDER_NAME = "AGGREGATE_PLACEHOLDER"
 
 METRIC_TYPE_REGEX = r"(c|s|d|g|e)"
 METRIC_NAMESPACE_REGEX = r"[a-zA-Z0-9_]+"
-METRIC_NAME_REGEX = r"([a-z0-9_]+(?:\.[a-z0-9_]+)*)"
+METRIC_NAME_REGEX = r"([a-zA-Z0-9_]+(?:\.[a-zA-Z0-9_]+)*)"
 METRIC_UNIT_REGEX = r"([\w.]*)"
 
 MQL_GRAMMAR = Grammar(

--- a/tests/test_mql.py
+++ b/tests/test_mql.py
@@ -11,20 +11,20 @@ from snuba_sdk.timeseries import Metric, Timeseries
 
 base_tests = [
     pytest.param(
-        "sum(`d:transactions/duration@millisecond`)",
+        "sum(`d:transactions/Duration.Metric@millisecond`)",
         MetricsQuery(
             query=Timeseries(
-                metric=Metric(mri="d:transactions/duration@millisecond"),
+                metric=Metric(mri="d:transactions/Duration.Metric@millisecond"),
                 aggregate="sum",
             )
         ),
         id="test quoted mri name",
     ),
     pytest.param(
-        "sum(d:transactions/duration@millisecond)",
+        "sum(d:transactions/Duration@millisecond)",
         MetricsQuery(
             query=Timeseries(
-                metric=Metric(mri="d:transactions/duration@millisecond"),
+                metric=Metric(mri="d:transactions/Duration@millisecond"),
                 aggregate="sum",
             )
         ),


### PR DESCRIPTION
This PR adds support of uppercase metric names in the snuba-sdk MQL grammar.

This change is linked to: https://github.com/getsentry/sentry/pull/64250