### PR TITLE
fix(mql): Fix missing handling of expressions and implement associativity

### DIFF
--- a/snuba_sdk/mql/mql.py
+++ b/snuba_sdk/mql/mql.py
@@ -146,13 +146,15 @@ class MQLVisitor(NodeVisitor):  # type: ignore
         """
         Top level node, simply returns the expression.
         """
-        expr, zero_or_more_others = children
-        assert isinstance(expr, (Formula, Timeseries, float, int, str))
+        term_left, zero_or_more_others = children
+        assert isinstance(term_left, (Formula, Timeseries, float, int, str))
 
         if zero_or_more_others:
-            _, expr_operator, _, coefficient, *_ = zero_or_more_others[0]
-            return Formula(expr_operator, [expr, coefficient])
-        return expr
+            for zero_or_more in zero_or_more_others:
+                _, expr_operator, _, term_right, *_ = zero_or_more
+                term_left = Formula(expr_operator, [term_left, term_right])
+
+        return term_left
 
     def visit_expr_op(self, node: Node, children: Sequence[Any]) -> Any:
         return EXPRESSION_OPERATORS[node.text]
@@ -164,13 +166,15 @@ class MQLVisitor(NodeVisitor):  # type: ignore
         Checks if the current node contains two term children, if so
         then merge them into a single Formula with the operator.
         """
-        term, zero_or_more_others = children
-        assert isinstance(term, (Formula, Timeseries, float, int, str))
+        coefficient_left, zero_or_more_others = children
+        assert isinstance(coefficient_left, (Formula, Timeseries, float, int, str))
 
         if zero_or_more_others:
-            _, term_operator, _, coefficient, *_ = zero_or_more_others[0]
-            return Formula(term_operator, [term, coefficient])
-        return term
+            for zero_or_more in zero_or_more_others:
+                _, term_operator, _, coefficient_right, *_ = zero_or_more
+                coefficient_left = Formula(term_operator, [coefficient_left, coefficient_right])
+
+        return coefficient_left
 
     def visit_term_op(self, node: Node, children: Sequence[Any]) -> Any:
         return TERM_OPERATORS[node.text]

--- a/snuba_sdk/mql/mql.py
+++ b/snuba_sdk/mql/mql.py
@@ -172,7 +172,9 @@ class MQLVisitor(NodeVisitor):  # type: ignore
         if zero_or_more_others:
             for zero_or_more in zero_or_more_others:
                 _, term_operator, _, coefficient_right, *_ = zero_or_more
-                coefficient_left = Formula(term_operator, [coefficient_left, coefficient_right])
+                coefficient_left = Formula(
+                    term_operator, [coefficient_left, coefficient_right]
+                )
 
         return coefficient_left
 

--- a/snuba_sdk/mql/mql.py
+++ b/snuba_sdk/mql/mql.py
@@ -147,6 +147,11 @@ class MQLVisitor(NodeVisitor):  # type: ignore
         Top level node, simply returns the expression.
         """
         expr, zero_or_more_others = children
+        assert isinstance(expr, (Formula, Timeseries, float, int, str))
+
+        if zero_or_more_others:
+            _, expr_operator, _, coefficient, *_ = zero_or_more_others[0]
+            return Formula(expr_operator, [expr, coefficient])
         return expr
 
     def visit_expr_op(self, node: Node, children: Sequence[Any]) -> Any:

--- a/snuba_sdk/mql/mql.py
+++ b/snuba_sdk/mql/mql.py
@@ -142,7 +142,9 @@ class MQLVisitor(NodeVisitor):  # type: ignore
         except Exception as e:
             raise e
 
-    def visit_expression(self, node: Node, children: Sequence[Any]) -> Any:
+    def visit_expression(
+        self, node: Node, children: Sequence[Any]
+    ) -> Union[Formula, Timeseries, float, int, str]:
         """
         Top level node, simply returns the expression.
         """
@@ -154,7 +156,7 @@ class MQLVisitor(NodeVisitor):  # type: ignore
                 _, expr_operator, _, term_right, *_ = zero_or_more
                 term_left = Formula(expr_operator, [term_left, term_right])
 
-        return term_left
+        return cast(Union[Formula, Timeseries, float, int, str], term_left)
 
     def visit_expr_op(self, node: Node, children: Sequence[Any]) -> Any:
         return EXPRESSION_OPERATORS[node.text]
@@ -176,7 +178,7 @@ class MQLVisitor(NodeVisitor):  # type: ignore
                     term_operator, [coefficient_left, coefficient_right]
                 )
 
-        return coefficient_left
+        return cast(Union[Formula, Timeseries, float, int, str], coefficient_left)
 
     def visit_term_op(self, node: Node, children: Sequence[Any]) -> Any:
         return TERM_OPERATORS[node.text]

