### PR TITLE
feat: Support MQL strings in MetricsQuery

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog and versioning
 2.0.26
 ------
 - Support multiple entities in MQL Context
+- Support MQL strings as a query
 
 2.0.25
 ------

--- a/snuba_sdk/metrics_query.py
+++ b/snuba_sdk/metrics_query.py
@@ -27,7 +27,7 @@ class MetricsQuery(BaseQuery):
     a simpler syntax for writing timeseries queries, which have fewer available features.
     """
 
-    query: Timeseries | Formula | None = None
+    query: Timeseries | Formula | str | None = None
     start: datetime | None = None
     end: datetime | None = None
     rollup: Rollup | None = None
@@ -40,9 +40,11 @@ class MetricsQuery(BaseQuery):
         new = replace(self, **{field: value})
         return new
 
-    def set_query(self, query: Formula | Timeseries) -> MetricsQuery:
-        if not isinstance(query, (Formula, Timeseries)):
-            raise InvalidQueryError("query must be a Formula or Timeseries")
+    def set_query(self, query: Formula | Timeseries | str) -> MetricsQuery:
+        if not isinstance(query, (Formula, Timeseries, str)):
+            raise InvalidQueryError(
+                "query must be a Formula or Timeseries or MQL string"
+            )
         return self._replace("query", query)
 
     def set_start(self, start: datetime) -> MetricsQuery:

--- a/snuba_sdk/metrics_visitors.py
+++ b/snuba_sdk/metrics_visitors.py
@@ -217,9 +217,7 @@ class MetricVisitor(ABC, Generic[TVisited]):
 class MetricMQLPrinter(
     MetricVisitor[Mapping[str, Union[str, Mapping[str, Union[str, None]]]]]
 ):
-    def visit(
-        self, metric: Metric
-    ) -> Mapping[str, str | Mapping[str, Union[str, None]]]:
+    def visit(self, metric: Metric) -> dict[str, str | dict[str, str | None]]:
         if metric.mri is None and metric.public_name is None:
             raise InvalidExpressionError(
                 "metric.mri or metric.public is required for serialization"

--- a/snuba_sdk/mql/mql.py
+++ b/snuba_sdk/mql/mql.py
@@ -13,9 +13,13 @@ from parsimonious.nodes import Node, NodeVisitor
 from snuba_sdk.column import Column
 from snuba_sdk.conditions import And, BooleanCondition, BooleanOp, Condition, Op, Or
 from snuba_sdk.formula import ArithmeticOperator, Formula
-from snuba_sdk.metrics_query import MetricsQuery
-from snuba_sdk.query_visitors import InvalidQueryError
 from snuba_sdk.timeseries import Metric, Timeseries
+
+
+# In order to avoid circular imports, we need to redefine the exception here.
+class InvalidQueryError(Exception):
+    pass
+
 
 AGGREGATE_PLACEHOLDER_NAME = "AGGREGATE_PLACEHOLDER"
 
@@ -107,7 +111,7 @@ TERM_OPERATORS: Mapping[str, str] = {
 }
 
 
-def parse_mql(mql: str) -> MetricsQuery:
+def parse_mql(mql: str) -> Timeseries | Formula:
     """
     Parse a MQL string into a MetricsQuery object.
     """
@@ -117,8 +121,7 @@ def parse_mql(mql: str) -> MetricsQuery:
         raise InvalidQueryError("Invalid metrics syntax") from e
     result = MQLVisitor().visit(tree)
     assert isinstance(result, (Timeseries, Formula))
-    metrics_query = MetricsQuery(query=result)
-    return metrics_query
+    return result
 
 
 class MQLVisitor(NodeVisitor):  # type: ignore

--- a/snuba_sdk/mql/mql.py
+++ b/snuba_sdk/mql/mql.py
@@ -113,7 +113,7 @@ TERM_OPERATORS: Mapping[str, str] = {
 
 def parse_mql(mql: str) -> Timeseries | Formula:
     """
