### PR TITLE
feat(mql): Support multiple entities in MQL Context

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,11 +1,16 @@
 Changelog and versioning
 ==========================
 
+2.0.26
+------
+- Support multiple entities in MQL Context
+
 2.0.25
 ------
 - Add support for `or` and `and` lowercase boolean operators in the MQL grammar.
 - Align MRI representation with backend, by allowing numbers in the metric name.
 - Add support for uppercase metric names.
+
 
 2.0.24
 ------

--- a/snuba_sdk/mql_context.py
+++ b/snuba_sdk/mql_context.py
@@ -22,7 +22,9 @@ class MQLContext:
     should be created exclusively from a valid MetricsQuery object.
     """
 
-    entity: str
+    entity: dict[
+        str, str
+    ]  # mapping between metric name (mri or public_name) and entity
     start: str
     end: str
     rollup: dict[str, str | int | None]

--- a/snuba_sdk/mql_visitor.py
+++ b/snuba_sdk/mql_visitor.py
@@ -104,7 +104,9 @@ class MQLPrinter(MQLVisitor):
             "mql_context": asdict(mql_context),
         }
 
-    def _visit_query(self, query: Timeseries | Formula | None) -> Mapping[str, str]:
+    def _visit_query(
+        self, query: Timeseries | Formula | None
+    ) -> Mapping[str, str | Mapping[str, str]]:
         if query is None:
             raise InvalidMetricsQueryError("MetricQuery.query must not be None")
         elif isinstance(query, Formula):

--- a/tests/test_formula.py
+++ b/tests/test_formula.py
@@ -257,7 +257,7 @@ formula_mql_tests = [
             None,
         ),
         {
-            "entity": "metrics_sets",
+            "entity": {"d:transactions/duration@millisecond": "metrics_sets"},
             "mql_string": '(sum(d:transactions/duration@millisecond){tags[referrer]:"foo"} * 100)',
         },
         None,
@@ -292,7 +292,7 @@ formula_mql_tests = [
             None,
         ),
         {
-            "entity": "metrics_sets",
+            "entity": {"d:transactions/duration@millisecond": "metrics_sets"},
             "mql_string": '(sum(d:transactions/duration@millisecond){tags[referrer]:"foo"} + sum(d:transactions/duration@millisecond){tags[referrer]:"bar"})',
         },
         None,
@@ -327,7 +327,7 @@ formula_mql_tests = [
             None,
         ),
         {
-            "entity": "metrics_sets",
+            "entity": {"d:transactions/duration@millisecond": "metrics_sets"},
             "mql_string": '(sum(d:transactions/duration@millisecond){tags[referrer]:"foo"} + sum(d:transactions/duration@millisecond){tags[referrer]:"bar"}){tags[status_code]:200}',
         },
         None,
@@ -364,7 +364,7 @@ formula_mql_tests = [
             [Column("tags[release]")],
         ),
         {
-            "entity": "metrics_sets",
+            "entity": {"d:transactions/duration@millisecond": "metrics_sets"},
             "mql_string": '(sum(d:transactions/duration@millisecond){tags[referrer]:"foo"} by (tags[status_code]) + sum(d:transactions/duration@millisecond){tags[referrer]:"bar"} by (tags[status_code])){tags[status_code]:200} by (tags[release])',
         },
         None,

--- a/tests/test_formula_printer.py
+++ b/tests/test_formula_printer.py
@@ -461,12 +461,14 @@ FORMULA_PRINTER = FormulaMQLPrinter()
 @pytest.mark.parametrize("formula, mql", formula_tests)
 def test_metrics_query_to_mql_formula(formula: Formula, mql: str) -> None:
     output = FORMULA_PRINTER.visit(formula)
-    assert output["mql_string"] == mql
+    mql_string = output["mql_string"]
+    assert isinstance(mql_string, str)
+    assert mql_string == mql
 
     # TODO: We can't simply assert the whole query, because we need an Entity in order to serialize the formula,
     # but when we parse the MQL the entity is None. Once SnQL support is removed, we can change this.
     # assert parse_mql(output["mql_string"]).query == formula
-    parsed = parse_mql(output["mql_string"])
+    parsed = parse_mql(mql_string)
     assert parsed.query is not None
     assert parsed.query.groupby == formula.groupby
     assert parsed.query.filters == formula.filters

--- a/tests/test_metrics_mql_query.py
+++ b/tests/test_metrics_mql_query.py
@@ -43,7 +43,9 @@ metrics_query_timeseries_to_mql_tests = [
         {
             "mql": "max(d:transactions/duration@millisecond)",
             "mql_context": {
-                "entity": "generic_metrics_distributions",
+                "entity": {
+                    "d:transactions/duration@millisecond": "generic_metrics_distributions"
+                },
                 "start": "2023-01-02T03:04:05+00:00",
                 "end": "2023-01-16T03:04:05+00:00",
                 "rollup": {
@@ -87,7 +89,9 @@ metrics_query_timeseries_to_mql_tests = [
         {
             "mql": "quantiles(0.5)(d:transactions/duration@millisecond)",
             "mql_context": {
-                "entity": "generic_metrics_distributions",
+                "entity": {
+                    "d:transactions/duration@millisecond": "generic_metrics_distributions"
+                },
                 "start": "2023-01-02T03:04:05+00:00",
                 "end": "2023-01-16T03:04:05+00:00",
                 "rollup": {
@@ -131,7 +135,9 @@ metrics_query_timeseries_to_mql_tests = [
         {
             "mql": "topK(10)(d:transactions/duration@millisecond)",
             "mql_context": {
-                "entity": "generic_metrics_distributions",
+                "entity": {
+                    "d:transactions/duration@millisecond": "generic_metrics_distributions"
+                },
                 "start": "2023-01-02T03:04:05+00:00",
                 "end": "2023-01-16T03:04:05+00:00",
                 "rollup": {
@@ -175,7 +181,7 @@ metrics_query_timeseries_to_mql_tests = [
         {
             "mql": "max(transactions.duration)",
             "mql_context": {
-                "entity": "generic_metrics_distributions",
+                "entity": {"transactions.duration": "generic_metrics_distributions"},
                 "start": "2023-01-02T03:04:05+00:00",
                 "end": "2023-01-16T03:04:05+00:00",
                 "rollup": {
@@ -219,7 +225,9 @@ metrics_query_timeseries_to_mql_tests = [
         {
             "mql": 'max(d:transactions/duration@millisecond){bar:"baz"}',
             "mql_context": {
-                "entity": "generic_metrics_distributions",
+                "entity": {
+                    "d:transactions/duration@millisecond": "generic_metrics_distributions"
+                },
                 "start": "2023-01-02T03:04:05+00:00",
                 "end": "2023-01-16T03:04:05+00:00",
                 "rollup": {
@@ -263,7 +271,9 @@ metrics_query_timeseries_to_mql_tests = [
         {
             "mql": 'max(d:transactions/duration@millisecond){bar:["baz", "bap"]}',
             "mql_context": {
-                "entity": "generic_metrics_distributions",
+                "entity": {
+                    "d:transactions/duration@millisecond": "generic_metrics_distributions"
+                },
                 "start": "2023-01-02T03:04:05+00:00",
                 "end": "2023-01-16T03:04:05+00:00",
                 "rollup": {
@@ -324,7 +334,9 @@ metrics_query_timeseries_to_mql_tests = [
         {
             "mql": 'max(d:transactions/duration@millisecond){bar:"baz" AND foo:"foz" AND (foo:"foz" OR hee:"hez" OR (foo:"foz" AND hee:"hez"))}',
             "mql_context": {
-                "entity": "generic_metrics_distributions",
+                "entity": {
+                    "d:transactions/duration@millisecond": "generic_metrics_distributions"
+                },
                 "start": "2023-01-02T03:04:05+00:00",
                 "end": "2023-01-16T03:04:05+00:00",
                 "rollup": {
@@ -368,7 +380,9 @@ metrics_query_timeseries_to_mql_tests = [
         {
             "mql": "max(d:transactions/duration@millisecond) by (transaction)",
             "mql_context": {
-                "entity": "generic_metrics_distributions",
+                "entity": {
+                    "d:transactions/duration@millisecond": "generic_metrics_distributions"
+                },
                 "start": "2023-01-02T03:04:05+00:00",
                 "end": "2023-01-16T03:04:05+00:00",
                 "rollup": {
@@ -412,7 +426,9 @@ metrics_query_timeseries_to_mql_tests = [
         {
             "mql": "max(d:transactions/duration@millisecond) by (a, b)",
             "mql_context": {
-                "entity": "generic_metrics_distributions",
+                "entity": {
+                    "d:transactions/duration@millisecond": "generic_metrics_distributions"
+                },
                 "start": "2023-01-02T03:04:05+00:00",
                 "end": "2023-01-16T03:04:05+00:00",
                 "rollup": {
@@ -458,7 +474,9 @@ metrics_query_timeseries_to_mql_tests = [
         {
             "mql": 'max(d:transactions/duration@millisecond){bar:"baz"} by (transaction)',
             "mql_context": {
-                "entity": "generic_metrics_distributions",
+                "entity": {
+                    "d:transactions/duration@millisecond": "generic_metrics_distributions"
+                },
                 "start": "2023-01-02T03:04:05+00:00",
                 "end": "2023-01-16T03:04:05+00:00",
                 "rollup": {
@@ -510,7 +528,9 @@ metrics_query_timeseries_to_mql_tests = [
         {
             "mql": 'max(d:transactions/duration@millisecond){bar:" !\\"#$%&\'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\\\]^_`abcdefghijklmnopqrstuvwxyz{|}~"} by (transaction)',
             "mql_context": {
-                "entity": "generic_metrics_distributions",
+                "entity": {
+                    "d:transactions/duration@millisecond": "generic_metrics_distributions"
+                },
                 "start": "2023-01-02T03:04:05+00:00",
                 "end": "2023-01-16T03:04:05+00:00",
                 "rollup": {
@@ -601,7 +621,7 @@ metrics_query_formula_to_mql_tests = [
         {
             "mql": "(sum(foo) / 1000)",
             "mql_context": {
-                "entity": "generic_metrics_distributions",
+                "entity": {"foo": "generic_metrics_distributions"},
                 "start": "2023-01-02T03:04:05+00:00",
                 "end": "2023-01-16T03:04:05+00:00",
                 "rollup": {
@@ -649,7 +669,7 @@ metrics_query_formula_to_mql_tests = [
         {
             "mql": "apdex(sum(foo), 1000)",
             "mql_context": {
-                "entity": "generic_metrics_distributions",
+                "entity": {"foo": "generic_metrics_distributions"},
                 "start": "2023-01-02T03:04:05+00:00",
                 "end": "2023-01-16T03:04:05+00:00",
                 "rollup": {
@@ -698,7 +718,7 @@ metrics_query_formula_to_mql_tests = [
         {
             "mql": "apdex(quantiles(0.5)(foo), 1000)",
             "mql_context": {
-                "entity": "generic_metrics_distributions",
+                "entity": {"foo": "generic_metrics_distributions"},
                 "start": "2023-01-02T03:04:05+00:00",
                 "end": "2023-01-16T03:04:05+00:00",
                 "rollup": {
@@ -752,7 +772,7 @@ metrics_query_formula_to_mql_tests = [
         {
             "mql": "apdex(failure_rate(sum(foo)), 1000)",
             "mql_context": {
-                "entity": "generic_metrics_distributions",
+                "entity": {"foo": "generic_metrics_distributions"},
                 "start": "2023-01-02T03:04:05+00:00",
                 "end": "2023-01-16T03:04:05+00:00",
                 "rollup": {
@@ -815,7 +835,10 @@ metrics_query_formula_to_mql_tests = [
         {
             "mql": 'apdex((sum(foo) / sum(bar)), 500){tag:"tag_value"} by (transaction)',
             "mql_context": {
-                "entity": "generic_metrics_distributions",
+                "entity": {
+                    "foo": "generic_metrics_distributions",
+                    "bar": "generic_metrics_distributions",
+                },
                 "start": "2023-01-02T03:04:05+00:00",
                 "end": "2023-01-16T03:04:05+00:00",
                 "rollup": {
@@ -876,7 +899,7 @@ metrics_query_formula_to_mql_tests = [
         {
             "mql": "topK(10)((sum(transaction.duration) / count(transaction.duration)))",
             "mql_context": {
-                "entity": "generic_metrics_distributions",
+                "entity": {"transaction.duration": "generic_metrics_distributions"},
                 "start": "2023-01-02T03:04:05+00:00",
                 "end": "2023-01-16T03:04:05+00:00",
                 "rollup": {
@@ -932,7 +955,7 @@ metrics_query_formula_to_mql_tests = [
         {
             "mql": 'topK(10)(apdex(sum(transaction.duration), 500){bar:"baz"})',
             "mql_context": {
-                "entity": "generic_metrics_distributions",
+                "entity": {"transaction.duration": "generic_metrics_distributions"},
                 "start": "2023-01-02T03:04:05+00:00",
                 "end": "2023-01-16T03:04:05+00:00",
                 "rollup": {

--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -77,7 +77,9 @@ tests = [
             "mql_context": {
                 "start": "2021-01-02T03:04:05.000006+00:00",
                 "end": "2021-01-16T03:04:05.000006+00:00",
-                "entity": "generic_metrics_distributions",
+                "entity": {
+                    "d:transactions/duration@millisecond": "generic_metrics_distributions"
+                },
                 "indexer_mappings": {},
                 "limit": None,
                 "offset": None,

--- a/tests/test_timeseries.py
+++ b/tests/test_timeseries.py
@@ -19,7 +19,9 @@ metric_tests = [
         123,
         "generic_metrics_distributions",
         {
-            "entity": "generic_metrics_distributions",
+            "entity": {
+                "d:transactions/duration@millisecond": "generic_metrics_distributions"
+            },
             "metric_name": "d:transactions/duration@millisecond",
         },
         None,
@@ -38,7 +40,7 @@ metric_tests = [
         123,
         "generic_metrics_distributions",
         {
-            "entity": "generic_metrics_distributions",
+            "entity": {"transaction.duration": "generic_metrics_distributions"},
             "metric_name": "transaction.duration",
         },
         None,
@@ -49,7 +51,9 @@ metric_tests = [
         123,
         "generic_metrics_distributions",
         {
-            "entity": "generic_metrics_distributions",
+            "entity": {
+                "d:transactions/duration@millisecond": "generic_metrics_distributions"
+            },
             "metric_name": "d:transactions/duration@millisecond",
         },
         None,
@@ -151,7 +155,7 @@ timeseries_tests = [
         timeseries(
             Metric("duration", entity="metrics_sets"), "count", None, None, None
         ),
-        {"entity": "metrics_sets", "mql_string": "count(duration)"},
+        {"entity": {"duration": "metrics_sets"}, "mql_string": "count(duration)"},
         None,
         id="simple test",
     ),
@@ -159,7 +163,10 @@ timeseries_tests = [
         timeseries(
             Metric("duration", entity="metrics_sets"), "quantile", [0.95], None, None
         ),
-        {"entity": "metrics_sets", "mql_string": "quantile(0.95)(duration)"},
+        {
+            "entity": {"duration": "metrics_sets"},
+            "mql_string": "quantile(0.95)(duration)",
+        },
         None,
         id="aggregate params",
     ),
@@ -172,7 +179,7 @@ timeseries_tests = [
             None,
         ),
         {
-            "entity": "metrics_sets",
+            "entity": {"duration": "metrics_sets"},
             "mql_string": 'quantile(0.95)(duration){tags[release]:"1.2.3"}',
         },
         None,
@@ -190,7 +197,7 @@ timeseries_tests = [
             None,
         ),
         {
-            "entity": "metrics_sets",
+            "entity": {"duration": "metrics_sets"},
             "mql_string": 'quantile(0.95)(duration){tags[release]:"1.2.3" AND tags[highway]:"401"}',
         },
         None,
@@ -212,7 +219,7 @@ timeseries_tests = [
             None,
         ),
         {
-            "entity": "metrics_sets",
+            "entity": {"duration": "metrics_sets"},
             "mql_string": 'quantile(0.95)(duration){(tags[release]:"1.2.3" OR tags[highway]:"401")}',
         },
         None,
@@ -230,7 +237,7 @@ timeseries_tests = [
             [Column("tags[transaction]")],
         ),
         {
-            "entity": "metrics_sets",
+            "entity": {"duration": "metrics_sets"},
             "mql_string": 'quantile(0.95)(duration){tags[release]:"1.2.3" AND tags[highway]:"401"} by (tags[transaction])',
         },
         None,
@@ -248,7 +255,7 @@ timeseries_tests = [
             [Column("tags[transaction]"), Column("tags[device]")],
         ),
         {
-            "entity": "metrics_sets",
+            "entity": {"duration": "metrics_sets"},
             "mql_string": 'quantile(0.95)(duration){tags[release]:"1.2.3" AND tags[highway]:"401"} by (tags[transaction], tags[device])',
         },
         None,
@@ -269,7 +276,7 @@ timeseries_tests = [
             ],
         ),
         {
-            "entity": "metrics_sets",
+            "entity": {"duration": "metrics_sets"},
             "mql_string": 'quantile(0.95)(duration){tags[release]:"1.2.3" AND tags[highway]:"401"} by (tags[transaction] AS `transaction`, tags[device] AS `device`)',
         },
         None,


### PR DESCRIPTION
### Overview
This PR is responsible for supporting multiple entities in the MQL Context. In order to support multi-type formula queries, the snuba API needs to be able to receive multiple entities to determine which table(s) to query. To accomplish this, store a mapping of the metric_names (mri or public_name) and entities in the context.   