### PR TITLE
feat(mql): Remove entity from Metrics SDK

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,10 +1,17 @@
 Changelog and versioning
 ==========================
 
+2.0.27
+------
+- Remove the entity field from the MQLContext
+    - This also fixes a bug with using formulas in raw MQL
+
+
 2.0.26
 ------
 - Support multiple entities in MQL Context
 - Support MQL strings as a query
+
 
 2.0.25
 ------

--- a/README.md
+++ b/README.md
@@ -84,7 +84,6 @@ The other arguments to the `MetricsQuery` are meta data about how to run the que
                 Timeseries(
                     metric=Metric(
                         public_name="transaction.duration",
-                        entity="generic_metrics_distributions",
                     ),
                     aggregate="sum",
                 ),

--- a/README.rst
+++ b/README.rst
@@ -118,7 +118,6 @@ The other arguments to the ``MetricsQuery`` are meta data about how to run the q
                 Timeseries(
                     metric=Metric(
                         public_name="transaction.duration",
-                        entity="generic_metrics_distributions",
                     ),
                     aggregate="sum",
                 ),

--- a/snuba_sdk/formula.py
+++ b/snuba_sdk/formula.py
@@ -44,13 +44,13 @@ class Formula:
 
     def __validate_consistency(self) -> None:
         """
-        Ensure that the entity and groupby columns are consistent across all Timeseries
+        Ensure that the groupby columns are consistent across all Timeseries
         and Formulas within this Formula."""
         if self.parameters is None:
             raise InvalidFormulaError("Formula must have parameters")
 
-        entities: set[str] = set()
         groupbys = set()
+        has_timeseries = False
 
         stack: list[FormulaParameterGroup] = [self]
         while stack:
@@ -62,13 +62,14 @@ class Formula:
                 if param.parameters:
                     stack.extend(param.parameters)
             elif isinstance(param, Timeseries):
-                if param.metric.entity is not None:
-                    entities.add(param.metric.entity)
+                has_timeseries = True
                 if param.groupby is not None:
                     groupbys.add(tuple(param.groupby))
 