-    Parse a MQL string into a MetricsQuery object.
+    Parse a MQL string into a Timeseries object.
     """
     try:
         tree = MQL_GRAMMAR.parse(mql.strip())

--- a/tests/test_formula_printer.py
+++ b/tests/test_formula_printer.py
@@ -469,6 +469,6 @@ def test_metrics_query_to_mql_formula(formula: Formula, mql: str) -> None:
     # but when we parse the MQL the entity is None. Once SnQL support is removed, we can change this.
     # assert parse_mql(output["mql_string"]).query == formula
     parsed = parse_mql(mql_string)
-    assert parsed.query is not None
-    assert parsed.query.groupby == formula.groupby
-    assert parsed.query.filters == formula.filters
+    assert parsed is not None
+    assert parsed.groupby == formula.groupby
+    assert parsed.filters == formula.filters

--- a/tests/test_metrics_mql_query.py
+++ b/tests/test_metrics_mql_query.py
@@ -551,6 +551,45 @@ metrics_query_timeseries_to_mql_tests = [
         },
         id="test_crazy_characters",
     ),
+    pytest.param(
+        MetricsQuery(
+            query="sum(transaction.duration){status_code:500} by transaction",
+            start=NOW,
+            end=NOW + timedelta(days=14),
+            rollup=Rollup(interval=3600, totals=None, granularity=3600),
+            scope=MetricsScope(
+                org_ids=[1], project_ids=[11], use_case_id="transactions"
+            ),
+            limit=Limit(100),
+            offset=Offset(5),
+            indexer_mappings={},
+        ),
+        {
+            "mql": 'sum(transaction.duration){status_code:"500"} by (transaction)',
+            "mql_context": {
+                "entity": {
+                    "transaction.duration": None,
+                },
+                "start": "2023-01-02T03:04:05+00:00",
+                "end": "2023-01-16T03:04:05+00:00",
+                "rollup": {
+                    "orderby": None,
+                    "granularity": 3600,
+                    "interval": 3600,
+                    "with_totals": None,
+                },
+                "scope": {
+                    "org_ids": [1],
+                    "project_ids": [11],
+                    "use_case_id": "transactions",
+                },
+                "limit": 100,
+                "offset": 5,
+                "indexer_mappings": {},
+            },
+        },
+        id="test_passing_string_directly",
+    ),
 ]
 
 

--- a/tests/test_mql.py
+++ b/tests/test_mql.py
@@ -5,677 +5,572 @@ import pytest
 from snuba_sdk.column import Column
 from snuba_sdk.conditions import And, Condition, Op, Or
 from snuba_sdk.formula import ArithmeticOperator, Formula
-from snuba_sdk.metrics_query import MetricsQuery
 from snuba_sdk.mql.mql import parse_mql
 from snuba_sdk.timeseries import Metric, Timeseries
 
 base_tests = [
     pytest.param(
         "sum(`d:transactions/Duration.Metric@millisecond`)",
-        MetricsQuery(
-            query=Timeseries(
-                metric=Metric(mri="d:transactions/Duration.Metric@millisecond"),
-                aggregate="sum",
-            )
+        Timeseries(
+            metric=Metric(mri="d:transactions/Duration.Metric@millisecond"),
+            aggregate="sum",
         ),
         id="test quoted mri name",
     ),
     pytest.param(
         "sum(d:transactions/Duration@millisecond)",
-        MetricsQuery(
-            query=Timeseries(
-                metric=Metric(mri="d:transactions/Duration@millisecond"),
-                aggregate="sum",
-            )
+        Timeseries(
+            metric=Metric(mri="d:transactions/Duration@millisecond"),
+            aggregate="sum",
         ),
         id="test unquoted mri name",
     ),
     pytest.param(
         "sum(`transactions.duration`)",
-        MetricsQuery(
-            query=Timeseries(
-                metric=Metric(public_name="transactions.duration"), aggregate="sum"
-            )
-        ),
+        Timeseries(metric=Metric(public_name="transactions.duration"), aggregate="sum"),
         id="test quoted public name 1",
     ),
     pytest.param(
         "sum(`foo`)",
-        MetricsQuery(
-            query=Timeseries(metric=Metric(public_name="foo"), aggregate="sum")
-        ),
+        Timeseries(metric=Metric(public_name="foo"), aggregate="sum"),
         id="test quoted public name 2",
     ),
     pytest.param(
         "sum(transactions.duration)",
-        MetricsQuery(
-            query=Timeseries(
-                metric=Metric(public_name="transactions.duration"), aggregate="sum"
-            )
-        ),
+        Timeseries(metric=Metric(public_name="transactions.duration"), aggregate="sum"),
         id="test unquoted public name 1",
     ),
     pytest.param(
         "sum(foo)",
-        MetricsQuery(
-            query=Timeseries(metric=Metric(public_name="foo"), aggregate="sum")
-        ),
+        Timeseries(metric=Metric(public_name="foo"), aggregate="sum"),
         id="test unquoted public name 1",
     ),
     pytest.param(
         "(sum(foo))",
-        MetricsQuery(
-            query=Timeseries(metric=Metric(public_name="foo"), aggregate="sum")
-        ),
+        Timeseries(metric=Metric(public_name="foo"), aggregate="sum"),
         id="test nested expressions 1",
     ),
     pytest.param(
         "(sum(foo))",
-        MetricsQuery(
-            query=Timeseries(metric=Metric(public_name="foo"), aggregate="sum")
-        ),
+        Timeseries(metric=Metric(public_name="foo"), aggregate="sum"),
         id="test nested expressions 2",
     ),
     pytest.param(
         'sum(foo){bar:"baz"}',
-        MetricsQuery(
-            query=Timeseries(
-                metric=Metric(public_name="foo"),
-                aggregate="sum",
-                filters=[Condition(Column("bar"), Op.EQ, "baz")],
-            )
+        Timeseries(
+            metric=Metric(public_name="foo"),
+            aggregate="sum",
+            filters=[Condition(Column("bar"), Op.EQ, "baz")],
         ),
         id="test filter",
     ),
     pytest.param(
         "sum(foo){}",
-        MetricsQuery(
-            query=Timeseries(
-                metric=Metric(public_name="foo"),
-                aggregate="sum",
-            )
+        Timeseries(
+            metric=Metric(public_name="foo"),
+            aggregate="sum",
         ),
         id="test empty filter",
     ),
     pytest.param(
         "sum(foo){bar:baz}",
-        MetricsQuery(
-            query=Timeseries(
-                metric=Metric(public_name="foo"),
-                aggregate="sum",
-                filters=[Condition(Column("bar"), Op.EQ, "baz")],
-            )
+        Timeseries(
+            metric=Metric(public_name="foo"),
+            aggregate="sum",
+            filters=[Condition(Column("bar"), Op.EQ, "baz")],
         ),
         id="test filter with unquoted value",
     ),
     pytest.param(
         'sum(foo){bar:"2023-01-03T10:00:00"}',
-        MetricsQuery(
-            query=Timeseries(
-                metric=Metric(public_name="foo"),
-                aggregate="sum",
-                filters=[Condition(Column("bar"), Op.EQ, "2023-01-03T10:00:00")],
-            )
+        Timeseries(
+            metric=Metric(public_name="foo"),
+            aggregate="sum",
+            filters=[Condition(Column("bar"), Op.EQ, "2023-01-03T10:00:00")],
         ),
         id="test filter with quoted value with special characters",
     ),
     pytest.param(
         "sum(foo){bar:2023-01-03T10:00:00}",
-        MetricsQuery(
-            query=Timeseries(
-                metric=Metric(public_name="foo"),
-                aggregate="sum",
-                filters=[Condition(Column("bar"), Op.EQ, "2023-01-03T10:00:00")],
-            )
+        Timeseries(
+            metric=Metric(public_name="foo"),
+            aggregate="sum",
+            filters=[Condition(Column("bar"), Op.EQ, "2023-01-03T10:00:00")],
         ),
         id="test filter with unquoted value with special characters",
     ),
     pytest.param(
         'sum(foo){!bar:"baz"}',
-        MetricsQuery(
-            query=Timeseries(
-                metric=Metric(public_name="foo"),
-                aggregate="sum",
-                filters=[Condition(Column("bar"), Op.NEQ, "baz")],
-            )
+        Timeseries(
+            metric=Metric(public_name="foo"),
+            aggregate="sum",
+            filters=[Condition(Column("bar"), Op.NEQ, "baz")],
         ),
         id="test not filter",
     ),
     pytest.param(
         "sum(foo){!bar:baz}",
-        MetricsQuery(
-            query=Timeseries(
-                metric=Metric(public_name="foo"),
-                aggregate="sum",
-                filters=[Condition(Column("bar"), Op.NEQ, "baz")],
-            )
+        Timeseries(
+            metric=Metric(public_name="foo"),
+            aggregate="sum",
+            filters=[Condition(Column("bar"), Op.NEQ, "baz")],
         ),
         id="test not filter with unquoted value",
     ),
     pytest.param(
         'sum(foo){bar:["baz", "bap"]}',
-        MetricsQuery(
-            query=Timeseries(
-                metric=Metric(public_name="foo"),
-                aggregate="sum",
-                filters=[Condition(Column("bar"), Op.IN, ["baz", "bap"])],
-            )
+        Timeseries(
+            metric=Metric(public_name="foo"),
+            aggregate="sum",
+            filters=[Condition(Column("bar"), Op.IN, ["baz", "bap"])],
         ),
         id="test in filter",
     ),
     pytest.param(
         'sum(foo){bar:["baz", bap]}',
-        MetricsQuery(
-            query=Timeseries(
-                metric=Metric(public_name="foo"),
-                aggregate="sum",
-                filters=[Condition(Column("bar"), Op.IN, ["baz", "bap"])],
-            )
+        Timeseries(
+            metric=Metric(public_name="foo"),
+            aggregate="sum",
+            filters=[Condition(Column("bar"), Op.IN, ["baz", "bap"])],
         ),
         id="test in filter with unquoted values",
     ),
     pytest.param(
         "sum(foo){bar:[baz, bap]}",
-        MetricsQuery(
-            query=Timeseries(
-                metric=Metric(public_name="foo"),
-                aggregate="sum",
-                filters=[Condition(Column("bar"), Op.IN, ["baz", "bap"])],
-            )
+        Timeseries(
+            metric=Metric(public_name="foo"),
+            aggregate="sum",
+            filters=[Condition(Column("bar"), Op.IN, ["baz", "bap"])],
         ),
         id="test in filter with quoted and unquoted values",
     ),
     pytest.param(
         'sum(foo){!bar:["baz", "bap"]}',
-        MetricsQuery(
-            query=Timeseries(
-                metric=Metric(public_name="foo"),
-                aggregate="sum",
-                filters=[Condition(Column("bar"), Op.NOT_IN, ["baz", "bap"])],
-            )
+        Timeseries(
+            metric=Metric(public_name="foo"),
+            aggregate="sum",
+            filters=[Condition(Column("bar"), Op.NOT_IN, ["baz", "bap"])],
         ),
         id="test not in filter",
     ),
     pytest.param(
         "sum(foo){!bar:[baz, bap]}",
-        MetricsQuery(
-            query=Timeseries(
-                metric=Metric(public_name="foo"),
-                aggregate="sum",
-                filters=[Condition(Column("bar"), Op.NOT_IN, ["baz", "bap"])],
-            )
+        Timeseries(
+            metric=Metric(public_name="foo"),
+            aggregate="sum",
+            filters=[Condition(Column("bar"), Op.NOT_IN, ["baz", "bap"])],
         ),
         id="test not in filter with unquoted values",
     ),
     pytest.param(
         'sum(foo){!bar:["baz", bap]}',
-        MetricsQuery(
-            query=Timeseries(
-                metric=Metric(public_name="foo"),
-                aggregate="sum",
-                filters=[Condition(Column("bar"), Op.NOT_IN, ["baz", "bap"])],
-            )
+        Timeseries(
+            metric=Metric(public_name="foo"),
+            aggregate="sum",
+            filters=[Condition(Column("bar"), Op.NOT_IN, ["baz", "bap"])],
         ),
         id="test not in filter with quoted and unquoted values",
     ),
     pytest.param(
         'sum(foo{bar:"baz"})',
-        MetricsQuery(
-            query=Timeseries(
-                metric=Metric(public_name="foo"),
-                aggregate="sum",
-                filters=[Condition(Column("bar"), Op.EQ, "baz")],
-            )
+        Timeseries(
+            metric=Metric(public_name="foo"),
+            aggregate="sum",
+            filters=[Condition(Column("bar"), Op.EQ, "baz")],
         ),
         id="test filter inside aggregate",
     ),
     pytest.param(
         "sum(foo{bar:baz})",
-        MetricsQuery(
-            query=Timeseries(
-                metric=Metric(public_name="foo"),
-                aggregate="sum",
-                filters=[Condition(Column("bar"), Op.EQ, "baz")],
-            )
+        Timeseries(
+            metric=Metric(public_name="foo"),
+            aggregate="sum",
+            filters=[Condition(Column("bar"), Op.EQ, "baz")],
         ),
         id="test filter inside aggregate with unquoted value",
     ),
     pytest.param(
         'sum(user{bar:"baz", foo:"foz"})',
-        MetricsQuery(
-            query=Timeseries(
-                metric=Metric(public_name="user"),
-                aggregate="sum",
-                filters=[
-                    And(
-                        conditions=[
-                            Condition(Column("bar"), Op.EQ, "baz"),
-                            Condition(Column("foo"), Op.EQ, "foz"),
-                        ],
-                    )
-                ],
-            )
+        Timeseries(
+            metric=Metric(public_name="user"),
+            aggregate="sum",
+            filters=[
+                And(
+                    conditions=[
+                        Condition(Column("bar"), Op.EQ, "baz"),
+                        Condition(Column("foo"), Op.EQ, "foz"),
+                    ],
+                )
+            ],
         ),
         id="test multiple filters",
     ),
     pytest.param(
         'sum(user{bar:"baz" foo:"foz"})',
-        MetricsQuery(
-            query=Timeseries(
-                metric=Metric(public_name="user"),
-                aggregate="sum",
-                filters=[
-                    And(
-                        conditions=[
-                            Condition(Column("bar"), Op.EQ, "baz"),
-                            Condition(Column("foo"), Op.EQ, "foz"),
-                        ]
-                    )
-                ],
-            )
+        Timeseries(
+            metric=Metric(public_name="user"),
+            aggregate="sum",
+            filters=[
+                And(
+                    conditions=[
+                        Condition(Column("bar"), Op.EQ, "baz"),
+                        Condition(Column("foo"), Op.EQ, "foz"),
+                    ]
+                )
+            ],
         ),
         id="test multiple filters with space delimiter",
     ),
     pytest.param(
         'sum(user{bar:"baz" and foo:"foz"})',
-        MetricsQuery(
-            query=Timeseries(
-                metric=Metric(public_name="user"),
-                aggregate="sum",
-                filters=[
-                    And(
-                        conditions=[
-                            Condition(Column("bar"), Op.EQ, "baz"),
-                            Condition(Column("foo"), Op.EQ, "foz"),
-                        ]
-                    )
-                ],
-            )
+        Timeseries(
+            metric=Metric(public_name="user"),
+            aggregate="sum",
+            filters=[
+                And(
+                    conditions=[
+                        Condition(Column("bar"), Op.EQ, "baz"),
+                        Condition(Column("foo"), Op.EQ, "foz"),
+                    ]
+                )
+            ],
         ),
         id="test multiple filters with lowercase AND operator",
     ),
     pytest.param(
         'sum(user{bar:"baz" OR foo:"foz" and (hee:"haw")})',
-        MetricsQuery(
-            query=Timeseries(
-                metric=Metric(public_name="user"),
-                aggregate="sum",
-                filters=[
-                    Or(
-                        conditions=[
-                            Condition(Column("bar"), Op.EQ, "baz"),
-                            And(
-                                conditions=[
-                                    Condition(Column("foo"), Op.EQ, "foz"),
-                                    Condition(Column("hee"), Op.EQ, "haw"),
-                                ]
-                            ),
-                        ],
-                    ),
-                ],
-            )
+        Timeseries(
+            metric=Metric(public_name="user"),
+            aggregate="sum",
+            filters=[
+                Or(
+                    conditions=[
+                        Condition(Column("bar"), Op.EQ, "baz"),
+                        And(
+                            conditions=[
+                                Condition(Column("foo"), Op.EQ, "foz"),
+                                Condition(Column("hee"), Op.EQ, "haw"),
+                            ]
+                        ),
+                    ],
+                ),
+            ],
         ),
         id="test multiple filters with lowercase AND and OR operators and no parentheses",
     ),
     pytest.param(
         'sum(user{(bar:"baz" or foo:"foz") AND hee:"haw"})',
-        MetricsQuery(
-            query=Timeseries(
-                metric=Metric(public_name="user"),
-                aggregate="sum",
-                filters=[
-                    And(
-                        conditions=[
-                            Or(
-                                conditions=[
-                                    Condition(Column("bar"), Op.EQ, "baz"),
-                                    Condition(Column("foo"), Op.EQ, "foz"),
-                                ],
-                            ),
-                            Condition(Column("hee"), Op.EQ, "haw"),
-                        ]
-                    )
-                ],
-            )
+        Timeseries(
+            metric=Metric(public_name="user"),
+            aggregate="sum",
+            filters=[
+                And(
+                    conditions=[
+                        Or(
+                            conditions=[
+                                Condition(Column("bar"), Op.EQ, "baz"),
+                                Condition(Column("foo"), Op.EQ, "foz"),
+                            ],
+                        ),
+                        Condition(Column("hee"), Op.EQ, "haw"),
+                    ]
+                )
+            ],
         ),
         id="test multiple filters with AND and lowercase OR operators",
     ),
     pytest.param(
         'sum(user{bar:"baz" foo:"foz", hee:"haw" AND key:"value"})',
-        MetricsQuery(
-            query=Timeseries(
-                metric=Metric(public_name="user"),
-                aggregate="sum",
-                filters=[
-                    And(
-                        conditions=[
-                            Condition(Column("bar"), Op.EQ, "baz"),
-                            Condition(Column("foo"), Op.EQ, "foz"),
-                            Condition(Column("hee"), Op.EQ, "haw"),
-                            Condition(Column("key"), Op.EQ, "value"),
-                        ]
-                    )
-                ],
-            )
+        Timeseries(
+            metric=Metric(public_name="user"),
+            aggregate="sum",
+            filters=[
+                And(
+                    conditions=[
+                        Condition(Column("bar"), Op.EQ, "baz"),
+                        Condition(Column("foo"), Op.EQ, "foz"),
+                        Condition(Column("hee"), Op.EQ, "haw"),
+                        Condition(Column("key"), Op.EQ, "value"),
+                    ]
+                )
+            ],
         ),
         id="test multiple filters with space and comma delimiter",
     ),
     pytest.param(
         "sum(user{bar:baz, foo:foz})",
-        MetricsQuery(
-            query=Timeseries(
-                metric=Metric(public_name="user"),
-                aggregate="sum",
-                filters=[
-                    And(
-                        conditions=[
-                            Condition(Column("bar"), Op.EQ, "baz"),
-                            Condition(Column("foo"), Op.EQ, "foz"),
-                        ]
-                    )
-                ],
-            )
+        Timeseries(
+            metric=Metric(public_name="user"),
+            aggregate="sum",
+            filters=[
+                And(
+                    conditions=[
+                        Condition(Column("bar"), Op.EQ, "baz"),
+                        Condition(Column("foo"), Op.EQ, "foz"),
+                    ]
+                )
+            ],
         ),
         id="test multiple filters with unquoted values",
     ),
     pytest.param(
         "sum(user{bar:baz foo:foz})",
-        MetricsQuery(
-            query=Timeseries(
-                metric=Metric(public_name="user"),
-                aggregate="sum",
-                filters=[
-                    And(
-                        conditions=[
-                            Condition(Column("bar"), Op.EQ, "baz"),
-                            Condition(Column("foo"), Op.EQ, "foz"),
-                        ]
-                    )
-                ],
-            )
+        Timeseries(
+            metric=Metric(public_name="user"),
+            aggregate="sum",
+            filters=[
+                And(
+                    conditions=[
+                        Condition(Column("bar"), Op.EQ, "baz"),
+                        Condition(Column("foo"), Op.EQ, "foz"),
+                    ]
+                )
+            ],
         ),
         id="test multiple filters with unquoted values with space delimiter",
     ),
     pytest.param(
         "sum(user{bar:baz foo:foz, hee:haw})",
-        MetricsQuery(
-            query=Timeseries(
-                metric=Metric(public_name="user"),
-                aggregate="sum",
-                filters=[
-                    And(
-                        conditions=[
-                            Condition(Column("bar"), Op.EQ, "baz"),
-                            Condition(Column("foo"), Op.EQ, "foz"),
-                            Condition(Column("hee"), Op.EQ, "haw"),
-                        ]
-                    )
-                ],
-            )
+        Timeseries(
+            metric=Metric(public_name="user"),
+            aggregate="sum",
+            filters=[
+                And(
+                    conditions=[
+                        Condition(Column("bar"), Op.EQ, "baz"),
+                        Condition(Column("foo"), Op.EQ, "foz"),
+                        Condition(Column("hee"), Op.EQ, "haw"),
+                    ]
+                )
+            ],
         ),
         id="test multiple filters with unquoted values with space and comma delimiter",
     ),
     pytest.param(
         'sum(user{bar:"baz", foo:foz})',
-        MetricsQuery(
-            query=Timeseries(
-                metric=Metric(public_name="user"),
-                aggregate="sum",
-                filters=[
-                    And(
-                        conditions=[
-                            Condition(Column("bar"), Op.EQ, "baz"),
-                            Condition(Column("foo"), Op.EQ, "foz"),
-                        ]
-                    )
-                ],
-            )
+        Timeseries(
+            metric=Metric(public_name="user"),
+            aggregate="sum",
+            filters=[
+                And(
+                    conditions=[
+                        Condition(Column("bar"), Op.EQ, "baz"),
+                        Condition(Column("foo"), Op.EQ, "foz"),
+                    ]
+                )
+            ],
         ),
         id="test multiple filters with quoted and unquoted values",
     ),
     pytest.param(
         'sum(user{bar:"baz" foo:foz})',
-        MetricsQuery(
-            query=Timeseries(
-                metric=Metric(public_name="user"),
-                aggregate="sum",
-                filters=[
-                    And(
-                        conditions=[
-                            Condition(Column("bar"), Op.EQ, "baz"),
-                            Condition(Column("foo"), Op.EQ, "foz"),
-                        ]
-                    )
-                ],
-            )
+        Timeseries(
+            metric=Metric(public_name="user"),
+            aggregate="sum",
+            filters=[
+                And(
+                    conditions=[
+                        Condition(Column("bar"), Op.EQ, "baz"),
+                        Condition(Column("foo"), Op.EQ, "foz"),
+                    ]
+                )
+            ],
         ),
         id="test multiple filters with quoted and unquoted values with space delimiter",
     ),
     pytest.param(
         'sum(user{bar:"baz" foo:foz, hee:"haw"})',
-        MetricsQuery(
-            query=Timeseries(
-                metric=Metric(public_name="user"),
-                aggregate="sum",
-                filters=[
-                    And(
-                        conditions=[
-                            Condition(Column("bar"), Op.EQ, "baz"),
-                            Condition(Column("foo"), Op.EQ, "foz"),
-                            Condition(Column("hee"), Op.EQ, "haw"),
-                        ]
-                    )
-                ],
-            )
+        Timeseries(
+            metric=Metric(public_name="user"),
+            aggregate="sum",
+            filters=[
+                And(
+                    conditions=[
+                        Condition(Column("bar"), Op.EQ, "baz"),
+                        Condition(Column("foo"), Op.EQ, "foz"),
+                        Condition(Column("hee"), Op.EQ, "haw"),
+                    ]
+                )
+            ],
         ),
         id="test multiple filters with quoted and unquoted values with space and comma delimiter",
     ),
     pytest.param(
         'sum(user{bar:baz foo:"foz", !hee:["haw", hoo]})',
-        MetricsQuery(
-            query=Timeseries(
-                metric=Metric(public_name="user"),
-                aggregate="sum",
-                filters=[
-                    And(
-                        conditions=[
-                            Condition(Column("bar"), Op.EQ, "baz"),
-                            Condition(Column("foo"), Op.EQ, "foz"),
-                            Condition(Column("hee"), Op.NOT_IN, ["haw", "hoo"]),
-                        ]
-                    )
-                ],
-            )
+        Timeseries(
+            metric=Metric(public_name="user"),
+            aggregate="sum",
+            filters=[
+                And(
+                    conditions=[
+                        Condition(Column("bar"), Op.EQ, "baz"),
+                        Condition(Column("foo"), Op.EQ, "foz"),
+                        Condition(Column("hee"), Op.NOT_IN, ["haw", "hoo"]),
+                    ]
+                )
+            ],
         ),
         id="test complex filters",
     ),
     pytest.param(
         'sum(`d:transactions/duration@millisecond`{foo:"foz", hee:"haw"}){bar:"baz"}',
-        MetricsQuery(
-            query=Timeseries(
-                metric=Metric(mri="d:transactions/duration@millisecond"),
-                aggregate="sum",
-                filters=[
-                    Condition(Column("bar"), Op.EQ, "baz"),
-                    And(
-                        conditions=[
-                            Condition(Column("foo"), Op.EQ, "foz"),
-                            Condition(Column("hee"), Op.EQ, "haw"),
-                        ]
-                    ),
-                ],
-            ),
+        Timeseries(
+            metric=Metric(mri="d:transactions/duration@millisecond"),
+            aggregate="sum",
+            filters=[
+                Condition(Column("bar"), Op.EQ, "baz"),
+                And(
+                    conditions=[
+                        Condition(Column("foo"), Op.EQ, "foz"),
+                        Condition(Column("hee"), Op.EQ, "haw"),
+                    ]
+                ),
+            ],
         ),
         id="test multiple layer filters",
     ),
     pytest.param(
         'max(`d:transactions/duration@millisecond`{foo:"foz"}) by transaction',
-        MetricsQuery(
-            query=Timeseries(
-                metric=Metric(mri="d:transactions/duration@millisecond"),
-                aggregate="max",
-                filters=[Condition(Column("foo"), Op.EQ, "foz")],
-                groupby=[Column("transaction")],
-            )
+        Timeseries(
+            metric=Metric(mri="d:transactions/duration@millisecond"),
+            aggregate="max",
+            filters=[Condition(Column("foo"), Op.EQ, "foz")],
+            groupby=[Column("transaction")],
         ),
         id="test group by 1",
     ),
     pytest.param(
         "max(`d:transactions/duration@millisecond`{transaction.status:foz} by http.status_code)",
-        MetricsQuery(
-            query=Timeseries(
-                metric=Metric(mri="d:transactions/duration@millisecond"),
-                aggregate="max",
-                filters=[Condition(Column("transaction.status"), Op.EQ, "foz")],
-                groupby=[Column("http.status_code")],
-            ),
+        Timeseries(
+            metric=Metric(mri="d:transactions/duration@millisecond"),
+            aggregate="max",
+            filters=[Condition(Column("transaction.status"), Op.EQ, "foz")],
+            groupby=[Column("http.status_code")],
         ),
         id="test group by 2",
     ),
     pytest.param(
         'max(`d:transactions/duration@millisecond`{transaction.status:"foz"}) by (transaction)',
-        MetricsQuery(
-            query=Timeseries(
-                metric=Metric(mri="d:transactions/duration@millisecond"),
-                aggregate="max",
-                filters=[Condition(Column("transaction.status"), Op.EQ, "foz")],
-                groupby=[Column("transaction")],
-            ),
+        Timeseries(
+            metric=Metric(mri="d:transactions/duration@millisecond"),
+            aggregate="max",
+            filters=[Condition(Column("transaction.status"), Op.EQ, "foz")],
+            groupby=[Column("transaction")],
         ),
         id="test group by 3",
     ),
     pytest.param(
         'max(`d:transactions/duration@millisecond`{transaction.status:"foz"}){transaction.op:baz} by (a.something, b.something)',
-        MetricsQuery(
-            query=Timeseries(
-                metric=Metric(mri="d:transactions/duration@millisecond"),
-                aggregate="max",
-                filters=[
-                    Condition(Column("transaction.op"), Op.EQ, "baz"),
-                    Condition(Column("transaction.status"), Op.EQ, "foz"),
-                ],
-                groupby=[Column("a.something"), Column("b.something")],
-            )
+        Timeseries(
+            metric=Metric(mri="d:transactions/duration@millisecond"),
+            aggregate="max",
+            filters=[
+                Condition(Column("transaction.op"), Op.EQ, "baz"),
+                Condition(Column("transaction.status"), Op.EQ, "foz"),
+            ],
+            groupby=[Column("a.something"), Column("b.something")],
         ),
         id="test group by 4",
     ),
     pytest.param(
         "p90(`d:transactions/duration@millisecond`)",
-        MetricsQuery(
-            query=Timeseries(
-                metric=Metric(mri="d:transactions/duration@millisecond"),
-                aggregate="p90",
-            )
+        Timeseries(
+            metric=Metric(mri="d:transactions/duration@millisecond"),
+            aggregate="p90",
         ),
         id="test percentile function",
     ),
     pytest.param(
         "quantiles(0.5)(`d:transactions/duration@millisecond`)",
-        MetricsQuery(
-            query=Timeseries(
-                metric=Metric(mri="d:transactions/duration@millisecond"),
-                aggregate="quantiles",
-                aggregate_params=[0.5],
-            )
+        Timeseries(
+            metric=Metric(mri="d:transactions/duration@millisecond"),
+            aggregate="quantiles",
+            aggregate_params=[0.5],
         ),
         id="test curried functions",
     ),
     pytest.param(
         "quantiles(0.5, 0.95)(`d:transactions/duration@millisecond`)",
-        MetricsQuery(
-            query=Timeseries(
-                metric=Metric(mri="d:transactions/duration@millisecond"),
-                aggregate="quantiles",
-                aggregate_params=[0.5, 0.95],
-            )
+        Timeseries(
+            metric=Metric(mri="d:transactions/duration@millisecond"),
+            aggregate="quantiles",
+            aggregate_params=[0.5, 0.95],
         ),
         id="test curried functions with multiple params",
     ),
     pytest.param(
         "quantiles()(`d:transactions/duration@millisecond`)",
-        MetricsQuery(
-            query=Timeseries(
-                metric=Metric(mri="d:transactions/duration@millisecond"),
-                aggregate="quantiles",
-                aggregate_params=[],
-            )
+        Timeseries(
+            metric=Metric(mri="d:transactions/duration@millisecond"),
+            aggregate="quantiles",
+            aggregate_params=[],
         ),
         id="test curried functions with no params",
     ),
     pytest.param(
         'quantiles(0.5, "random", other, 9)(`d:transactions/duration@millisecond`)',
-        MetricsQuery(
-            query=Timeseries(
-                metric=Metric(mri="d:transactions/duration@millisecond"),
-                aggregate="quantiles",
-                aggregate_params=[0.5, "random", "other", 9],
-            )
+        Timeseries(
+            metric=Metric(mri="d:transactions/duration@millisecond"),
+            aggregate="quantiles",
+            aggregate_params=[0.5, "random", "other", 9],
         ),
         id="test curried functions with random params",
     ),
     pytest.param(
         "quantiles(0.5)(`d:transactions/duration.1@millisecond`{})",
-        MetricsQuery(
-            query=Timeseries(
-                metric=Metric(mri="d:transactions/duration.1@millisecond"),
-                aggregate="quantiles",
-                aggregate_params=[0.5],
-            )
+        Timeseries(
+            metric=Metric(mri="d:transactions/duration.1@millisecond"),
+            aggregate="quantiles",
+            aggregate_params=[0.5],
         ),
         id="test curried functions with empty filter",
     ),
     pytest.param(
         'quantiles(0.5)(`d:transactions/duration_2@millisecond`{foo:"foz"}){bar:baz} by (a, b)',
-        MetricsQuery(
-            query=Timeseries(
-                metric=Metric(mri="d:transactions/duration_2@millisecond"),
-                aggregate="quantiles",
-                aggregate_params=[0.5],
-                filters=[
-                    Condition(Column("bar"), Op.EQ, "baz"),
-                    Condition(Column("foo"), Op.EQ, "foz"),
-                ],
-                groupby=[Column("a"), Column("b")],
-            )
+        Timeseries(
+            metric=Metric(mri="d:transactions/duration_2@millisecond"),
+            aggregate="quantiles",
+            aggregate_params=[0.5],
+            filters=[
+                Condition(Column("bar"), Op.EQ, "baz"),
+                Condition(Column("foo"), Op.EQ, "foz"),
+            ],
+            groupby=[Column("a"), Column("b")],
         ),
         id="test curried functions with filters and group by",
     ),
     pytest.param(
         "quantiles(0.5)(`d:transactions/duration@millisecond`{foo:'foz' AND hee:\"hoo\"}){bar:baz} by (a, b)",
-        MetricsQuery(
-            query=Timeseries(
-                metric=Metric(mri="d:transactions/duration@millisecond"),
-                aggregate="quantiles",
-                aggregate_params=[0.5],
-                filters=[
-                    Condition(Column("bar"), Op.EQ, "baz"),
-                    And(
-                        [
-                            Condition(Column("foo"), Op.EQ, "'foz'"),
-                            Condition(Column("hee"), Op.EQ, "hoo"),
-                        ]
-                    ),
-                ],
-                groupby=[Column("a"), Column("b")],
-            )
+        Timeseries(
+            metric=Metric(mri="d:transactions/duration@millisecond"),
+            aggregate="quantiles",
+            aggregate_params=[0.5],
+            filters=[
+                Condition(Column("bar"), Op.EQ, "baz"),
+                And(
+                    [
+                        Condition(Column("foo"), Op.EQ, "'foz'"),
+                        Condition(Column("hee"), Op.EQ, "hoo"),
+                    ]
+                ),
+            ],
+            groupby=[Column("a"), Column("b")],
         ),
         id="test quotes parsing",
     ),
     pytest.param(
         'max(d:transactions/duration@millisecond){bar:" !\\"#$%&\'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\\\]^_`abcdefghijklmnopqrstuvwxyz{|}~"} by (transaction)',
-        MetricsQuery(
-            query=Timeseries(
-                metric=Metric(mri="d:transactions/duration@millisecond"),
-                aggregate="max",
-                filters=[
-                    Condition(
-                        Column("bar"),
-                        Op.EQ,
-                        " !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\\\]^_`abcdefghijklmnopqrstuvwxyz{|}~",
-                    ),
-                ],
-                groupby=[Column("transaction")],
-            )
+        Timeseries(
+            metric=Metric(mri="d:transactions/duration@millisecond"),
+            aggregate="max",
+            filters=[
+                Condition(
+                    Column("bar"),
+                    Op.EQ,
+                    " !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\\\]^_`abcdefghijklmnopqrstuvwxyz{|}~",
+                ),
+            ],
+            groupby=[Column("transaction")],
         ),
         id="test terms with crazy characters",
     ),
@@ -683,7 +578,7 @@ base_tests = [
 
 
 @pytest.mark.parametrize("mql_string, metrics_query", base_tests)
-def test_parse_mql_base(mql_string: str, metrics_query: MetricsQuery) -> None:
+def test_parse_mql_base(mql_string: str, metrics_query: Formula | Timeseries) -> None:
     result = parse_mql(mql_string)
     assert result == metrics_query
 
@@ -691,244 +586,222 @@ def test_parse_mql_base(mql_string: str, metrics_query: MetricsQuery) -> None:
 term_tests = [
     pytest.param(
         "sum(foo) / 1000",
-        MetricsQuery(
-            query=Formula(
-                ArithmeticOperator.DIVIDE.value,
-                [
-                    Timeseries(
-                        metric=Metric(public_name="foo"),
-                        aggregate="sum",
-                    ),
-                    1000.0,
-                ],
-            )
+        Formula(
+            ArithmeticOperator.DIVIDE.value,
+            [
+                Timeseries(
+                    metric=Metric(public_name="foo"),
+                    aggregate="sum",
+                ),
+                1000.0,
+            ],
         ),
         id="test terms with number",
     ),
     pytest.param(
         "sum(foo) * max(bar)",
-        MetricsQuery(
-            query=Formula(
-                ArithmeticOperator.MULTIPLY.value,
-                [
-                    Timeseries(
-                        metric=Metric(public_name="foo"),
-                        aggregate="sum",
-                    ),
-                    Timeseries(
-                        metric=Metric(public_name="bar"),
-                        aggregate="max",
-                    ),
-                ],
-            )
+        Formula(
+            ArithmeticOperator.MULTIPLY.value,
+            [
+                Timeseries(
+                    metric=Metric(public_name="foo"),
+                    aggregate="sum",
+                ),
+                Timeseries(
+                    metric=Metric(public_name="bar"),
+                    aggregate="max",
+                ),
+            ],
         ),
         id="test terms with both aggregates",
     ),
     pytest.param(
         "(sum(foo) * sum(bar)) / 1000",
-        MetricsQuery(
-            query=Formula(
-                ArithmeticOperator.DIVIDE.value,
-                [
-                    Formula(
-                        ArithmeticOperator.MULTIPLY.value,
-                        [
-                            Timeseries(
-                                metric=Metric(public_name="foo"),
-                                aggregate="sum",
-                            ),
-                            Timeseries(
-                                metric=Metric(public_name="bar"),
-                                aggregate="sum",
-                            ),
-                        ],
-                    ),
-                    1000.0,
-                ],
-            )
+        Formula(
+            ArithmeticOperator.DIVIDE.value,
+            [
+                Formula(
+                    ArithmeticOperator.MULTIPLY.value,
+                    [
+                        Timeseries(
+                            metric=Metric(public_name="foo"),
+                            aggregate="sum",
+                        ),
+                        Timeseries(
+                            metric=Metric(public_name="bar"),
+                            aggregate="sum",
+                        ),
+                    ],
+                ),
+                1000.0,
+            ],
         ),
         id="test multi terms",
     ),
     pytest.param(
         '(sum(foo) / sum(bar)){tag:"tag_value"}',
-        MetricsQuery(
-            query=Formula(
-                ArithmeticOperator.DIVIDE.value,
-                [
-                    Timeseries(
-                        metric=Metric(public_name="foo"),
-                        aggregate="sum",
-                    ),
-                    Timeseries(
-                        metric=Metric(public_name="bar"),
-                        aggregate="sum",
-                    ),
-                ],
-                filters=[Condition(Column("tag"), Op.EQ, "tag_value")],
-            ),
+        Formula(
+            ArithmeticOperator.DIVIDE.value,
+            [
+                Timeseries(
+                    metric=Metric(public_name="foo"),
+                    aggregate="sum",
+                ),
+                Timeseries(
+                    metric=Metric(public_name="bar"),
+                    aggregate="sum",
+                ),
+            ],
+            filters=[Condition(Column("tag"), Op.EQ, "tag_value")],
         ),
         id="test terms with one filter",
     ),
     pytest.param(
         'sum(foo{tag:"tag_value"}) / sum(bar{tag:"tag_value"})',
-        MetricsQuery(
-            query=Formula(
-                ArithmeticOperator.DIVIDE.value,
-                [
-                    Timeseries(
-                        metric=Metric(public_name="foo"),
-                        aggregate="sum",
-                        filters=[Condition(Column("tag"), Op.EQ, "tag_value")],
-                    ),
-                    Timeseries(
-                        metric=Metric(public_name="bar"),
-                        aggregate="sum",
-                        filters=[Condition(Column("tag"), Op.EQ, "tag_value")],
-                    ),
-                ],
-            ),
+        Formula(
+            ArithmeticOperator.DIVIDE.value,
+            [
+                Timeseries(
+                    metric=Metric(public_name="foo"),
+                    aggregate="sum",
+                    filters=[Condition(Column("tag"), Op.EQ, "tag_value")],
+                ),
+                Timeseries(
+                    metric=Metric(public_name="bar"),
+                    aggregate="sum",
+                    filters=[Condition(Column("tag"), Op.EQ, "tag_value")],
+                ),
+            ],
         ),
         id="test terms with two filters",
     ),
     pytest.param(
         '(sum(foo) / sum(bar)){tag:"tag_value"} by transaction',
-        MetricsQuery(
-            query=Formula(
-                ArithmeticOperator.DIVIDE.value,
-                [
-                    Timeseries(
-                        metric=Metric(public_name="foo"),
-                        aggregate="sum",
-                    ),
-                    Timeseries(
-                        metric=Metric(public_name="bar"),
-                        aggregate="sum",
-                    ),
-                ],
-                filters=[Condition(Column("tag"), Op.EQ, "tag_value")],
-                groupby=[Column("transaction")],
-            ),
+        Formula(
+            ArithmeticOperator.DIVIDE.value,
+            [
+                Timeseries(
+                    metric=Metric(public_name="foo"),
+                    aggregate="sum",
+                ),
+                Timeseries(
+                    metric=Metric(public_name="bar"),
+                    aggregate="sum",
+                ),
+            ],
+            filters=[Condition(Column("tag"), Op.EQ, "tag_value")],
+            groupby=[Column("transaction")],
         ),
         id="test terms with groupby 1",
     ),
     pytest.param(
         "(sum(foo) by transaction / sum(bar) by transaction)",
-        MetricsQuery(
-            query=Formula(
-                ArithmeticOperator.DIVIDE.value,
-                [
-                    Timeseries(
-                        metric=Metric(public_name="foo"),
-                        aggregate="sum",
-                        groupby=[Column("transaction")],
-                    ),
-                    Timeseries(
-                        metric=Metric(public_name="bar"),
-                        aggregate="sum",
-                        groupby=[Column("transaction")],
-                    ),
-                ],
-            ),
+        Formula(
+            ArithmeticOperator.DIVIDE.value,
+            [
+                Timeseries(
+                    metric=Metric(public_name="foo"),
+                    aggregate="sum",
+                    groupby=[Column("transaction")],
+                ),
+                Timeseries(
+                    metric=Metric(public_name="bar"),
+                    aggregate="sum",
+                    groupby=[Column("transaction")],
+                ),
+            ],
         ),
         id="test terms with groupby 2",
     ),
     pytest.param(
         '(sum(foo) by transaction / sum(bar) by transaction){tag:"tag_value"}',
-        MetricsQuery(
-            query=Formula(
-                ArithmeticOperator.DIVIDE.value,
-                [
-                    Timeseries(
-                        metric=Metric(public_name="foo"),
-                        aggregate="sum",
-                        groupby=[Column("transaction")],
-                    ),
-                    Timeseries(
-                        metric=Metric(public_name="bar"),
-                        aggregate="sum",
-                        groupby=[Column("transaction")],
-                    ),
-                ],
-                filters=[Condition(Column("tag"), Op.EQ, "tag_value")],
-            ),
+        Formula(
+            ArithmeticOperator.DIVIDE.value,
+            [
+                Timeseries(
+                    metric=Metric(public_name="foo"),
+                    aggregate="sum",
+                    groupby=[Column("transaction")],
+                ),
+                Timeseries(
+                    metric=Metric(public_name="bar"),
+                    aggregate="sum",
+                    groupby=[Column("transaction")],
+                ),
+            ],
+            filters=[Condition(Column("tag"), Op.EQ, "tag_value")],
         ),
         id="test terms with groupby 3",
     ),
     pytest.param(
         '(sum(foo{tag:"tag_value"}) by transaction) / (sum(bar{tag:"tag_value"}) by transaction)',
-        MetricsQuery(
-            query=Formula(
-                ArithmeticOperator.DIVIDE.value,
-                [
-                    Timeseries(
-                        metric=Metric(public_name="foo"),
-                        aggregate="sum",
-                        filters=[Condition(Column("tag"), Op.EQ, "tag_value")],
-                        groupby=[Column("transaction")],
-                    ),
-                    Timeseries(
-                        metric=Metric(public_name="bar"),
-                        aggregate="sum",
-                        filters=[Condition(Column("tag"), Op.EQ, "tag_value")],
-                        groupby=[Column("transaction")],
-                    ),
-                ],
-            ),
+        Formula(
+            ArithmeticOperator.DIVIDE.value,
+            [
+                Timeseries(
+                    metric=Metric(public_name="foo"),
+                    aggregate="sum",
+                    filters=[Condition(Column("tag"), Op.EQ, "tag_value")],
+                    groupby=[Column("transaction")],
+                ),
+                Timeseries(
+                    metric=Metric(public_name="bar"),
+                    aggregate="sum",
+                    filters=[Condition(Column("tag"), Op.EQ, "tag_value")],
+                    groupby=[Column("transaction")],
+                ),
+            ],
         ),
         id="test terms with groupby 4",
     ),
     pytest.param(
         '(sum(foo) / sum(bar)){tag:"tag_value"} by transaction',
-        MetricsQuery(
-            query=Formula(
-                ArithmeticOperator.DIVIDE.value,
-                [
-                    Timeseries(
-                        metric=Metric(public_name="foo"),
-                        aggregate="sum",
-                    ),
-                    Timeseries(
-                        metric=Metric(public_name="bar"),
-                        aggregate="sum",
-                    ),
-                ],
-                filters=[Condition(Column("tag"), Op.EQ, "tag_value")],
-                groupby=[Column("transaction")],
-            ),
+        Formula(
+            ArithmeticOperator.DIVIDE.value,
+            [
+                Timeseries(
+                    metric=Metric(public_name="foo"),
+                    aggregate="sum",
+                ),
+                Timeseries(
+                    metric=Metric(public_name="bar"),
+                    aggregate="sum",
+                ),
+            ],
+            filters=[Condition(Column("tag"), Op.EQ, "tag_value")],
+            groupby=[Column("transaction")],
         ),
         id="test terms with groupby 5",
     ),
     pytest.param(
         '((sum(foo{tag:"tag_value"}){tag2:"tag_value2"} / sum(bar)){tag3:"tag_value3"} * sum(pop)) by transaction',
-        MetricsQuery(
-            query=Formula(
-                function_name=ArithmeticOperator.MULTIPLY.value,
-                parameters=[
-                    Formula(
-                        ArithmeticOperator.DIVIDE.value,
-                        [
-                            Timeseries(
-                                metric=Metric(public_name="foo"),
-                                aggregate="sum",
-                                filters=[
-                                    Condition(Column("tag2"), Op.EQ, "tag_value2"),
-                                    Condition(Column("tag"), Op.EQ, "tag_value"),
-                                ],
-                            ),
-                            Timeseries(
-                                metric=Metric(public_name="bar"),
-                                aggregate="sum",
-                            ),
-                        ],
-                        filters=[Condition(Column("tag3"), Op.EQ, "tag_value3")],
-                    ),
-                    Timeseries(
-                        metric=Metric(public_name="pop"),
-                        aggregate="sum",
-                    ),
-                ],
-                groupby=[Column("transaction")],
-            )
+        Formula(
+            function_name=ArithmeticOperator.MULTIPLY.value,
+            parameters=[
+                Formula(
+                    ArithmeticOperator.DIVIDE.value,
+                    [
+                        Timeseries(
+                            metric=Metric(public_name="foo"),
+                            aggregate="sum",
+                            filters=[
+                                Condition(Column("tag2"), Op.EQ, "tag_value2"),
+                                Condition(Column("tag"), Op.EQ, "tag_value"),
+                            ],
+                        ),
+                        Timeseries(
+                            metric=Metric(public_name="bar"),
+                            aggregate="sum",
+                        ),
+                    ],
+                    filters=[Condition(Column("tag3"), Op.EQ, "tag_value3")],
+                ),
+                Timeseries(
+                    metric=Metric(public_name="pop"),
+                    aggregate="sum",
+                ),
+            ],
+            groupby=[Column("transaction")],
         ),
         id="test complex nested terms",
     ),
@@ -936,7 +809,7 @@ term_tests = [
 
 
 @pytest.mark.parametrize("mql_string, metrics_query", term_tests)
-def test_parse_mql_terms(mql_string: str, metrics_query: MetricsQuery) -> None:
+def test_parse_mql_terms(mql_string: str, metrics_query: Formula | Timeseries) -> None:
     result = parse_mql(mql_string)
     assert result == metrics_query
 
@@ -944,176 +817,158 @@ def test_parse_mql_terms(mql_string: str, metrics_query: MetricsQuery) -> None:
 arbitrary_function_tests = [
     pytest.param(
         "simple_function(sum(transaction.duration))",
-        MetricsQuery(
-            query=Formula(
-                "simple_function",
-                [
-                    Timeseries(
-                        metric=Metric(public_name="transaction.duration"),
-                        aggregate="sum",
-                    ),
-                ],
-            )
+        Formula(
+            "simple_function",
+            [
+                Timeseries(
+                    metric=Metric(public_name="transaction.duration"),
+                    aggregate="sum",
+                ),
+            ],
         ),
         id="test simple arbitrary function",
     ),
     pytest.param(
         'another_function("test", 500)',
-        MetricsQuery(
-            query=Formula(
-                "another_function",
-                [
-                    "test",
-                    500,
-                ],
-            )
+        Formula(
+            "another_function",
+            [
+                "test",
+                500,
+            ],
         ),
         id="test arbitrary function with string parameter",
     ),
     pytest.param(
         "sum(count(transaction.duration))",
-        MetricsQuery(
-            query=Formula(
-                "sum",
-                [
-                    Timeseries(
-                        metric=Metric(public_name="transaction.duration"),
-                        aggregate="count",
-                    ),
-                ],
-            )
+        Formula(
+            "sum",
+            [
+                Timeseries(
+                    metric=Metric(public_name="transaction.duration"),
+                    aggregate="count",
+                ),
+            ],
         ),
         id="test arbitrary function with inner aggregate",
     ),
     pytest.param(
         'apdex(sum(transaction.duration), 500){tag:"tag_value"} by transaction',
-        MetricsQuery(
-            query=Formula(
-                function_name="apdex",
-                parameters=[
-                    Timeseries(
-                        metric=Metric(public_name="transaction.duration"),
-                        aggregate="sum",
-                    ),
-                    500,
-                ],
-                filters=[Condition(Column("tag"), Op.EQ, "tag_value")],
-                groupby=[Column("transaction")],
-            ),
+        Formula(
+            function_name="apdex",
+            parameters=[
+                Timeseries(
+                    metric=Metric(public_name="transaction.duration"),
+                    aggregate="sum",
+                ),
+                500,
+            ],
+            filters=[Condition(Column("tag"), Op.EQ, "tag_value")],
+            groupby=[Column("transaction")],
         ),
         id="test arbitrary function with filters and groupby",
     ),
     pytest.param(
         "apdex(quantiles(0.5)(transaction.duration), 500)",
-        MetricsQuery(
-            query=Formula(
-                "apdex",
-                [
-                    Timeseries(
-                        metric=Metric(public_name="transaction.duration"),
-                        aggregate="quantiles",
-                        aggregate_params=[0.5],
-                    ),
-                    500,
-                ],
-            )
+        Formula(
+            "apdex",
+            [
+                Timeseries(
+                    metric=Metric(public_name="transaction.duration"),
+                    aggregate="quantiles",
+                    aggregate_params=[0.5],
+                ),
+                500,
+            ],
         ),
         id="test arbitrary function with curried aggregate",
     ),
     pytest.param(
         "apdex(failure_rate(sum(transaction.duration)), 500)",
-        MetricsQuery(
-            query=Formula(
-                "apdex",
-                [
-                    Formula(
-                        function_name="failure_rate",
-                        parameters=[
-                            Timeseries(
-                                metric=Metric(public_name="transaction.duration"),
-                                aggregate="sum",
-                            )
-                        ],
-                    ),
-                    500,
-                ],
-            )
+        Formula(
+            "apdex",
+            [
+                Formula(
+                    function_name="failure_rate",
+                    parameters=[
+                        Timeseries(
+                            metric=Metric(public_name="transaction.duration"),
+                            aggregate="sum",
+                        )
+                    ],
+                ),
+                500,
+            ],
         ),
         id="test arbitrary function within arbitrary function",
     ),
     pytest.param(
         'topK(sum(transaction.duration), 500, 4.2){tag:"tag_value"} by transaction',
-        MetricsQuery(
-            query=Formula(
-                function_name="topK",
-                parameters=[
-                    Timeseries(
-                        metric=Metric(public_name="transaction.duration"),
-                        aggregate="sum",
-                    ),
-                    500,
-                    4.2,
-                ],
-                filters=[Condition(Column("tag"), Op.EQ, "tag_value")],
-                groupby=[Column("transaction")],
-            ),
+        Formula(
+            function_name="topK",
+            parameters=[
+                Timeseries(
+                    metric=Metric(public_name="transaction.duration"),
+                    aggregate="sum",
+                ),
+                500,
+                4.2,
+            ],
+            filters=[Condition(Column("tag"), Op.EQ, "tag_value")],
+            groupby=[Column("transaction")],
         ),
         id="test arbitrary function with filters and groupby",
     ),
     pytest.param(
         'apdex(sum(foo) / sum(bar), 500){tag:"tag_value"} by transaction',
-        MetricsQuery(
-            query=Formula(
-                function_name="apdex",
-                parameters=[
-                    Formula(
-                        function_name=ArithmeticOperator.DIVIDE.value,
-                        parameters=[
-                            Timeseries(
-                                metric=Metric(public_name="foo"),
-                                aggregate="sum",
-                            ),
-                            Timeseries(
-                                metric=Metric(public_name="bar"),
-                                aggregate="sum",
-                            ),
-                        ],
-                    ),
-                    500,
-                ],
-                filters=[Condition(Column("tag"), Op.EQ, "tag_value")],
-                groupby=[Column("transaction")],
-            )
+        Formula(
+            function_name="apdex",
+            parameters=[
+                Formula(
+                    function_name=ArithmeticOperator.DIVIDE.value,
+                    parameters=[
+                        Timeseries(
+                            metric=Metric(public_name="foo"),
+                            aggregate="sum",
+                        ),
+                        Timeseries(
+                            metric=Metric(public_name="bar"),
+                            aggregate="sum",
+                        ),
+                    ],
+                ),
+                500,
+            ],
+            filters=[Condition(Column("tag"), Op.EQ, "tag_value")],
+            groupby=[Column("transaction")],
         ),
         id="test arbitrary function with inner terms",
     ),
     pytest.param(
         "apdex(sum(transaction.duration), 500) * failure_rate(sum(transaction.duration))",
-        MetricsQuery(
-            query=Formula(
-                function_name="multiply",
-                parameters=[
-                    Formula(
-                        function_name="apdex",
-                        parameters=[
-                            Timeseries(
-                                metric=Metric(public_name="transaction.duration"),
-                                aggregate="sum",
-                            ),
-                            500,
-                        ],
-                    ),
-                    Formula(
-                        function_name="failure_rate",
-                        parameters=[
-                            Timeseries(
-                                metric=Metric(public_name="transaction.duration"),
-                                aggregate="sum",
-                            )
-                        ],
-                    ),
-                ],
-            )
+        Formula(
+            function_name="multiply",
+            parameters=[
+                Formula(
+                    function_name="apdex",
+                    parameters=[
+                        Timeseries(
+                            metric=Metric(public_name="transaction.duration"),
+                            aggregate="sum",
+                        ),
+                        500,
+                    ],
+                ),
+                Formula(
+                    function_name="failure_rate",
+                    parameters=[
+                        Timeseries(
+                            metric=Metric(public_name="transaction.duration"),
+                            aggregate="sum",
+                        )
+                    ],
+                ),
+            ],
         ),
         id="test arbitrary function as outer terms",
     ),
@@ -1122,7 +977,7 @@ arbitrary_function_tests = [
 
 @pytest.mark.parametrize("mql_string, metrics_query", arbitrary_function_tests)
 def test_parse_mql_arbitrary_functions(
-    mql_string: str, metrics_query: MetricsQuery
+    mql_string: str, metrics_query: Formula | Timeseries
 ) -> None:
     result = parse_mql(mql_string)
     assert result == metrics_query
@@ -1131,160 +986,144 @@ def test_parse_mql_arbitrary_functions(
 curried_arbitrary_function_tests = [
     pytest.param(
         'topK(10)("test.duration")',
-        MetricsQuery(
-            query=Formula(
-                function_name="topK",
-                aggregate_params=[10],
-                parameters=["test.duration"],
-            )
+        Formula(
+            function_name="topK",
+            aggregate_params=[10],
+            parameters=["test.duration"],
         ),
         id="test curried arbitrary function with string param",
     ),
     pytest.param(
         "topK(10)(sum(transaction.duration))",
-        MetricsQuery(
-            query=Formula(
-                function_name="topK",
-                aggregate_params=[10],
-                parameters=[
-                    Timeseries(
-                        metric=Metric(public_name="transaction.duration"),
-                        aggregate="sum",
-                    ),
-                ],
-            )
+        Formula(
+            function_name="topK",
+            aggregate_params=[10],
+            parameters=[
+                Timeseries(
+                    metric=Metric(public_name="transaction.duration"),
+                    aggregate="sum",
+                ),
+            ],
         ),
         id="test curried arbitrary function with inner aggregate",
     ),
     pytest.param(
         'topK(10)(sum(transaction.duration), 500, "test")',
-        MetricsQuery(
-            query=Formula(
-                function_name="topK",
-                aggregate_params=[10],
-                parameters=[
-                    Timeseries(
-                        metric=Metric(public_name="transaction.duration"),
-                        aggregate="sum",
-                    ),
-                    500,
-                    "test",
-                ],
-            )
+        Formula(
+            function_name="topK",
+            aggregate_params=[10],
+            parameters=[
+                Timeseries(
+                    metric=Metric(public_name="transaction.duration"),
+                    aggregate="sum",
+                ),
+                500,
+                "test",
+            ],
         ),
         id="test curried arbitrary function with inner aggregate and params",
     ),
     pytest.param(
         "topK(10)(sum(transaction.duration), count(transaction.duration))",
-        MetricsQuery(
-            query=Formula(
-                function_name="topK",
-                aggregate_params=[10],
-                parameters=[
-                    Timeseries(
-                        metric=Metric(public_name="transaction.duration"),
-                        aggregate="sum",
-                    ),
-                    Timeseries(
-                        metric=Metric(public_name="transaction.duration"),
-                        aggregate="count",
-                    ),
-                ],
-            )
+        Formula(
+            function_name="topK",
+            aggregate_params=[10],
+            parameters=[
+                Timeseries(
+                    metric=Metric(public_name="transaction.duration"),
+                    aggregate="sum",
+                ),
+                Timeseries(
+                    metric=Metric(public_name="transaction.duration"),
+                    aggregate="count",
+                ),
+            ],
         ),
         id="test curried arbitrary function with multiple inner aggregate params",
     ),
     pytest.param(
         "topK(10)(sum(transaction.duration) / count(transaction.duration))",
-        MetricsQuery(
-            query=Formula(
-                function_name="topK",
-                aggregate_params=[10],
-                parameters=[
-                    Formula(
-                        function_name="divide",
-                        parameters=[
-                            Timeseries(
-                                metric=Metric(public_name="transaction.duration"),
-                                aggregate="sum",
-                            ),
-                            Timeseries(
-                                metric=Metric(public_name="transaction.duration"),
-                                aggregate="count",
-                            ),
-                        ],
-                    ),
-                ],
-            )
+        Formula(
+            function_name="topK",
+            aggregate_params=[10],
+            parameters=[
+                Formula(
+                    function_name="divide",
+                    parameters=[
+                        Timeseries(
+                            metric=Metric(public_name="transaction.duration"),
+                            aggregate="sum",
+                        ),
+                        Timeseries(
+                            metric=Metric(public_name="transaction.duration"),
+                            aggregate="count",
+                        ),
+                    ],
+                ),
+            ],
         ),
         id="test curried arbitrary function with inner aggregate and terms",
     ),
     pytest.param(
         "topK(10)(sum(transaction.duration{bar:baz}) / count(transaction.duration{foo:foz})) by transaction",
-        MetricsQuery(
-            query=Formula(
-                function_name="topK",
-                aggregate_params=[10],
-                parameters=[
-                    Formula(
-                        function_name="divide",
-                        parameters=[
-                            Timeseries(
-                                metric=Metric(public_name="transaction.duration"),
-                                aggregate="sum",
-                                filters=[Condition(Column("bar"), Op.EQ, "baz")],
-                            ),
-                            Timeseries(
-                                metric=Metric(public_name="transaction.duration"),
-                                aggregate="count",
-                                filters=[Condition(Column("foo"), Op.EQ, "foz")],
-                            ),
-                        ],
-                    ),
-                ],
-                groupby=[Column("transaction")],
-            ),
+        Formula(
+            function_name="topK",
+            aggregate_params=[10],
+            parameters=[
+                Formula(
+                    function_name="divide",
+                    parameters=[
+                        Timeseries(
+                            metric=Metric(public_name="transaction.duration"),
+                            aggregate="sum",
+                            filters=[Condition(Column("bar"), Op.EQ, "baz")],
+                        ),
+                        Timeseries(
+                            metric=Metric(public_name="transaction.duration"),
+                            aggregate="count",
+                            filters=[Condition(Column("foo"), Op.EQ, "foz")],
+                        ),
+                    ],
+                ),
+            ],
+            groupby=[Column("transaction")],
         ),
         id="test complex curried arbitrary function with inner terms",
     ),
     pytest.param(
         "topK(10)(topK(5)(transaction.duration){bar:baz})",
-        MetricsQuery(
-            query=Formula(
-                function_name="topK",
-                aggregate_params=[10],
-                parameters=[
-                    Timeseries(
-                        metric=Metric(public_name="transaction.duration"),
-                        aggregate="topK",
-                        aggregate_params=[5],
-                        filters=[Condition(Column("bar"), Op.EQ, "baz")],
-                    ),
-                ],
-            ),
+        Formula(
+            function_name="topK",
+            aggregate_params=[10],
+            parameters=[
+                Timeseries(
+                    metric=Metric(public_name="transaction.duration"),
+                    aggregate="topK",
+                    aggregate_params=[5],
+                    filters=[Condition(Column("bar"), Op.EQ, "baz")],
+                ),
+            ],
         ),
         id="test nested curried arbitrary function",
     ),
     pytest.param(
         "topK(10)(apdex(sum(transaction.duration), 500){bar:baz})",
-        MetricsQuery(
-            query=Formula(
-                function_name="topK",
-                aggregate_params=[10],
-                parameters=[
-                    Formula(
-                        function_name="apdex",
-                        parameters=[
-                            Timeseries(
-                                metric=Metric(public_name="transaction.duration"),
-                                aggregate="sum",
-                            ),
-                            500,
-                        ],
-                        filters=[Condition(Column("bar"), Op.EQ, "baz")],
-                    ),
-                ],
-            ),
+        Formula(
+            function_name="topK",
+            aggregate_params=[10],
+            parameters=[
+                Formula(
+                    function_name="apdex",
+                    parameters=[
+                        Timeseries(
+                            metric=Metric(public_name="transaction.duration"),
+                            aggregate="sum",
+                        ),
+                        500,
+                    ],
+                    filters=[Condition(Column("bar"), Op.EQ, "baz")],
+                ),
+            ],
         ),
         id="test curried arbitrary function with inner arbitrary function",
     ),
@@ -1293,7 +1132,7 @@ curried_arbitrary_function_tests = [
 
 @pytest.mark.parametrize("mql_string, metrics_query", curried_arbitrary_function_tests)
 def test_parse_mql_curried_arbitrary_functions(
-    mql_string: str, metrics_query: MetricsQuery
+    mql_string: str, metrics_query: Formula | Timeseries
 ) -> None:
     result = parse_mql(mql_string)
     assert result == metrics_query


### PR DESCRIPTION
Allow providing a MQL string as the `query` parameter to a MetricsQuery. The
string will get parsed and validated when being serialized to ensure that it's
a valid MQL string.

Since an MQL string can't specify an entity, this requires that Snuba can
automatically infer the entity based on the passed in MRI. See https://github.com/getsentry/snuba/pull/5501

This also refactored a lot of tests: `parse_mql` was wrapping the parsed
value in a MetricsQuery object. Returning the Formula/Timeseries directly
meant gently refactoring a lot of tests.