--- a/tests/test_mql.py
+++ b/tests/test_mql.py
@@ -574,6 +574,19 @@ base_tests = [
         ),
         id="test terms with crazy characters",
     ),
+    pytest.param(
+        'count(c:custom/page_click@none) + max(d:custom/app_load@millisecond) / count(c:custom/page_click@none)',
+        Formula(function_name='plus',
+                parameters=[Timeseries(metric=Metric(mri='c:custom/page_click@none', ),
+                                       aggregate='count', ),
+                            Formula(function_name='divide',
+                                    parameters=[Timeseries(metric=Metric(mri='d:custom/app_load@millisecond', ),
+                                                           aggregate='max', ),
+                                                Timeseries(metric=Metric(
+                                                    mri='c:custom/page_click@none', ),
+                                                    aggregate='count', )], )], ),
+        id="test expression with precedence",
+    ),
 ]
 
 
@@ -977,7 +990,7 @@ arbitrary_function_tests = [
 
 @pytest.mark.parametrize("mql_string, metrics_query", arbitrary_function_tests)
 def test_parse_mql_arbitrary_functions(
-    mql_string: str, metrics_query: Formula | Timeseries
+        mql_string: str, metrics_query: Formula | Timeseries
 ) -> None:
     result = parse_mql(mql_string)
     assert result == metrics_query
@@ -1132,7 +1145,7 @@ curried_arbitrary_function_tests = [
 
 @pytest.mark.parametrize("mql_string, metrics_query", curried_arbitrary_function_tests)
 def test_parse_mql_curried_arbitrary_functions(
-    mql_string: str, metrics_query: Formula | Timeseries
+        mql_string: str, metrics_query: Formula | Timeseries
 ) -> None:
     result = parse_mql(mql_string)
     assert result == metrics_query

--- a/tests/test_mql.py
+++ b/tests/test_mql.py
@@ -830,6 +830,31 @@ term_tests = [
         ),
         id="test expression with precedence",
     ),
+pytest.param(
+        "count(c:custom/page_click@none) + max(d:custom/app_load@millisecond) + count(c:custom/page_click@none)",
+        Formula(
+            function_name=ArithmeticOperator.PLUS.value,
+            parameters=[
+                Formula(
+                    function_name=ArithmeticOperator.PLUS.value,
+                    parameters=[
+                        Timeseries(
+                            metric=Metric(mri="c:custom/page_click@none"),
+                            aggregate="count",
+                        ),
+                        Timeseries(
+                            metric=Metric(mri="d:custom/app_load@millisecond"),
+                            aggregate="max",
+                        ),
+                    ],
+                ),
+                Timeseries(
+                    metric=Metric(mri="c:custom/page_click@none"), aggregate="count"
+                ),
+            ],
+        ),
+        id="test expression with associativity",
+    )
 ]
 
 

--- a/tests/test_mql.py
+++ b/tests/test_mql.py
@@ -574,31 +574,6 @@ base_tests = [
         ),
         id="test terms with crazy characters",
     ),
-    pytest.param(
-        "count(c:custom/page_click@none) + max(d:custom/app_load@millisecond) / count(c:custom/page_click@none)",
-        Formula(
-            function_name=ArithmeticOperator.PLUS.value,
-            parameters=[
-                Timeseries(
-                    metric=Metric(mri="c:custom/page_click@none"), aggregate="count"
-                ),
-                Formula(
-                    function_name=ArithmeticOperator.DIVIDE.value,
-                    parameters=[
-                        Timeseries(
-                            metric=Metric(mri="d:custom/app_load@millisecond"),
-                            aggregate="max",
-                        ),
-                        Timeseries(
-                            metric=Metric(mri="c:custom/page_click@none"),
-                            aggregate="count",
-                        ),
-                    ],
-                ),
-            ],
-        ),
-        id="test expression with precedence",
-    ),
 ]
 
 