-        if len(entities) != 1:
-            raise InvalidFormulaError("Formulas must operate on a single entity")
+        if not has_timeseries:
+            raise InvalidFormulaError(
+                "Formulas must operate on at least one Timeseries"
+            )
         if len(set(groupbys)) > 1:
             raise InvalidFormulaError(
                 "Formula parameters must group by the same columns"

--- a/snuba_sdk/mql_context.py
+++ b/snuba_sdk/mql_context.py
@@ -22,9 +22,6 @@ class MQLContext:
     should be created exclusively from a valid MetricsQuery object.
     """
 
-    entity: dict[
-        str, str
-    ]  # mapping between metric name (mri or public_name) and entity
     start: str
     end: str
     rollup: dict[str, str | int | None]
@@ -38,7 +35,7 @@ class MQLContext:
 
     def validate(self) -> None:
         # Simple assert that all the expected fields are present
-        fields = ["entity", "start", "end", "rollup", "scope", "indexer_mappings"]
+        fields = ["start", "end", "rollup", "scope", "indexer_mappings"]
         for field in fields:
             if getattr(self, field) is None:
                 raise InvalidMQLContextError(f"MQLContext.{field} is required")

--- a/snuba_sdk/mql_visitor.py
+++ b/snuba_sdk/mql_visitor.py
@@ -39,7 +39,7 @@ class MQLVisitor(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def _visit_query(self, query: Timeseries | None) -> Mapping[str, Any]:
+    def _visit_query(self, query: Timeseries | None) -> str:
         raise NotImplementedError
 
     @abstractmethod
@@ -84,10 +84,9 @@ class MQLPrinter(MQLVisitor):
     def _combine(
         self, query: main.MetricsQuery, returns: Mapping[str, Any]
     ) -> dict[str, Any]:
-        assert isinstance(returns["query"], Mapping)  # mypy
-        mql_string = returns["query"]["mql_string"]
+        assert isinstance(returns["query"], str)  # mypy
+        mql_string = returns["query"]
         mql_context = MQLContext(
-            entity=returns["query"]["entity"],
             start=returns["start"],
             end=returns["end"],
             rollup=returns["rollup"],
@@ -101,9 +100,7 @@ class MQLPrinter(MQLVisitor):
             "mql_context": asdict(mql_context),
         }
 
-    def _visit_query(
-        self, query: Timeseries | Formula | str | None
-    ) -> Mapping[str, str | Mapping[str, str]]:
+    def _visit_query(self, query: Timeseries | Formula | str | None) -> str:
         if query is None:
             raise InvalidMetricsQueryError("MetricQuery.query must not be None")
         elif isinstance(query, Formula):

--- a/snuba_sdk/timeseries.py
+++ b/snuba_sdk/timeseries.py
@@ -29,7 +29,6 @@ class Metric:
     public_name: str | None = None
     mri: str | None = None
     id: int | None = None
-    entity: str | None = None
 
     def __post_init__(self) -> None:
         self.validate()
@@ -45,8 +44,6 @@ class Metric:
             raise InvalidTimeseriesError("mri must be a string")
         if self.id is not None and not isinstance(self.id, int):
             raise InvalidTimeseriesError("id must be an integer")
-        if self.entity is not None and not isinstance(self.entity, str):
-            raise InvalidTimeseriesError("entity must be a string")
 
         if all(v is None for v in (self.public_name, self.mri)):
             raise InvalidTimeseriesError(
@@ -67,11 +64,6 @@ class Metric:
         if not isinstance(id, int):
             raise InvalidExpressionError("id must be an int")
         return replace(self, id=id)
-
-    def set_entity(self, entity: str) -> Metric:
-        if not isinstance(entity, str):
-            raise InvalidExpressionError("entity must be an str")
-        return replace(self, entity=entity)
 
 
 @dataclass

--- a/tests/test_formula.py
+++ b/tests/test_formula.py
@@ -25,7 +25,7 @@ tests = [
             ArithmeticOperator.PLUS.value,
             [
                 Timeseries(
-                    metric=Metric(public_name="foo", entity="metrics_sets"),
+                    metric=Metric(public_name="foo"),
                     aggregate="sum",
                 ),
                 1,
@@ -41,7 +41,7 @@ tests = [
             ArithmeticOperator.PLUS.value,
             [
                 Timeseries(
-                    metric=Metric(public_name="foo", entity="metrics_sets"),
+                    metric=Metric(public_name="foo"),
                     aggregate="sum",
                 ),
                 1,
@@ -57,7 +57,7 @@ tests = [
             ArithmeticOperator.PLUS.value,
             [
                 Timeseries(
-                    metric=Metric(public_name="foo", entity="metrics_sets"),
+                    metric=Metric(public_name="foo"),
                     aggregate="sum",
                 ),
                 1,
@@ -73,11 +73,11 @@ tests = [
             ArithmeticOperator.PLUS.value,
             [
                 Timeseries(
-                    metric=Metric(public_name="foo", entity="metrics_sets"),
+                    metric=Metric(public_name="foo"),
                     aggregate="sum",
                 ),
                 Timeseries(
-                    metric=Metric(public_name="bar", entity="metrics_sets"),
+                    metric=Metric(public_name="bar"),
                     aggregate="sum",
                 ),
             ],
@@ -92,12 +92,12 @@ tests = [
             ArithmeticOperator.DIVIDE.value,
             [
                 Timeseries(
-                    metric=Metric(public_name="foo", entity="metrics_sets"),
+                    metric=Metric(public_name="foo"),
                     aggregate="sum",
                     groupby=[Column("transaction")],
                 ),
                 Timeseries(
-                    metric=Metric(public_name="foo", entity="metrics_sets"),
+                    metric=Metric(public_name="foo"),
                     aggregate="avg",
                     groupby=[Column("transaction")],
                 ),
@@ -111,7 +111,7 @@ tests = [
             42,
             [
                 Timeseries(
-                    metric=Metric(public_name="foo", entity="metrics_sets"),
+                    metric=Metric(public_name="foo"),
                     aggregate="sum",
                 ),
                 1,
@@ -132,7 +132,7 @@ tests = [
             ArithmeticOperator.MULTIPLY.value,
             [
                 Timeseries(
-                    metric=Metric(public_name="foo", entity="metrics_sets"),
+                    metric=Metric(public_name="foo"),
                     aggregate="sum",
                 ),
                 "foo",
@@ -152,7 +152,6 @@ tests = [
                         "transaction.duration",
                         "d:transactions/duration@millisecond",
                         1123,
-                        "metrics_sets",
                     ),
                     aggregate="sum",
                     filters=[Condition(Column("tags[referrer]"), Op.EQ, "foo")],
@@ -163,40 +162,6 @@ tests = [
                         "transaction.duration",
                         "d:transactions/duration@millisecond",
                         123,
-                        "metrics_distributions",
-                    ),
-                    aggregate="sum",
-                    filters=[Condition(Column("tags[referrer]"), Op.EQ, "bar")],
-                    groupby=[Column("tags[status_code]")],
-                ),
-            ],
-            [Condition(Column("tags[status_code]"), Op.EQ, 200)],
-            [Column("tags[release]")],
-        ),
-        InvalidFormulaError("Formulas must operate on a single entity"),
-        id="different entities",
-    ),
-    pytest.param(
-        formula(
-            ArithmeticOperator.PLUS.value,
-            [
-                Timeseries(
-                    metric=Metric(
-                        "transaction.duration",
-                        "d:transactions/duration@millisecond",
-                        1123,
-                        "metrics_sets",
-                    ),
-                    aggregate="sum",
-                    filters=[Condition(Column("tags[referrer]"), Op.EQ, "foo")],
-                    groupby=[Column("tags[status_code]")],
-                ),
-                Timeseries(
-                    metric=Metric(
-                        "transaction.duration",
-                        "d:transactions/duration@millisecond",
-                        123,
-                        "metrics_sets",
                     ),
                     aggregate="sum",
                     filters=[Condition(Column("tags[referrer]"), Op.EQ, "bar")],
@@ -216,7 +181,7 @@ tests = [
             [Condition(Column("tags[status_code]"), Op.EQ, 200)],
             [Column("tags[release]")],
         ),
-        InvalidFormulaError("Formulas must operate on a single entity"),
+        InvalidFormulaError("Formulas must operate on at least one Timeseries"),
         id="no simple math",
     ),
 ]
@@ -246,7 +211,6 @@ formula_mql_tests = [
                         "transaction.duration",
                         "d:transactions/duration@millisecond",
                         1123,
-                        "metrics_sets",
                     ),
                     aggregate="sum",
                     filters=[Condition(Column("tags[referrer]"), Op.EQ, "foo")],
@@ -256,10 +220,7 @@ formula_mql_tests = [
             None,
             None,
         ),
-        {
-            "entity": {"d:transactions/duration@millisecond": "metrics_sets"},
-            "mql_string": '(sum(d:transactions/duration@millisecond){tags[referrer]:"foo"} * 100)',
-        },
+        '(sum(d:transactions/duration@millisecond){tags[referrer]:"foo"} * 100)',
         None,
         id="basic formula",
     ),
@@ -272,7 +233,6 @@ formula_mql_tests = [
                         "transaction.duration",
                         "d:transactions/duration@millisecond",
                         1123,
-                        "metrics_sets",
                     ),
                     aggregate="sum",
                     filters=[Condition(Column("tags[referrer]"), Op.EQ, "foo")],
@@ -282,7 +242,6 @@ formula_mql_tests = [
                         "transaction.duration",
                         "d:transactions/duration@millisecond",
                         123,
-                        "metrics_sets",
                     ),
                     aggregate="sum",
                     filters=[Condition(Column("tags[referrer]"), Op.EQ, "bar")],
@@ -291,10 +250,7 @@ formula_mql_tests = [
             None,
             None,
         ),
-        {
-            "entity": {"d:transactions/duration@millisecond": "metrics_sets"},
-            "mql_string": '(sum(d:transactions/duration@millisecond){tags[referrer]:"foo"} + sum(d:transactions/duration@millisecond){tags[referrer]:"bar"})',
-        },
+        '(sum(d:transactions/duration@millisecond){tags[referrer]:"foo"} + sum(d:transactions/duration@millisecond){tags[referrer]:"bar"})',
         None,
         id="basic timeseries formula",
     ),
@@ -307,7 +263,6 @@ formula_mql_tests = [
                         "transaction.duration",
                         "d:transactions/duration@millisecond",
                         1123,
-                        "metrics_sets",
                     ),
                     aggregate="sum",
                     filters=[Condition(Column("tags[referrer]"), Op.EQ, "foo")],
@@ -317,7 +272,6 @@ formula_mql_tests = [
                         "transaction.duration",
                         "d:transactions/duration@millisecond",
                         123,
-                        "metrics_sets",
                     ),
                     aggregate="sum",
                     filters=[Condition(Column("tags[referrer]"), Op.EQ, "bar")],
@@ -326,10 +280,7 @@ formula_mql_tests = [
             [Condition(Column("tags[status_code]"), Op.EQ, 200)],
             None,
         ),
-        {
-            "entity": {"d:transactions/duration@millisecond": "metrics_sets"},
-            "mql_string": '(sum(d:transactions/duration@millisecond){tags[referrer]:"foo"} + sum(d:transactions/duration@millisecond){tags[referrer]:"bar"}){tags[status_code]:200}',
-        },
+        '(sum(d:transactions/duration@millisecond){tags[referrer]:"foo"} + sum(d:transactions/duration@millisecond){tags[referrer]:"bar"}){tags[status_code]:200}',
         None,
         id="formula with filters",
     ),
@@ -342,7 +293,6 @@ formula_mql_tests = [
                         "transaction.duration",
                         "d:transactions/duration@millisecond",
                         1123,
-                        "metrics_sets",
                     ),
                     aggregate="sum",
                     filters=[Condition(Column("tags[referrer]"), Op.EQ, "foo")],
@@ -353,7 +303,6 @@ formula_mql_tests = [
                         "transaction.duration",
                         "d:transactions/duration@millisecond",
                         123,
-                        "metrics_sets",
                     ),
                     aggregate="sum",
                     filters=[Condition(Column("tags[referrer]"), Op.EQ, "bar")],
@@ -363,10 +312,7 @@ formula_mql_tests = [
             [Condition(Column("tags[status_code]"), Op.EQ, 200)],
             [Column("tags[release]")],
         ),
-        {
-            "entity": {"d:transactions/duration@millisecond": "metrics_sets"},
-            "mql_string": '(sum(d:transactions/duration@millisecond){tags[referrer]:"foo"} by (tags[status_code]) + sum(d:transactions/duration@millisecond){tags[referrer]:"bar"} by (tags[status_code])){tags[status_code]:200} by (tags[release])',
-        },
+        '(sum(d:transactions/duration@millisecond){tags[referrer]:"foo"} by (tags[status_code]) + sum(d:transactions/duration@millisecond){tags[referrer]:"bar"} by (tags[status_code])){tags[status_code]:200} by (tags[release])',
         None,
         id="group bys",
     ),
@@ -379,7 +325,7 @@ TRANSLATOR = FormulaMQLPrinter()
 @pytest.mark.parametrize("formula_func, translated, exception", formula_mql_tests)
 def test_formula_translate(
     formula_func: Callable[[], Any],
-    translated: dict[str, str],
+    translated: str,
     exception: Optional[Exception],
 ) -> None:
     if exception is not None:

--- a/tests/test_formula_printer.py
+++ b/tests/test_formula_printer.py
@@ -15,9 +15,7 @@ formula_tests = [
             ArithmeticOperator.DIVIDE.value,
             [
                 Timeseries(
-                    metric=Metric(
-                        public_name="foo", entity="generic_metrics_distributions"
-                    ),
+                    metric=Metric(public_name="foo"),
                     aggregate="sum",
                 ),
                 1000,
@@ -31,15 +29,11 @@ formula_tests = [
             ArithmeticOperator.MULTIPLY.value,
             [
                 Timeseries(
-                    metric=Metric(
-                        public_name="foo", entity="generic_metrics_distributions"
-                    ),
+                    metric=Metric(public_name="foo"),
                     aggregate="sum",
                 ),
                 Timeseries(
-                    metric=Metric(
-                        public_name="bar", entity="generic_metrics_distributions"
-                    ),
+                    metric=Metric(public_name="bar"),
                     aggregate="max",
                 ),
             ],
@@ -55,17 +49,11 @@ formula_tests = [
                     ArithmeticOperator.MULTIPLY.value,
                     [
                         Timeseries(
-                            metric=Metric(
-                                public_name="foo",
-                                entity="generic_metrics_distributions",
-                            ),
+                            metric=Metric(public_name="foo"),
                             aggregate="sum",
                         ),
                         Timeseries(
-                            metric=Metric(
-                                public_name="bar",
-                                entity="generic_metrics_distributions",
-                            ),
+                            metric=Metric(public_name="bar"),
                             aggregate="sum",
                         ),
                     ],
@@ -81,15 +69,11 @@ formula_tests = [
             ArithmeticOperator.DIVIDE.value,
             [
                 Timeseries(
-                    metric=Metric(
-                        public_name="foo", entity="generic_metrics_distributions"
-                    ),
+                    metric=Metric(public_name="foo"),
                     aggregate="sum",
                 ),
                 Timeseries(
-                    metric=Metric(
-                        public_name="bar", entity="generic_metrics_distributions"
-                    ),
+                    metric=Metric(public_name="bar"),
                     aggregate="sum",
                 ),
             ],
@@ -103,16 +87,12 @@ formula_tests = [
             ArithmeticOperator.DIVIDE.value,
             [
                 Timeseries(
-                    metric=Metric(
-                        public_name="foo", entity="generic_metrics_distributions"
-                    ),
+                    metric=Metric(public_name="foo"),
                     aggregate="sum",
                     filters=[Condition(Column("tag"), Op.EQ, "tag_value")],
                 ),
                 Timeseries(
-                    metric=Metric(
-                        public_name="bar", entity="generic_metrics_distributions"
-                    ),
+                    metric=Metric(public_name="bar"),
                     aggregate="sum",
                     filters=[Condition(Column("tag"), Op.EQ, "tag_value")],
                 ),
@@ -126,15 +106,11 @@ formula_tests = [
             ArithmeticOperator.DIVIDE.value,
             [
                 Timeseries(
-                    metric=Metric(
-                        public_name="foo", entity="generic_metrics_distributions"
-                    ),
+                    metric=Metric(public_name="foo"),
                     aggregate="sum",
                 ),
                 Timeseries(
-                    metric=Metric(
-                        public_name="bar", entity="generic_metrics_distributions"
-                    ),
+                    metric=Metric(public_name="bar"),
                     aggregate="sum",
                 ),
             ],
@@ -149,16 +125,12 @@ formula_tests = [
             ArithmeticOperator.DIVIDE.value,
             [
                 Timeseries(
-                    metric=Metric(
-                        public_name="foo", entity="generic_metrics_distributions"
-                    ),
+                    metric=Metric(public_name="foo"),
                     aggregate="sum",
                     groupby=[Column("transaction")],
                 ),
                 Timeseries(
-                    metric=Metric(
-                        public_name="bar", entity="generic_metrics_distributions"
-                    ),
+                    metric=Metric(public_name="bar"),
                     aggregate="sum",
                     groupby=[Column("transaction")],
                 ),
@@ -172,16 +144,12 @@ formula_tests = [
             ArithmeticOperator.DIVIDE.value,
             [
                 Timeseries(
-                    metric=Metric(
-                        public_name="foo", entity="generic_metrics_distributions"
-                    ),
+                    metric=Metric(public_name="foo"),
                     aggregate="sum",
                     groupby=[Column("transaction")],
                 ),
                 Timeseries(
-                    metric=Metric(
-                        public_name="bar", entity="generic_metrics_distributions"
-                    ),
+                    metric=Metric(public_name="bar"),
                     aggregate="sum",
                     groupby=[Column("transaction")],
                 ),
@@ -196,17 +164,13 @@ formula_tests = [
             ArithmeticOperator.DIVIDE.value,
             [
                 Timeseries(
-                    metric=Metric(
-                        public_name="foo", entity="generic_metrics_distributions"
-                    ),
+                    metric=Metric(public_name="foo"),
                     aggregate="sum",
                     filters=[Condition(Column("tag"), Op.EQ, "tag_value")],
                     groupby=[Column("transaction")],
                 ),
                 Timeseries(
-                    metric=Metric(
-                        public_name="bar", entity="generic_metrics_distributions"
-                    ),
+                    metric=Metric(public_name="bar"),
                     aggregate="sum",
                     filters=[Condition(Column("tag"), Op.EQ, "tag_value")],
                     groupby=[Column("transaction")],
@@ -221,15 +185,11 @@ formula_tests = [
             ArithmeticOperator.DIVIDE.value,
             [
                 Timeseries(
-                    metric=Metric(
-                        public_name="foo", entity="generic_metrics_distributions"
-                    ),
+                    metric=Metric(public_name="foo"),
                     aggregate="sum",
                 ),
                 Timeseries(
-                    metric=Metric(
-                        public_name="bar", entity="generic_metrics_distributions"
-                    ),
+                    metric=Metric(public_name="bar"),
                     aggregate="sum",
                 ),
             ],
@@ -247,10 +207,7 @@ formula_tests = [
                     ArithmeticOperator.DIVIDE.value,
                     [
                         Timeseries(
-                            metric=Metric(
-                                public_name="foo",
-                                entity="generic_metrics_distributions",
-                            ),
+                            metric=Metric(public_name="foo"),
                             aggregate="sum",
                             filters=[
                                 Condition(Column("tag2"), Op.EQ, "tag_value2"),
@@ -258,19 +215,14 @@ formula_tests = [
                             ],
                         ),
                         Timeseries(
-                            metric=Metric(
-                                public_name="bar",
-                                entity="generic_metrics_distributions",
-                            ),
+                            metric=Metric(public_name="bar"),
                             aggregate="sum",
                         ),
                     ],
                     filters=[Condition(Column("tag3"), Op.EQ, "tag_value3")],
                 ),
                 Timeseries(
-                    metric=Metric(
-                        public_name="pop", entity="generic_metrics_distributions"
-                    ),
+                    metric=Metric(public_name="pop"),
                     aggregate="sum",
                 ),
             ],
@@ -287,10 +239,7 @@ formula_tests = [
                     ArithmeticOperator.DIVIDE.value,
                     [
                         Timeseries(
-                            metric=Metric(
-                                public_name="foo",
-                                entity="generic_metrics_distributions",
-                            ),
+                            metric=Metric(public_name="foo"),
                             aggregate="sum",
                             filters=[
                                 Condition(Column("tag2"), Op.EQ, "tag_value2"),
@@ -303,19 +252,14 @@ formula_tests = [
                             ],
                         ),
                         Timeseries(
-                            metric=Metric(
-                                public_name="bar",
-                                entity="generic_metrics_distributions",
-                            ),
+                            metric=Metric(public_name="bar"),
                             aggregate="sum",
                         ),
                     ],
                     filters=[Condition(Column("tag3"), Op.EQ, "tag_value3")],
                 ),
                 Timeseries(
-                    metric=Metric(
-                        public_name="pop", entity="generic_metrics_distributions"
-                    ),
+                    metric=Metric(public_name="pop"),
                     aggregate="sum",
                 ),
             ],
@@ -329,10 +273,7 @@ formula_tests = [
             function_name="apdex",
             parameters=[
                 Timeseries(
-                    metric=Metric(
-                        public_name="foo",
-                        entity="generic_metrics_distributions",
-                    ),
+                    metric=Metric(public_name="foo"),
                     aggregate="sum",
                 ),
                 500,
@@ -351,17 +292,11 @@ formula_tests = [
                     function_name=ArithmeticOperator.DIVIDE.value,
                     parameters=[
                         Timeseries(
-                            metric=Metric(
-                                public_name="foo",
-                                entity="generic_metrics_distributions",
-                            ),
+                            metric=Metric(public_name="foo"),
                             aggregate="sum",
                         ),
                         Timeseries(
-                            metric=Metric(
-                                public_name="bar",
-                                entity="generic_metrics_distributions",
-                            ),
+                            metric=Metric(public_name="bar"),
                             aggregate="sum",
                         ),
                     ],
@@ -379,10 +314,7 @@ formula_tests = [
             function_name="topK",
             parameters=[
                 Timeseries(
-                    metric=Metric(
-                        public_name="foo",
-                        entity="generic_metrics_distributions",
-                    ),
+                    metric=Metric(public_name="foo"),
                     aggregate="sum",
                 ),
                 500,
@@ -404,10 +336,7 @@ formula_tests = [
                     "apdex",
                     [
                         Timeseries(
-                            metric=Metric(
-                                public_name="foo",
-                                entity="generic_metrics_distributions",
-                            ),
+                            metric=Metric(public_name="foo"),
                             aggregate="sum",
                         ),
                         500,
@@ -417,10 +346,7 @@ formula_tests = [
                     "apdex",
                     [
                         Timeseries(
-                            metric=Metric(
-                                public_name="foo",
-                                entity="generic_metrics_distributions",
-                            ),
+                            metric=Metric(public_name="foo"),
                             aggregate="sum",
                         ),
                         400,
@@ -438,10 +364,7 @@ formula_tests = [
             "apdex",
             [
                 Timeseries(
-                    metric=Metric(
-                        public_name="foo",
-                        entity="generic_metrics_distributions",
-                    ),
+                    metric=Metric(public_name="foo"),
                     aggregate="quantiles",
                     aggregate_params=[0.5],
                 ),
@@ -460,9 +383,7 @@ FORMULA_PRINTER = FormulaMQLPrinter()
 
 @pytest.mark.parametrize("formula, mql", formula_tests)
 def test_metrics_query_to_mql_formula(formula: Formula, mql: str) -> None:
-    output = FORMULA_PRINTER.visit(formula)
-    mql_string = output["mql_string"]
-    assert isinstance(mql_string, str)
+    mql_string = FORMULA_PRINTER.visit(formula)
     assert mql_string == mql
 
     # TODO: We can't simply assert the whole query, because we need an Entity in order to serialize the formula,

--- a/tests/test_metrics_mql_query.py
+++ b/tests/test_metrics_mql_query.py
@@ -25,7 +25,6 @@ metrics_query_timeseries_to_mql_tests = [
             query=Timeseries(
                 metric=Metric(
                     mri="d:transactions/duration@millisecond",
-                    entity="generic_metrics_distributions",
                 ),
                 aggregate="max",
                 aggregate_params=None,
@@ -43,9 +42,6 @@ metrics_query_timeseries_to_mql_tests = [
         {
             "mql": "max(d:transactions/duration@millisecond)",
             "mql_context": {
-                "entity": {
-                    "d:transactions/duration@millisecond": "generic_metrics_distributions"
-                },
                 "start": "2023-01-02T03:04:05+00:00",
                 "end": "2023-01-16T03:04:05+00:00",
                 "rollup": {
@@ -71,7 +67,6 @@ metrics_query_timeseries_to_mql_tests = [
             query=Timeseries(
                 metric=Metric(
                     mri="d:transactions/duration@millisecond",
-                    entity="generic_metrics_distributions",
                 ),
                 aggregate="quantiles",
                 aggregate_params=[0.5],
@@ -89,9 +84,6 @@ metrics_query_timeseries_to_mql_tests = [
         {
             "mql": "quantiles(0.5)(d:transactions/duration@millisecond)",
             "mql_context": {
-                "entity": {
-                    "d:transactions/duration@millisecond": "generic_metrics_distributions"
-                },
                 "start": "2023-01-02T03:04:05+00:00",
                 "end": "2023-01-16T03:04:05+00:00",
                 "rollup": {
@@ -117,7 +109,6 @@ metrics_query_timeseries_to_mql_tests = [
             query=Timeseries(
                 metric=Metric(
                     mri="d:transactions/duration@millisecond",
-                    entity="generic_metrics_distributions",
                 ),
                 aggregate="topK",
                 aggregate_params=[10],
@@ -135,9 +126,6 @@ metrics_query_timeseries_to_mql_tests = [
         {
             "mql": "topK(10)(d:transactions/duration@millisecond)",
             "mql_context": {
-                "entity": {
-                    "d:transactions/duration@millisecond": "generic_metrics_distributions"
-                },
                 "start": "2023-01-02T03:04:05+00:00",
                 "end": "2023-01-16T03:04:05+00:00",
                 "rollup": {
@@ -163,7 +151,6 @@ metrics_query_timeseries_to_mql_tests = [
             query=Timeseries(
                 metric=Metric(
                     public_name="transactions.duration",
-                    entity="generic_metrics_distributions",
                 ),
                 aggregate="max",
                 aggregate_params=None,
@@ -181,7 +168,6 @@ metrics_query_timeseries_to_mql_tests = [
         {
             "mql": "max(transactions.duration)",
             "mql_context": {
-                "entity": {"transactions.duration": "generic_metrics_distributions"},
                 "start": "2023-01-02T03:04:05+00:00",
                 "end": "2023-01-16T03:04:05+00:00",
                 "rollup": {
@@ -207,7 +193,6 @@ metrics_query_timeseries_to_mql_tests = [
             query=Timeseries(
                 metric=Metric(
                     mri="d:transactions/duration@millisecond",
-                    entity="generic_metrics_distributions",
                 ),
                 aggregate="max",
                 aggregate_params=None,
@@ -225,9 +210,6 @@ metrics_query_timeseries_to_mql_tests = [
         {
             "mql": 'max(d:transactions/duration@millisecond){bar:"baz"}',
             "mql_context": {
-                "entity": {
-                    "d:transactions/duration@millisecond": "generic_metrics_distributions"
-                },
                 "start": "2023-01-02T03:04:05+00:00",
                 "end": "2023-01-16T03:04:05+00:00",
                 "rollup": {
@@ -253,7 +235,6 @@ metrics_query_timeseries_to_mql_tests = [
             query=Timeseries(
                 metric=Metric(
                     mri="d:transactions/duration@millisecond",
-                    entity="generic_metrics_distributions",
                 ),
                 aggregate="max",
                 aggregate_params=None,
@@ -271,9 +252,6 @@ metrics_query_timeseries_to_mql_tests = [
         {
             "mql": 'max(d:transactions/duration@millisecond){bar:["baz", "bap"]}',
             "mql_context": {
-                "entity": {
-                    "d:transactions/duration@millisecond": "generic_metrics_distributions"
-                },
                 "start": "2023-01-02T03:04:05+00:00",
                 "end": "2023-01-16T03:04:05+00:00",
                 "rollup": {
@@ -299,7 +277,6 @@ metrics_query_timeseries_to_mql_tests = [
             query=Timeseries(
                 metric=Metric(
                     mri="d:transactions/duration@millisecond",
-                    entity="generic_metrics_distributions",
                 ),
                 aggregate="max",
                 aggregate_params=None,
@@ -334,9 +311,6 @@ metrics_query_timeseries_to_mql_tests = [
         {
             "mql": 'max(d:transactions/duration@millisecond){bar:"baz" AND foo:"foz" AND (foo:"foz" OR hee:"hez" OR (foo:"foz" AND hee:"hez"))}',
             "mql_context": {
-                "entity": {
-                    "d:transactions/duration@millisecond": "generic_metrics_distributions"
-                },
                 "start": "2023-01-02T03:04:05+00:00",
                 "end": "2023-01-16T03:04:05+00:00",
                 "rollup": {
@@ -362,7 +336,6 @@ metrics_query_timeseries_to_mql_tests = [
             query=Timeseries(
                 metric=Metric(
                     mri="d:transactions/duration@millisecond",
-                    entity="generic_metrics_distributions",
                 ),
                 aggregate="max",
                 aggregate_params=None,
@@ -380,9 +353,6 @@ metrics_query_timeseries_to_mql_tests = [
         {
             "mql": "max(d:transactions/duration@millisecond) by (transaction)",
             "mql_context": {
-                "entity": {
-                    "d:transactions/duration@millisecond": "generic_metrics_distributions"
-                },
                 "start": "2023-01-02T03:04:05+00:00",
                 "end": "2023-01-16T03:04:05+00:00",
                 "rollup": {
@@ -408,7 +378,6 @@ metrics_query_timeseries_to_mql_tests = [
             query=Timeseries(
                 metric=Metric(
                     mri="d:transactions/duration@millisecond",
-                    entity="generic_metrics_distributions",
                 ),
                 aggregate="max",
                 aggregate_params=None,
@@ -426,9 +395,6 @@ metrics_query_timeseries_to_mql_tests = [
         {
             "mql": "max(d:transactions/duration@millisecond) by (a, b)",
             "mql_context": {
-                "entity": {
-                    "d:transactions/duration@millisecond": "generic_metrics_distributions"
-                },
                 "start": "2023-01-02T03:04:05+00:00",
                 "end": "2023-01-16T03:04:05+00:00",
                 "rollup": {
@@ -454,7 +420,6 @@ metrics_query_timeseries_to_mql_tests = [
             query=Timeseries(
                 metric=Metric(
                     mri="d:transactions/duration@millisecond",
-                    entity="generic_metrics_distributions",
                 ),
                 aggregate="max",
                 aggregate_params=None,
@@ -474,9 +439,6 @@ metrics_query_timeseries_to_mql_tests = [
         {
             "mql": 'max(d:transactions/duration@millisecond){bar:"baz"} by (transaction)',
             "mql_context": {
-                "entity": {
-                    "d:transactions/duration@millisecond": "generic_metrics_distributions"
-                },
                 "start": "2023-01-02T03:04:05+00:00",
                 "end": "2023-01-16T03:04:05+00:00",
                 "rollup": {
@@ -502,7 +464,6 @@ metrics_query_timeseries_to_mql_tests = [
             query=Timeseries(
                 metric=Metric(
                     mri="d:transactions/duration@millisecond",
-                    entity="generic_metrics_distributions",
                 ),
                 aggregate="max",
                 aggregate_params=None,
@@ -528,9 +489,6 @@ metrics_query_timeseries_to_mql_tests = [
         {
             "mql": 'max(d:transactions/duration@millisecond){bar:" !\\"#$%&\'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\\\]^_`abcdefghijklmnopqrstuvwxyz{|}~"} by (transaction)',
             "mql_context": {
-                "entity": {
-                    "d:transactions/duration@millisecond": "generic_metrics_distributions"
-                },
                 "start": "2023-01-02T03:04:05+00:00",
                 "end": "2023-01-16T03:04:05+00:00",
                 "rollup": {
@@ -567,9 +525,6 @@ metrics_query_timeseries_to_mql_tests = [
         {
             "mql": 'sum(transaction.duration){status_code:"500"} by (transaction)',
             "mql_context": {
-                "entity": {
-                    "transaction.duration": None,
-                },
                 "start": "2023-01-02T03:04:05+00:00",
                 "end": "2023-01-16T03:04:05+00:00",
                 "rollup": {
@@ -639,9 +594,7 @@ metrics_query_formula_to_mql_tests = [
                 ArithmeticOperator.DIVIDE.value,
                 [
                     Timeseries(
-                        metric=Metric(
-                            public_name="foo", entity="generic_metrics_distributions"
-                        ),
+                        metric=Metric(public_name="foo"),
                         aggregate="sum",
                     ),
                     1000,
@@ -660,7 +613,6 @@ metrics_query_formula_to_mql_tests = [
         {
             "mql": "(sum(foo) / 1000)",
             "mql_context": {
-                "entity": {"foo": "generic_metrics_distributions"},
                 "start": "2023-01-02T03:04:05+00:00",
                 "end": "2023-01-16T03:04:05+00:00",
                 "rollup": {
@@ -687,9 +639,7 @@ metrics_query_formula_to_mql_tests = [
                 "apdex",
                 [
                     Timeseries(
-                        metric=Metric(
-                            public_name="foo", entity="generic_metrics_distributions"
-                        ),
+                        metric=Metric(public_name="foo"),
                         aggregate="sum",
                     ),
                     1000,
@@ -708,7 +658,6 @@ metrics_query_formula_to_mql_tests = [
         {
             "mql": "apdex(sum(foo), 1000)",
             "mql_context": {
-                "entity": {"foo": "generic_metrics_distributions"},
                 "start": "2023-01-02T03:04:05+00:00",
                 "end": "2023-01-16T03:04:05+00:00",
                 "rollup": {
@@ -735,9 +684,7 @@ metrics_query_formula_to_mql_tests = [
                 "apdex",
                 [
                     Timeseries(
-                        metric=Metric(
-                            public_name="foo", entity="generic_metrics_distributions"
-                        ),
+                        metric=Metric(public_name="foo"),
                         aggregate="quantiles",
                         aggregate_params=[0.5],
                     ),
@@ -757,7 +704,6 @@ metrics_query_formula_to_mql_tests = [
         {
             "mql": "apdex(quantiles(0.5)(foo), 1000)",
             "mql_context": {
-                "entity": {"foo": "generic_metrics_distributions"},
                 "start": "2023-01-02T03:04:05+00:00",
                 "end": "2023-01-16T03:04:05+00:00",
                 "rollup": {
@@ -787,10 +733,7 @@ metrics_query_formula_to_mql_tests = [
                         function_name="failure_rate",
                         parameters=[
                             Timeseries(
-                                metric=Metric(
-                                    public_name="foo",
-                                    entity="generic_metrics_distributions",
-                                ),
+                                metric=Metric(public_name="foo"),
                                 aggregate="sum",
                             ),
                         ],
@@ -811,7 +754,6 @@ metrics_query_formula_to_mql_tests = [
         {
             "mql": "apdex(failure_rate(sum(foo)), 1000)",
             "mql_context": {
-                "entity": {"foo": "generic_metrics_distributions"},
                 "start": "2023-01-02T03:04:05+00:00",
                 "end": "2023-01-16T03:04:05+00:00",
                 "rollup": {
@@ -841,17 +783,11 @@ metrics_query_formula_to_mql_tests = [
                         function_name=ArithmeticOperator.DIVIDE.value,
                         parameters=[
                             Timeseries(
-                                metric=Metric(
-                                    public_name="foo",
-                                    entity="generic_metrics_distributions",
-                                ),
+                                metric=Metric(public_name="foo"),
                                 aggregate="sum",
                             ),
                             Timeseries(
-                                metric=Metric(
-                                    public_name="bar",
-                                    entity="generic_metrics_distributions",
-                                ),
+                                metric=Metric(public_name="bar"),
                                 aggregate="sum",
                             ),
                         ],
@@ -874,10 +810,6 @@ metrics_query_formula_to_mql_tests = [
         {
             "mql": 'apdex((sum(foo) / sum(bar)), 500){tag:"tag_value"} by (transaction)',
             "mql_context": {
-                "entity": {
-                    "foo": "generic_metrics_distributions",
-                    "bar": "generic_metrics_distributions",
-                },
                 "start": "2023-01-02T03:04:05+00:00",
                 "end": "2023-01-16T03:04:05+00:00",
                 "rollup": {
@@ -908,17 +840,11 @@ metrics_query_formula_to_mql_tests = [
                         function_name="divide",
                         parameters=[
                             Timeseries(
-                                metric=Metric(
-                                    public_name="transaction.duration",
-                                    entity="generic_metrics_distributions",
-                                ),
+                                metric=Metric(public_name="transaction.duration"),
                                 aggregate="sum",
                             ),
                             Timeseries(
-                                metric=Metric(
-                                    public_name="transaction.duration",
-                                    entity="generic_metrics_distributions",
-                                ),
+                                metric=Metric(public_name="transaction.duration"),
                                 aggregate="count",
                             ),
                         ],
@@ -938,7 +864,6 @@ metrics_query_formula_to_mql_tests = [
         {
             "mql": "topK(10)((sum(transaction.duration) / count(transaction.duration)))",
             "mql_context": {
-                "entity": {"transaction.duration": "generic_metrics_distributions"},
                 "start": "2023-01-02T03:04:05+00:00",
                 "end": "2023-01-16T03:04:05+00:00",
                 "rollup": {
@@ -969,10 +894,7 @@ metrics_query_formula_to_mql_tests = [
                         function_name="apdex",
                         parameters=[
                             Timeseries(
-                                metric=Metric(
-                                    public_name="transaction.duration",
-                                    entity="generic_metrics_distributions",
-                                ),
+                                metric=Metric(public_name="transaction.duration"),
                                 aggregate="sum",
                             ),
                             500,
@@ -994,7 +916,42 @@ metrics_query_formula_to_mql_tests = [
         {
             "mql": 'topK(10)(apdex(sum(transaction.duration), 500){bar:"baz"})',
             "mql_context": {
-                "entity": {"transaction.duration": "generic_metrics_distributions"},
+                "start": "2023-01-02T03:04:05+00:00",
+                "end": "2023-01-16T03:04:05+00:00",
+                "rollup": {
+                    "orderby": None,
+                    "granularity": 3600,
+                    "interval": 3600,
+                    "with_totals": None,
+                },
+                "scope": {
+                    "org_ids": [1],
+                    "project_ids": [11],
+                    "use_case_id": "transactions",
+                },
+                "limit": 100,
+                "offset": 5,
+                "indexer_mappings": {},
+            },
+        },
+        id="test curried arbitrary function with inner arbitrary function",
+    ),
+    pytest.param(
+        MetricsQuery(
+            query="((sum(transaction.duration{transaction:t1}) / sum(transaction.duration)){transaction:t2} + sum(transaction.duration){transaction:t3}) by transaction",
+            start=NOW,
+            end=NOW + timedelta(days=14),
+            rollup=Rollup(interval=3600, totals=None, granularity=3600),
+            scope=MetricsScope(
+                org_ids=[1], project_ids=[11], use_case_id="transactions"
+            ),
+            limit=Limit(100),
+            offset=Offset(5),
+            indexer_mappings={},
+        ),
+        {
+            "mql": '((sum(transaction.duration){transaction:"t1"} / sum(transaction.duration)){transaction:"t2"} + sum(transaction.duration){transaction:"t3"}) by (transaction)',
+            "mql_context": {
                 "start": "2023-01-02T03:04:05+00:00",
                 "end": "2023-01-16T03:04:05+00:00",
                 "rollup": {

--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -27,7 +27,6 @@ BASIC_METRICS_QUERY = MetricsQuery(
         metric=Metric(
             mri="d:transactions/duration@millisecond",
             id=11235813,
-            entity="generic_metrics_distributions",
         ),
         aggregate="max",
         aggregate_params=None,
@@ -77,9 +76,6 @@ tests = [
             "mql_context": {
                 "start": "2021-01-02T03:04:05.000006+00:00",
                 "end": "2021-01-16T03:04:05.000006+00:00",
-                "entity": {
-                    "d:transactions/duration@millisecond": "generic_metrics_distributions"
-                },
                 "indexer_mappings": {},
                 "limit": None,
                 "offset": None,

--- a/tests/test_timeseries.py
+++ b/tests/test_timeseries.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import re
-from typing import Any, Callable, Mapping, Optional
+from typing import Any, Callable, Optional
 
 import pytest
 
@@ -17,20 +17,13 @@ metric_tests = [
         "transaction.duration",
         "d:transactions/duration@millisecond",
         123,
-        "generic_metrics_distributions",
-        {
-            "entity": {
-                "d:transactions/duration@millisecond": "generic_metrics_distributions"
-            },
-            "metric_name": "d:transactions/duration@millisecond",
-        },
+        "d:transactions/duration@millisecond",
         None,
     ),
     pytest.param(
         "transaction.duration",
         "d:transactions/duration@millisecond",
         None,
-        "generic_metrics_distributions",
         None,
         None,
     ),
@@ -38,31 +31,20 @@ metric_tests = [
         "transaction.duration",
         None,
         123,
-        "generic_metrics_distributions",
-        {
-            "entity": {"transaction.duration": "generic_metrics_distributions"},
-            "metric_name": "transaction.duration",
-        },
+        "transaction.duration",
         None,
     ),
     pytest.param(
         None,
         "d:transactions/duration@millisecond",
         123,
-        "generic_metrics_distributions",
-        {
-            "entity": {
-                "d:transactions/duration@millisecond": "generic_metrics_distributions"
-            },
-            "metric_name": "d:transactions/duration@millisecond",
-        },
+        "d:transactions/duration@millisecond",
         None,
     ),
     pytest.param(
         "transaction.duration",
         None,
         None,
-        "generic_metrics_distributions",
         None,
         None,
     ),
@@ -70,7 +52,6 @@ metric_tests = [
         None,
         "d:transactions/duration@millisecond",
         None,
-        "generic_metrics_distributions",
         None,
         None,
     ),
@@ -78,7 +59,6 @@ metric_tests = [
         None,
         None,
         123,
-        "generic_metrics_distributions",
         None,
         InvalidTimeseriesError("Metric must have at least one of public_name or mri"),
     ),
@@ -86,7 +66,6 @@ metric_tests = [
         None,
         None,
         None,
-        "generic_metrics_distributions",
         None,
         InvalidTimeseriesError("Metric must have at least one of public_name or mri"),
     ),
@@ -94,7 +73,6 @@ metric_tests = [
         123,
         "d:transactions/duration@millisecond",
         123,
-        "generic_metrics_distributions",
         None,
         InvalidTimeseriesError("public_name must be a string"),
     ),
@@ -102,7 +80,6 @@ metric_tests = [
         "transaction.duration",
         123,
         123,
-        "generic_metrics_distributions",
         None,
         InvalidTimeseriesError("mri must be a string"),
     ),
@@ -110,39 +87,27 @@ metric_tests = [
         "transaction.duration",
         "d:transactions/duration@millisecond",
         "wrong",
-        "generic_metrics_distributions",
         None,
         InvalidTimeseriesError("id must be an integer"),
-    ),
-    pytest.param(
-        "transaction.duration",
-        "d:transactions/duration@millisecond",
-        123,
-        667,
-        None,
-        InvalidTimeseriesError("entity must be a string"),
     ),
 ]
 
 METRIC_PRINTER = MetricMQLPrinter()
 
 
-@pytest.mark.parametrize(
-    "public_name, mri, mid, entity, translated, exception", metric_tests
-)
+@pytest.mark.parametrize("public_name, mri, mid, translated, exception", metric_tests)
 def test_metric(
     public_name: Any,
     mri: Any,
     mid: Any,
-    entity: Any,
-    translated: dict[str, str] | None,
+    translated: str | None,
     exception: Optional[Exception],
 ) -> None:
     if exception is not None:
         with pytest.raises(type(exception), match=re.escape(str(exception))):
-            Metric(public_name, mri, mid, entity)
+            Metric(public_name, mri, mid)
     else:
-        metric = Metric(public_name, mri, mid, entity)
+        metric = Metric(public_name, mri, mid)
         assert metric.id == mid
         if translated:
             assert METRIC_PRINTER.visit(metric) == translated, METRIC_PRINTER.visit(
@@ -152,42 +117,32 @@ def test_metric(
 
 timeseries_tests = [
     pytest.param(
-        timeseries(
-            Metric("duration", entity="metrics_sets"), "count", None, None, None
-        ),
-        {"entity": {"duration": "metrics_sets"}, "mql_string": "count(duration)"},
+        timeseries(Metric("duration"), "count", None, None, None),
+        "count(duration)",
         None,
         id="simple test",
     ),
     pytest.param(
-        timeseries(
-            Metric("duration", entity="metrics_sets"), "quantile", [0.95], None, None
-        ),
-        {
-            "entity": {"duration": "metrics_sets"},
-            "mql_string": "quantile(0.95)(duration)",
-        },
+        timeseries(Metric("duration"), "quantile", [0.95], None, None),
+        "quantile(0.95)(duration)",
         None,
         id="aggregate params",
     ),
     pytest.param(
         timeseries(
-            Metric("duration", entity="metrics_sets"),
+            Metric("duration"),
             "quantile",
             [0.95],
             [Condition(Column("tags[release]"), Op.EQ, "1.2.3")],
             None,
         ),
-        {
-            "entity": {"duration": "metrics_sets"},
-            "mql_string": 'quantile(0.95)(duration){tags[release]:"1.2.3"}',
-        },
+        'quantile(0.95)(duration){tags[release]:"1.2.3"}',
         None,
         id="filter",
     ),
     pytest.param(
         timeseries(
-            Metric("duration", entity="metrics_sets"),
+            Metric("duration"),
             "quantile",
             [0.95],
             [
@@ -196,16 +151,13 @@ timeseries_tests = [
             ],
             None,
         ),
-        {
-            "entity": {"duration": "metrics_sets"},
-            "mql_string": 'quantile(0.95)(duration){tags[release]:"1.2.3" AND tags[highway]:"401"}',
-        },
+        'quantile(0.95)(duration){tags[release]:"1.2.3" AND tags[highway]:"401"}',
         None,
         id="filters",
     ),
     pytest.param(
         timeseries(
-            Metric("duration", entity="metrics_sets"),
+            Metric("duration"),
             "quantile",
             [0.95],
             [
@@ -218,16 +170,13 @@ timeseries_tests = [
             ],
             None,
         ),
-        {
-            "entity": {"duration": "metrics_sets"},
-            "mql_string": 'quantile(0.95)(duration){(tags[release]:"1.2.3" OR tags[highway]:"401")}',
-        },
+        'quantile(0.95)(duration){(tags[release]:"1.2.3" OR tags[highway]:"401")}',
         None,
         id="boolean condition filters",
     ),
     pytest.param(
         timeseries(
-            Metric("duration", entity="metrics_sets"),
+            Metric("duration"),
             "quantile",
             [0.95],
             [
@@ -236,16 +185,13 @@ timeseries_tests = [
             ],
             [Column("tags[transaction]")],
         ),
-        {
-            "entity": {"duration": "metrics_sets"},
-            "mql_string": 'quantile(0.95)(duration){tags[release]:"1.2.3" AND tags[highway]:"401"} by (tags[transaction])',
-        },
+        'quantile(0.95)(duration){tags[release]:"1.2.3" AND tags[highway]:"401"} by (tags[transaction])',
         None,
         id="groupby",
     ),
     pytest.param(
         timeseries(
-            Metric("duration", entity="metrics_sets"),
+            Metric("duration"),
             "quantile",
             [0.95],
             [
@@ -254,16 +200,13 @@ timeseries_tests = [
             ],
             [Column("tags[transaction]"), Column("tags[device]")],
         ),
-        {
-            "entity": {"duration": "metrics_sets"},
-            "mql_string": 'quantile(0.95)(duration){tags[release]:"1.2.3" AND tags[highway]:"401"} by (tags[transaction], tags[device])',
-        },
+        'quantile(0.95)(duration){tags[release]:"1.2.3" AND tags[highway]:"401"} by (tags[transaction], tags[device])',
         None,
         id="groupbys",
     ),
     pytest.param(
         timeseries(
-            Metric("duration", entity="metrics_sets"),
+            Metric("duration"),
             "quantile",
             [0.95],
             [
@@ -275,28 +218,25 @@ timeseries_tests = [
                 AliasedExpression(Column("tags[device]"), "device"),
             ],
         ),
-        {
-            "entity": {"duration": "metrics_sets"},
-            "mql_string": 'quantile(0.95)(duration){tags[release]:"1.2.3" AND tags[highway]:"401"} by (tags[transaction] AS `transaction`, tags[device] AS `device`)',
-        },
+        'quantile(0.95)(duration){tags[release]:"1.2.3" AND tags[highway]:"401"} by (tags[transaction] AS `transaction`, tags[device] AS `device`)',
         None,
         id="aliased groupbys",
     ),
     pytest.param(
-        timeseries(Metric("duration", entity="metrics_sets"), 456, None, None, None),
+        timeseries(Metric("duration"), 456, None, None, None),
         None,
         InvalidTimeseriesError("aggregate must be a string"),
         id="invalid aggregate",
     ),
     pytest.param(
-        timeseries(Metric("duration", entity="metrics_sets"), "count", 6, None, None),
+        timeseries(Metric("duration"), "count", 6, None, None),
         None,
         InvalidTimeseriesError("aggregate_params must be a list"),
         id="invalid aggregate param",
     ),
     pytest.param(
         timeseries(
-            Metric("duration", entity="metrics_sets"),
+            Metric("duration"),
             "count",
             [Column("test")],
             None,
@@ -307,14 +247,14 @@ timeseries_tests = [
         id="invalid aggregate params",
     ),
     pytest.param(
-        timeseries(Metric("duration", entity="metrics_sets"), "count", None, 6, None),
+        timeseries(Metric("duration"), "count", None, 6, None),
         None,
         InvalidTimeseriesError("filters must be a list"),
         id="invalid filter",
     ),
     pytest.param(
         timeseries(
-            Metric("duration", entity="metrics_sets"),
+            Metric("duration"),
             "count",
             None,
             [Column("test")],
@@ -325,14 +265,14 @@ timeseries_tests = [
         id="invalid filters",
     ),
     pytest.param(
-        timeseries(Metric("duration", entity="metrics_sets"), "count", None, None, 3),
+        timeseries(Metric("duration"), "count", None, None, 3),
         None,
         InvalidTimeseriesError("groupby must be a list"),
         id="invalid groupby",
     ),
     pytest.param(
         timeseries(
-            Metric("duration", entity="metrics_sets"),
+            Metric("duration"),
             "count",
             None,
             None,
@@ -350,7 +290,7 @@ TRANSLATOR = TimeseriesMQLPrinter()
 @pytest.mark.parametrize("func_wrapper, translated, exception", timeseries_tests)
 def test_timeseries(
     func_wrapper: Callable[[], Any],
-    translated: Mapping[str, str] | None,
+    translated: str | None,
     exception: Exception | None,
 ) -> None:
     def verify() -> None:


### PR DESCRIPTION
Snuba is now able to parse the entity from the MRI that is passed in. So there
is no need to encode the MRI in the SDK at all. This simplifies the SDK quite a
bit, and also properly enables using raw MQL strings in the SDK.
