### PR TITLE
feat(mql): Add support for unary operator

### DIFF
--- a/snuba_sdk/mql/mql.py
+++ b/snuba_sdk/mql/mql.py
@@ -114,7 +114,7 @@ TERM_OPERATORS: Mapping[str, str] = {
 }
 
 UNARY_OPERATORS: Mapping[str, str] = {
-    "-": ArithmeticOperator.MINUS.value,
+    "-": "negate",
 }
 
 
@@ -199,7 +199,7 @@ class MQLVisitor(NodeVisitor):  # type: ignore
             elif isinstance(coefficient, Formula) or isinstance(
                 coefficient, Timeseries
             ):
-                return Formula(function_name=unary_op[0], parameters=[0, coefficient])
+                return Formula(function_name=unary_op[0], parameters=[coefficient])
             else:
                 raise InvalidMQLQueryError(
                     f"Unary expression not supported for type {type(coefficient)}"

--- a/snuba_sdk/mql/mql.py
+++ b/snuba_sdk/mql/mql.py
@@ -194,12 +194,15 @@ class MQLVisitor(NodeVisitor):  # type: ignore
     ) -> Union[Formula, Timeseries, float, int, str]:
         unary_op, coefficient = children
         if unary_op:
-            # We want to transform -1 in 0 - 1.
             if isinstance(coefficient, float) or isinstance(coefficient, int):
                 return -coefficient
+            elif isinstance(coefficient, Formula) or isinstance(
+                coefficient, Timeseries
+            ):
+                return Formula(function_name=unary_op[0], parameters=[0, coefficient])
             else:
                 raise InvalidMQLQueryError(
-                    "Unary expression only applicable on a numeric scalar"
+                    f"Unary expression not supported for type {type(coefficient)}"
                 )
 
         return cast(Union[Formula, Timeseries, float, int, str], coefficient)

