### PR TITLE
fix(mql): Add support for negation in mql visitor

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,11 @@
 Changelog and versioning
 ==========================
 
+2.0.31
+------
+
+- Add support for generating correct unary expressions in MQL.
+
 2.0.30
 ------
 

--- a/snuba_sdk/formula.py
+++ b/snuba_sdk/formula.py
@@ -33,6 +33,8 @@ PREFIX_TO_INFIX: dict[str, str] = {
     ArithmeticOperator.DIVIDE.value: "/",
 }
 
+PREFIX_ALIASES: dict[str, str] = {"negate": "-"}
+
 
 @dataclass(frozen=True)
 class Formula:

--- a/snuba_sdk/metrics_visitors.py
+++ b/snuba_sdk/metrics_visitors.py
@@ -8,7 +8,12 @@ from snuba_sdk.aliased_expression import AliasedExpression
 from snuba_sdk.column import Column
 from snuba_sdk.conditions import BooleanCondition, Condition, ConditionGroup
 from snuba_sdk.expressions import InvalidExpressionError
-from snuba_sdk.formula import PREFIX_TO_INFIX, Formula, FormulaParameterGroup
+from snuba_sdk.formula import (
+    PREFIX_ALIASES,
+    PREFIX_TO_INFIX,
+    Formula,
+    FormulaParameterGroup,
+)
 from snuba_sdk.timeseries import Metric, MetricsScope, Rollup, Timeseries
 from snuba_sdk.visitors import Translation
 
@@ -180,7 +185,10 @@ class FormulaMQLPrinter:
             separator = f" {PREFIX_TO_INFIX[formula.function_name]} "
             mql_string = f"({separator.join(param_strings)})"
         else:
-            mql_string = f"{formula.function_name}{self._visit_aggregate_params(formula.aggregate_params)}({', '.join(param_strings)})"
+            mql_string = (
+                f"{PREFIX_ALIASES.get(formula.function_name) or formula.function_name}"
+                f"{self._visit_aggregate_params(formula.aggregate_params)}({', '.join(param_strings)})"
+            )
 
         mql_string += f"{self._visit_filters(formula.filters)}"
         mql_string += f"{self._visit_groupby(formula.groupby)}"

--- a/tests/test_metrics_mql_query.py
+++ b/tests/test_metrics_mql_query.py
@@ -545,6 +545,42 @@ metrics_query_timeseries_to_mql_tests = [
         },
         id="test_passing_string_directly",
     ),
+    pytest.param(
+        MetricsQuery(
+            query="-sum(transaction.duration) + -1",
+            start=NOW,
+            end=NOW + timedelta(days=14),
+            rollup=Rollup(interval=3600, totals=None, granularity=3600),
+            scope=MetricsScope(
+                org_ids=[1], project_ids=[11], use_case_id="transactions"
+            ),
+            limit=Limit(100),
+            offset=Offset(5),
+            indexer_mappings={},
+        ),
+        {
+            "mql": "(-(sum(transaction.duration)) + -1.0)",
+            "mql_context": {
+                "start": "2023-01-02T03:04:05+00:00",
+                "end": "2023-01-16T03:04:05+00:00",
+                "rollup": {
+                    "orderby": None,
+                    "granularity": 3600,
+                    "interval": 3600,
+                    "with_totals": None,
+                },
+                "scope": {
+                    "org_ids": [1],
+                    "project_ids": [11],
+                    "use_case_id": "transactions",
+                },
+                "limit": 100,
+                "offset": 5,
+                "indexer_mappings": {},
+            },
+        },
+        id="test_unary_negation",
+    ),
 ]
 
 


### PR DESCRIPTION
This PR implements the missing part of the unary implementation, that is, the serialization of `-` when generating mql from the ast.