### PR TITLE
fix(mql): Fix ambiguous grammar for filters

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,10 @@
 Changelog and versioning
 ==========================
 
+2.0.29
+------
+- Fix filters grammar to avoid ambiguity
+
 2.0.28
 ------
 - Fix a bug in how dependencies were defined to fix build bugs

--- a/tests/test_mql.py
+++ b/tests/test_mql.py
@@ -1022,6 +1022,50 @@ arbitrary_function_tests = [
         ),
         id="test arbitrary function as outer terms",
     ),
+    pytest.param(
+        "rate(count(g:custom/zone.domains@none))",
+        Formula(
+            function_name="rate",
+            parameters=[
+                Timeseries(
+                    metric=Metric(mri="g:custom/zone.domains@none"),
+                    aggregate="count",
+                ),
+            ],
+        ),
+        id="test arbitrary function with inner timeseries"
+    ),
+    pytest.param(
+        "rate(count(g:custom/zone.domains@none){hello:world})",
+        Formula(
+            function_name="rate",
+            parameters=[
+                Timeseries(
+                    metric=Metric(mri="g:custom/zone.domains@none"),
+                    aggregate="count",
+                    filters=[
+Condition(Column("hello"), Op.EQ, "world")
+                    ]
+                ),
+            ],
+        ),
+        id="test arbitrary function with inner timeseries with params"
+    ),
+    pytest.param(
+        "rate(count(g:custom/zone.domains@none), 10, \"hello\")",
+        Formula(
+            function_name="rate",
+            parameters=[
+                Timeseries(
+                    metric=Metric(mri="g:custom/zone.domains@none"),
+                    aggregate="count",
+                ),
+                10,
+                "hello"
+            ],
+        ),
+        id="test arbitrary function with inner timeseries and params"
+    ),
 ]
 
 

--- a/tests/test_mql.py
+++ b/tests/test_mql.py
@@ -1033,7 +1033,7 @@ arbitrary_function_tests = [
                 ),
             ],
         ),
-        id="test arbitrary function with inner timeseries"
+        id="test arbitrary function with inner timeseries",
     ),
     pytest.param(
         "rate(count(g:custom/zone.domains@none){hello:world})",
@@ -1043,16 +1043,14 @@ arbitrary_function_tests = [
                 Timeseries(
                     metric=Metric(mri="g:custom/zone.domains@none"),
                     aggregate="count",
-                    filters=[
-Condition(Column("hello"), Op.EQ, "world")
-                    ]
+                    filters=[Condition(Column("hello"), Op.EQ, "world")],
                 ),
             ],
         ),
-        id="test arbitrary function with inner timeseries with params"
+        id="test arbitrary function with inner timeseries with params",
     ),
     pytest.param(
-        "rate(count(g:custom/zone.domains@none), 10, \"hello\")",
+        'rate(count(g:custom/zone.domains@none), 10, "hello")',
         Formula(
             function_name="rate",
             parameters=[
@@ -1061,10 +1059,10 @@ Condition(Column("hello"), Op.EQ, "world")
                     aggregate="count",
                 ),
                 10,
-                "hello"
+                "hello",
             ],
         ),
-        id="test arbitrary function with inner timeseries and params"
+        id="test arbitrary function with inner timeseries and params",
     ),
 ]
 


### PR DESCRIPTION
This PR fixes the grammar for filters, which misused quantifiers allowing filters without being surrounded by `{}`. The new grammar makes filter definitions unambiguous.

An example that would show the ambiguity of the grammar is as follows:
`rate(count(g:custom/zone.domains@none))`
which results in:
`Timeseries(metric=Metric(public_name='count', mri=None, id=None), aggregate='rate', aggregate_params=None, filters=[Condition(lhs=Column(name='g', entity=None, subscriptable=None, key=None), op=<Op.EQ: '='>, rhs='custom/zone.domains@none')], groupby=None)` which is clearly wrong.

The new grammar will output the correct result, that is, a `Formula` of `function_name=rate` containing a `Timeseries`.