--- a/tests/test_mql.py
+++ b/tests/test_mql.py
@@ -869,6 +869,24 @@ term_tests = [
         id="test expression with single unary on metric",
     ),
     pytest.param(
+        "-(-count(c:custom/page_click@none))",
+        Formula(
+            function_name="negate",
+            parameters=[
+                Formula(
+                    function_name="negate",
+                    parameters=[
+                        Timeseries(
+                            metric=Metric(mri="c:custom/page_click@none"),
+                            aggregate="count",
+                        ),
+                    ],
+                ),
+            ],
+        ),
+        id="test expression with nested unary on metric",
+    ),
+    pytest.param(
         "count(c:custom/page_click@none) - -1",
         Formula(
             function_name=ArithmeticOperator.MINUS.value,
@@ -881,6 +899,25 @@ term_tests = [
             ],
         ),
         id="test expression with unary",
+    ),
+    pytest.param(
+        "-(count(c:custom/page_click@none) + -1)",
+        Formula(
+            function_name="negate",
+            parameters=[
+                Formula(
+                    function_name=ArithmeticOperator.PLUS.value,
+                    parameters=[
+                        Timeseries(
+                            metric=Metric(mri="c:custom/page_click@none"),
+                            aggregate="count",
+                        ),
+                        -1,
+                    ],
+                ),
+            ],
+        ),
+        id="test expression with unary on parenthesis expression",
     ),
     pytest.param(
         "count(c:custom/page_click@none) + -max(d:custom/app_load@millisecond)",

--- a/tests/test_mql.py
+++ b/tests/test_mql.py
@@ -856,9 +856,22 @@ term_tests = [
         id="test expression with associativity",
     ),
     pytest.param(
-        "count(c:custom/page_click@none) + -1",
+        "-count(c:custom/page_click@none)",
         Formula(
-            function_name=ArithmeticOperator.PLUS.value,
+            function_name="negate",
+            parameters=[
+                Timeseries(
+                    metric=Metric(mri="c:custom/page_click@none"),
+                    aggregate="count",
+                ),
+            ],
+        ),
+        id="test expression with single unary on metric",
+    ),
+    pytest.param(
+        "count(c:custom/page_click@none) - -1",
+        Formula(
+            function_name=ArithmeticOperator.MINUS.value,
             parameters=[
                 Timeseries(
                     metric=Metric(mri="c:custom/page_click@none"),
@@ -879,9 +892,8 @@ term_tests = [
                     aggregate="count",
                 ),
                 Formula(
-                    function_name=ArithmeticOperator.MINUS.value,
+                    function_name="negate",
                     parameters=[
-                        0,
                         Timeseries(
                             metric=Metric(mri="d:custom/app_load@millisecond"),
                             aggregate="max",
@@ -906,9 +918,8 @@ term_tests = [
                     parameters=[
                         -1,
                         Formula(
-                            function_name=ArithmeticOperator.MINUS.value,
+                            function_name="negate",
                             parameters=[
-                                0,
                                 Timeseries(
                                     metric=Metric(mri="d:custom/app_load@millisecond"),
                                     aggregate="max",

--- a/tests/test_mql.py
+++ b/tests/test_mql.py
@@ -855,6 +855,43 @@ term_tests = [
         ),
         id="test expression with associativity",
     ),
+    pytest.param(
+        "count(c:custom/page_click@none) + -1",
+        Formula(
+            function_name=ArithmeticOperator.PLUS.value,
+            parameters=[
+                Timeseries(
+                    metric=Metric(mri="c:custom/page_click@none"),
+                    aggregate="count",
+                ),
+                -1,
+            ],
+        ),
+        id="test expression with unary",
+    ),
+    pytest.param(
+        "count(c:custom/page_click@none) + (-1 + max(d:custom/app_load@millisecond))",
+        Formula(
+            function_name=ArithmeticOperator.PLUS.value,
+            parameters=[
+                Timeseries(
+                    metric=Metric(mri="c:custom/page_click@none"),
+                    aggregate="count",
+                ),
+                Formula(
+                    function_name=ArithmeticOperator.PLUS.value,
+                    parameters=[
+                        -1,
+                        Timeseries(
+                            metric=Metric(mri="d:custom/app_load@millisecond"),
+                            aggregate="max",
+                        ),
+                    ],
+                ),
+            ],
+        ),
+        id="test expression with complex unary",
+    ),
 ]
 
 

--- a/tests/test_mql.py
+++ b/tests/test_mql.py
@@ -870,7 +870,30 @@ term_tests = [
         id="test expression with unary",
     ),
     pytest.param(
-        "count(c:custom/page_click@none) + (-1 + max(d:custom/app_load@millisecond))",
+        "count(c:custom/page_click@none) + -max(d:custom/app_load@millisecond)",
+        Formula(
+            function_name=ArithmeticOperator.PLUS.value,
+            parameters=[
+                Timeseries(
+                    metric=Metric(mri="c:custom/page_click@none"),
+                    aggregate="count",
+                ),
+                Formula(
+                    function_name=ArithmeticOperator.MINUS.value,
+                    parameters=[
+                        0,
+                        Timeseries(
+                            metric=Metric(mri="d:custom/app_load@millisecond"),
+                            aggregate="max",
+                        ),
+                    ],
+                ),
+            ],
+        ),
+        id="test expression with unary on metric",
+    ),
+    pytest.param(
+        "count(c:custom/page_click@none) + (-1 + -max(d:custom/app_load@millisecond))",
         Formula(
             function_name=ArithmeticOperator.PLUS.value,
             parameters=[
@@ -882,9 +905,15 @@ term_tests = [
                     function_name=ArithmeticOperator.PLUS.value,
                     parameters=[
                         -1,
-                        Timeseries(
-                            metric=Metric(mri="d:custom/app_load@millisecond"),
-                            aggregate="max",
+                        Formula(
+                            function_name=ArithmeticOperator.MINUS.value,
+                            parameters=[
+                                0,
+                                Timeseries(
+                                    metric=Metric(mri="d:custom/app_load@millisecond"),
+                                    aggregate="max",
+                                ),
+                            ],
                         ),
                     ],
                 ),


### PR DESCRIPTION
This PR adds support for unary operator `-` on numeric scalars and timeseries/formulas, which was requested by some users.