@@ -799,9 +774,9 @@ term_tests = [
         id="test terms with groupby 5",
     ),
     pytest.param(
-        '((sum(foo{tag:"tag_value"}){tag2:"tag_value2"} / sum(bar)){tag3:"tag_value3"} * sum(pop)) by transaction',
+        '((sum(foo{tag:"tag_value"}){tag2:"tag_value2"} / sum(bar)){tag3:"tag_value3"} + sum(pop)) by transaction',
         Formula(
-            function_name=ArithmeticOperator.MULTIPLY.value,
+            function_name=ArithmeticOperator.PLUS.value,
             parameters=[
                 Formula(
                     ArithmeticOperator.DIVIDE.value,
@@ -829,6 +804,31 @@ term_tests = [
             groupby=[Column("transaction")],
         ),
         id="test complex nested terms",
+    ),
+    pytest.param(
+        "count(c:custom/page_click@none) + max(d:custom/app_load@millisecond) / count(c:custom/page_click@none)",
+        Formula(
+            function_name=ArithmeticOperator.PLUS.value,
+            parameters=[
+                Timeseries(
+                    metric=Metric(mri="c:custom/page_click@none"), aggregate="count"
+                ),
+                Formula(
+                    function_name=ArithmeticOperator.DIVIDE.value,
+                    parameters=[
+                        Timeseries(
+                            metric=Metric(mri="d:custom/app_load@millisecond"),
+                            aggregate="max",
+                        ),
+                        Timeseries(
+                            metric=Metric(mri="c:custom/page_click@none"),
+                            aggregate="count",
+                        ),
+                    ],
+                ),
+            ],
+        ),
+        id="test expression with precedence",
     ),
 ]
 

--- a/tests/test_mql.py
+++ b/tests/test_mql.py
@@ -577,13 +577,13 @@ base_tests = [
     pytest.param(
         "count(c:custom/page_click@none) + max(d:custom/app_load@millisecond) / count(c:custom/page_click@none)",
         Formula(
-            function_name="plus",
+            function_name=ArithmeticOperator.PLUS.value,
             parameters=[
                 Timeseries(
                     metric=Metric(mri="c:custom/page_click@none"), aggregate="count"
                 ),
                 Formula(
-                    function_name="divide",
+                    function_name=ArithmeticOperator.DIVIDE.value,
                     parameters=[
                         Timeseries(
                             metric=Metric(mri="d:custom/app_load@millisecond"),

--- a/tests/test_mql.py
+++ b/tests/test_mql.py
@@ -830,7 +830,7 @@ term_tests = [
         ),
         id="test expression with precedence",
     ),
-pytest.param(
+    pytest.param(
         "count(c:custom/page_click@none) + max(d:custom/app_load@millisecond) + count(c:custom/page_click@none)",
         Formula(
             function_name=ArithmeticOperator.PLUS.value,
@@ -854,7 +854,7 @@ pytest.param(
             ],
         ),
         id="test expression with associativity",
-    )
+    ),
 ]
 
 

--- a/tests/test_mql.py
+++ b/tests/test_mql.py
@@ -575,16 +575,28 @@ base_tests = [
         id="test terms with crazy characters",
     ),
     pytest.param(
-        'count(c:custom/page_click@none) + max(d:custom/app_load@millisecond) / count(c:custom/page_click@none)',
-        Formula(function_name='plus',
-                parameters=[Timeseries(metric=Metric(mri='c:custom/page_click@none', ),
-                                       aggregate='count', ),
-                            Formula(function_name='divide',
-                                    parameters=[Timeseries(metric=Metric(mri='d:custom/app_load@millisecond', ),
-                                                           aggregate='max', ),
-                                                Timeseries(metric=Metric(
-                                                    mri='c:custom/page_click@none', ),
-                                                    aggregate='count', )], )], ),
+        "count(c:custom/page_click@none) + max(d:custom/app_load@millisecond) / count(c:custom/page_click@none)",
+        Formula(
+            function_name="plus",
+            parameters=[
+                Timeseries(
+                    metric=Metric(mri="c:custom/page_click@none"), aggregate="count"
+                ),
+                Formula(
+                    function_name="divide",
+                    parameters=[
+                        Timeseries(
+                            metric=Metric(mri="d:custom/app_load@millisecond"),
+                            aggregate="max",
+                        ),
+                        Timeseries(
+                            metric=Metric(mri="c:custom/page_click@none"),
+                            aggregate="count",
+                        ),
+                    ],
+                ),
+            ],
+        ),
         id="test expression with precedence",
     ),
 ]
@@ -990,7 +1002,7 @@ arbitrary_function_tests = [
 
 @pytest.mark.parametrize("mql_string, metrics_query", arbitrary_function_tests)
 def test_parse_mql_arbitrary_functions(
-        mql_string: str, metrics_query: Formula | Timeseries
+    mql_string: str, metrics_query: Formula | Timeseries
 ) -> None:
     result = parse_mql(mql_string)
     assert result == metrics_query
@@ -1145,7 +1157,7 @@ curried_arbitrary_function_tests = [
 
 @pytest.mark.parametrize("mql_string, metrics_query", curried_arbitrary_function_tests)
 def test_parse_mql_curried_arbitrary_functions(
-        mql_string: str, metrics_query: Formula | Timeseries
+    mql_string: str, metrics_query: Formula | Timeseries
 ) -> None:
     result = parse_mql(mql_string)
     assert result == metrics_query


### PR DESCRIPTION
This PR fixes the missing implementation of the `expression` visitor that didn't generate the right AST for summations and subtractions. In addition, it implements the correct left associativity of both `expression` and `term`.