### PR TITLE
feat: sdk or optimizer

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -28,3 +28,4 @@
     "python.testing.pytestEnabled": false,
     "python.testing.unittestEnabled": false,
     "python.testing.nosetestsEnabled": false
+  }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -25,25 +25,6 @@
     "python.formatting.provider": "black",
     // test discovery is sluggish and the UI around running
     // tests is often in your way and misclicked
-    "python.testing.pytestEnabled": true,
-    "workbench.colorCustomizations": {
-      "activityBar.activeBackground": "#2f7c47",
-      "activityBar.background": "#2f7c47",
-      "activityBar.foreground": "#e7e7e7",
-      "activityBar.inactiveForeground": "#e7e7e799",
-      "activityBarBadge.background": "#422c74",
-      "activityBarBadge.foreground": "#e7e7e7",
-      "commandCenter.border": "#e7e7e799",
-      "sash.hoverBorder": "#2f7c47",
-      "statusBar.background": "#215732",
-      "statusBar.foreground": "#e7e7e7",
-      "statusBarItem.hoverBackground": "#2f7c47",
-      "statusBarItem.remoteBackground": "#215732",
-      "statusBarItem.remoteForeground": "#e7e7e7",
-      "titleBar.activeBackground": "#215732",
-      "titleBar.activeForeground": "#e7e7e7",
-      "titleBar.inactiveBackground": "#21573299",
-      "titleBar.inactiveForeground": "#e7e7e799"
-    },
-    "peacock.color": "#215732"
-  }
+    "python.testing.pytestEnabled": false,
+    "python.testing.unittestEnabled": false,
+    "python.testing.nosetestsEnabled": false

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -25,7 +25,25 @@
     "python.formatting.provider": "black",
     // test discovery is sluggish and the UI around running
     // tests is often in your way and misclicked
-    "python.testing.pytestEnabled": false,
-    "python.testing.unittestEnabled": false,
-    "python.testing.nosetestsEnabled": false
+    "python.testing.pytestEnabled": true,
+    "workbench.colorCustomizations": {
+      "activityBar.activeBackground": "#2f7c47",
+      "activityBar.background": "#2f7c47",
+      "activityBar.foreground": "#e7e7e7",
+      "activityBar.inactiveForeground": "#e7e7e799",
+      "activityBarBadge.background": "#422c74",
+      "activityBarBadge.foreground": "#e7e7e7",
+      "commandCenter.border": "#e7e7e799",
+      "sash.hoverBorder": "#2f7c47",
+      "statusBar.background": "#215732",
+      "statusBar.foreground": "#e7e7e7",
+      "statusBarItem.hoverBackground": "#2f7c47",
+      "statusBarItem.remoteBackground": "#215732",
+      "statusBarItem.remoteForeground": "#e7e7e7",
+      "titleBar.activeBackground": "#215732",
+      "titleBar.activeForeground": "#e7e7e7",
+      "titleBar.inactiveBackground": "#21573299",
+      "titleBar.inactiveForeground": "#e7e7e799"
+    },
+    "peacock.color": "#215732"
   }

--- a/snuba_sdk/metrics_query.py
+++ b/snuba_sdk/metrics_query.py
@@ -98,8 +98,13 @@ class MetricsQuery(BaseQuery):
         return result
 
     def _optimize(self) -> None:
-        if isinstance(self.query, (Formula, Timeseries)):
-            self.query = OrOptimizer().optimize(self.query)
+        if (
+            isinstance(self.query, (Formula, Timeseries))
+            and self.query.filters is not None
+        ):
+            new_filters = OrOptimizer().optimize(self.query.filters)
+            if new_filters is not None:
+                self.query = replace(self.query, filters=new_filters)
 
 
 MQL_PRINTER = MQLPrinter()

--- a/snuba_sdk/metrics_query.py
+++ b/snuba_sdk/metrics_query.py
@@ -7,9 +7,10 @@ from typing import Any
 
 from snuba_sdk.expressions import Limit, Offset
 from snuba_sdk.formula import Formula
-from snuba_sdk.metrics_query_visitors import OrOptimizer, Validator
+from snuba_sdk.metrics_query_visitors import Validator
 from snuba_sdk.mql_visitor import MQLPrinter
 from snuba_sdk.query import BaseQuery
+from snuba_sdk.query_optimizers.or_optimizer import OrOptimizer
 from snuba_sdk.query_visitors import InvalidQueryError
 from snuba_sdk.timeseries import MetricsScope, Rollup, Timeseries
 

--- a/snuba_sdk/metrics_query.py
+++ b/snuba_sdk/metrics_query.py
@@ -98,11 +98,7 @@ class MetricsQuery(BaseQuery):
         return result
 
     def _optimize(self) -> None:
-        if isinstance(self.query, str):
-            raise ValueError(
-                "Expected a Formula or Timeseries query, got a str. Hint: call validate before optimizing?"
-            )
-        if self.query is not None:
+        if isinstance(self.query, (Formula, Timeseries)):
             self.query = OrOptimizer().optimize(self.query)
 
 

--- a/snuba_sdk/query_optimizers/or_optimizer.py
+++ b/snuba_sdk/query_optimizers/or_optimizer.py
@@ -1,0 +1,68 @@
+from snuba_sdk.conditions import (
+    BooleanCondition,
+    BooleanOp,
+    Condition,
+    Op,
+)
+from snuba_sdk.formula import Formula
+from snuba_sdk.timeseries import Timeseries
+
+
+class OrOptimizer:
+    def optimize(self, query: Formula | Timeseries) -> Formula | Timeseries:
+        if query.filters is None:
+            return query
+
+        optimized = False
+        new_filters = []
+        for cond in query.filters:
+            res = self._optimize_condition(cond)
+            if res is not None:
+                optimized = True
+                new_filters.append(res)
+            else:
+                new_filters.append(cond)
+
+        if not optimized:
+            return query
+        elif isinstance(query, Timeseries):
+            return Timeseries(
+                metric=query.metric,
+                aggregate=query.aggregate,
+                aggregate_params=query.aggregate_params,
+                filters=new_filters,
+                groupby=query.groupby,
+            )
+        else:
+            return Formula(
+                function_name=query.function_name,
+                parameters=query.parameters,
+                aggregate_params=query.aggregate_params,
+                filters=new_filters,
+                groupby=query.groupby,
+            )
+
+    def _optimize_condition(
+        self, cond: BooleanCondition | Condition
+    ) -> BooleanCondition | Condition | None:
+        """
+        Given a condition, returns the optimized version, or None if it can't be optimized
+        """
+        if cond.op != BooleanOp.OR:
+            return None
+        shared_lhs = None
+        rhsides = []
+        for curr in cond.conditions:
+            if (
+                not isinstance(curr, Condition)
+                or curr.op != Op.EQ
+                or (shared_lhs and curr.lhs != shared_lhs)
+            ):
+                # can't be optimized
+                return None
+            if not shared_lhs:
+                shared_lhs = curr.lhs
+            rhsides += [curr.rhs]
+        assert shared_lhs
+        assert rhsides
+        return Condition(shared_lhs, Op.IN, rhsides)  # type: ignore

--- a/snuba_sdk/query_optimizers/or_optimizer.py
+++ b/snuba_sdk/query_optimizers/or_optimizer.py
@@ -5,7 +5,7 @@ from snuba_sdk.conditions import ConditionGroup
 
 
 class OrOptimizer:
-    def optimize(self, condition_group: ConditionGroup) -> ConditionGroup | None:
+    def optimize(self, condition_group: ConditionGroup) -> Union[ConditionGroup, None]:
         """
         Given a condition group, returns a new condition group with optimized or-conditions,
         or None if the conditions can't be optimized.

--- a/snuba_sdk/query_optimizers/or_optimizer.py
+++ b/snuba_sdk/query_optimizers/or_optimizer.py
@@ -22,7 +22,7 @@ class OrOptimizer:
                 new_filters.append(cond)
 
         if optimized:
-            replace(query, filters=new_filters)
+            return replace(query, filters=new_filters)
         return query
 
     def _optimize_condition(

--- a/snuba_sdk/query_optimizers/or_optimizer.py
+++ b/snuba_sdk/query_optimizers/or_optimizer.py
@@ -8,6 +8,14 @@ from snuba_sdk.timeseries import Timeseries
 
 class OrOptimizer:
     def optimize(self, query: Union[Formula, Timeseries]) -> Union[Formula, Timeseries]:
+        """
+        Given a query, returns a new query with optimized or conditions.
+
+        Specifically, any condition in query.filters that have the form:
+        BooleanCondition(OR, [tag=val1,tag=val2, tag=val3, ...])
+        become
+        Condition(tag, IN, [tag=val1,tag=val2, tag=val3, ...])
+        """
         if query.filters is None:
             return query
 

--- a/snuba_sdk/query_optimizers/or_optimizer.py
+++ b/snuba_sdk/query_optimizers/or_optimizer.py
@@ -1,7 +1,7 @@
 from dataclasses import replace
 from typing import Union
 
-from snuba_sdk.conditions import BooleanCondition, BooleanOp, Condition, Op
+from snuba_sdk.conditions import BooleanCondition, Condition, Op, Or
 from snuba_sdk.formula import Formula
 from snuba_sdk.timeseries import Timeseries
 
@@ -31,7 +31,7 @@ class OrOptimizer:
         """
         Given a condition, returns the optimized version, or None if it can't be optimized
         """
-        if cond.op != BooleanOp.OR:
+        if not isinstance(cond, Or):
             return None
         shared_lhs = None
         rhsides = []

--- a/snuba_sdk/query_optimizers/or_optimizer.py
+++ b/snuba_sdk/query_optimizers/or_optimizer.py
@@ -38,9 +38,18 @@ class OrOptimizer:
         """
         if not isinstance(cond, BooleanCondition) or cond.op != BooleanOp.OR:
             return None
-        shared_lhs = None
-        rhsides = []
-        for curr in cond.conditions:
+
+        if len(cond.conditions) == 0:
+            return None
+
+        curr = cond.conditions[0]
+        if not isinstance(curr, Condition) or curr.op != Op.EQ:
+            # can't be optimized
+            return None
+        shared_lhs = curr.lhs
+        rhsides = [curr.rhs]
+        for i in range(1, len(cond.conditions)):
+            curr = cond.conditions[i]
             if (
                 not isinstance(curr, Condition)
                 or curr.op != Op.EQ
@@ -48,9 +57,5 @@ class OrOptimizer:
             ):
                 # can't be optimized
                 return None
-            if not shared_lhs:
-                shared_lhs = curr.lhs
             rhsides += [curr.rhs]
-        assert shared_lhs
-        assert rhsides
         return Condition(shared_lhs, Op.IN, rhsides)  # type: ignore

--- a/snuba_sdk/query_optimizers/or_optimizer.py
+++ b/snuba_sdk/query_optimizers/or_optimizer.py
@@ -1,7 +1,7 @@
 from dataclasses import replace
 from typing import Union
 
-from snuba_sdk.conditions import BooleanCondition, Condition, Op, Or
+from snuba_sdk.conditions import BooleanCondition, BooleanOp, Condition, Op
 from snuba_sdk.formula import Formula
 from snuba_sdk.timeseries import Timeseries
 
@@ -31,7 +31,7 @@ class OrOptimizer:
         """
         Given a condition, returns the optimized version, or None if it can't be optimized
         """
-        if not isinstance(cond, Or):
+        if not isinstance(cond, BooleanCondition) or cond.op != BooleanOp.OR:
             return None
         shared_lhs = None
         rhsides = []

--- a/snuba_sdk/query_optimizers/or_optimizer.py
+++ b/snuba_sdk/query_optimizers/or_optimizer.py
@@ -1,7 +1,12 @@
 from typing import Union
 
-from snuba_sdk.conditions import BooleanCondition, BooleanOp, Condition, Op
-from snuba_sdk.conditions import ConditionGroup
+from snuba_sdk.conditions import (
+    BooleanCondition,
+    BooleanOp,
+    Condition,
+    ConditionGroup,
+    Op,
+)
 
 
 class OrOptimizer:

--- a/tests/test_mql.py
+++ b/tests/test_mql.py
@@ -6,7 +6,6 @@ from snuba_sdk.column import Column
 from snuba_sdk.conditions import And, Condition, Op, Or
 from snuba_sdk.formula import ArithmeticOperator, Formula
 from snuba_sdk.mql.mql import parse_mql
-from snuba_sdk.query_optimizers.or_optimizer import OrOptimizer
 from snuba_sdk.timeseries import Metric, Timeseries
 
 base_tests = [
@@ -977,21 +976,6 @@ term_tests = [
 def test_parse_mql_terms(mql_string: str, metrics_query: Formula | Timeseries) -> None:
     result = parse_mql(mql_string)
     assert result == metrics_query
-
-
-def test_or_optimizer() -> None:
-    mql_string = '(avg(d:transactions/duration@millisecond) by (transaction)){(transaction:"a" OR transaction:"b" OR transaction:"c")}'
-    parsed = parse_mql(mql_string)
-    assert isinstance(parsed, Timeseries)
-    expected_optimized = Timeseries(
-        metric=parsed.metric,
-        aggregate=parsed.aggregate,
-        aggregate_params=parsed.aggregate_params,
-        filters=[Condition(Column("transaction"), Op.IN, ["a", "b", "c"])],
-        groupby=parsed.groupby,
-    )
-    actual_optimized = OrOptimizer().optimize(parsed)
-    assert actual_optimized == expected_optimized
 
 
 arbitrary_function_tests = [

--- a/tests/test_mql.py
+++ b/tests/test_mql.py
@@ -5,6 +5,7 @@ import pytest
 from snuba_sdk.column import Column
 from snuba_sdk.conditions import And, Condition, Op, Or
 from snuba_sdk.formula import ArithmeticOperator, Formula
+from snuba_sdk.metrics_query_visitors import OrOptimizer
 from snuba_sdk.mql.mql import parse_mql
 from snuba_sdk.timeseries import Metric, Timeseries
 
@@ -976,6 +977,21 @@ term_tests = [
 def test_parse_mql_terms(mql_string: str, metrics_query: Formula | Timeseries) -> None:
     result = parse_mql(mql_string)
     assert result == metrics_query
+
+
+def test_or_optimizer() -> None:
+    mql_string = '(avg(d:transactions/duration@millisecond) by (transaction)){(transaction:"a" OR transaction:"b" OR transaction:"c")}'
+    parsed = parse_mql(mql_string)
+    assert isinstance(parsed, Timeseries)
+    expected_optimized = Timeseries(
+        metric=parsed.metric,
+        aggregate=parsed.aggregate,
+        aggregate_params=parsed.aggregate_params,
+        filters=[Condition(Column("transaction"), Op.IN, ["a", "b", "c"])],
+        groupby=parsed.groupby,
+    )
+    actual_optimized = OrOptimizer().optimize(parsed)
+    assert actual_optimized == expected_optimized
 
 
 arbitrary_function_tests = [

--- a/tests/test_mql.py
+++ b/tests/test_mql.py
@@ -5,8 +5,8 @@ import pytest
 from snuba_sdk.column import Column
 from snuba_sdk.conditions import And, Condition, Op, Or
 from snuba_sdk.formula import ArithmeticOperator, Formula
-from snuba_sdk.query_optimizers.or_optimizer import OrOptimizer
 from snuba_sdk.mql.mql import parse_mql
+from snuba_sdk.query_optimizers.or_optimizer import OrOptimizer
 from snuba_sdk.timeseries import Metric, Timeseries
 
 base_tests = [

--- a/tests/test_mql.py
+++ b/tests/test_mql.py
@@ -5,7 +5,7 @@ import pytest
 from snuba_sdk.column import Column
 from snuba_sdk.conditions import And, Condition, Op, Or
 from snuba_sdk.formula import ArithmeticOperator, Formula
-from snuba_sdk.metrics_query_visitors import OrOptimizer
+from snuba_sdk.query_optimizers.or_optimizer import OrOptimizer
 from snuba_sdk.mql.mql import parse_mql
 from snuba_sdk.timeseries import Metric, Timeseries
 

--- a/tests/test_or_optimizer.py
+++ b/tests/test_or_optimizer.py
@@ -38,7 +38,7 @@ def test_unsupported() -> None:
         )
     ]
     actual = OrOptimizer().optimize(condition_group)
-    assert actual == None
+    assert actual is None
 
 
 def test_snql() -> None:

--- a/tests/test_or_optimizer.py
+++ b/tests/test_or_optimizer.py
@@ -1,0 +1,43 @@
+from snuba_sdk.column import Column
+from snuba_sdk.conditions import Condition, Op
+from snuba_sdk.formula import Formula
+from snuba_sdk.mql.mql import parse_mql
+from snuba_sdk.query_optimizers.or_optimizer import OrOptimizer
+from snuba_sdk.timeseries import Timeseries
+
+
+def test_timeseries() -> None:
+    mql_string = '(avg(d:transactions/duration@millisecond) by (transaction)){transaction:"a" OR transaction:"b" OR transaction:"c"}'
+    parsed = parse_mql(mql_string)
+    assert isinstance(parsed, Timeseries)
+    expected_optimized = Timeseries(
+        metric=parsed.metric,
+        aggregate=parsed.aggregate,
+        aggregate_params=parsed.aggregate_params,
+        filters=[Condition(Column("transaction"), Op.IN, ["a", "b", "c"])],
+        groupby=parsed.groupby,
+    )
+    actual_optimized = OrOptimizer().optimize(parsed)
+    assert actual_optimized == expected_optimized
+
+
+def test_formula() -> None:
+    mql_string = '(avg(d:transactions/duration@millisecond) / sum(d:transactions/duration@millisecond)){transaction:"a" OR transaction:"b" OR transaction:"c"}'
+    parsed = parse_mql(mql_string)
+    assert isinstance(parsed, Formula)
+    expected_optimized = Formula(
+        function_name=parsed.function_name,
+        parameters=parsed.parameters,
+        aggregate_params=parsed.aggregate_params,
+        filters=[Condition(Column("transaction"), Op.IN, ["a", "b", "c"])],
+        groupby=parsed.groupby,
+    )
+    actual_optimized = OrOptimizer().optimize(parsed)
+    assert actual_optimized == expected_optimized
+
+
+def test_unsupported() -> None:
+    mql_string = '(avg(d:transactions/duration@millisecond) by (transaction)){transaction:"a" OR (transaction:"b" OR transaction:"c")}'
+    parsed = parse_mql(mql_string)
+    actual_optimized = OrOptimizer().optimize(parsed)
+    assert actual_optimized == parsed


### PR DESCRIPTION
This PR adds an optimizer pass to the Query and MetricsQuery during serialization. 
It will take a condition: `c=val1 or c=val2 or c=val3...` and convert it to `c in [val1, val2, val3, ...]`.
This change should fix --at least some of the queries causing-- the recursion bug in parsing.

## testing
* I wrote unit tests for the OrOptimizer to verify it optimizes ConditionGroups as expected. 
* I wrote more "end-to-end" tests of `serialize` that verify Query and MetricsQuery are optimized as expected when serialize is called.
* I wrote a test in sentry that sends an MQL query that caused the recursion bug previously. This test doesn't cause the error anymore. Note, this test is not committed to any repo it only exists locally in my own branch. https://github.com/getsentry/sentry/blob/560fe2f33afe0448b13ad5cab0c71d077309e0d5/tests/sentry/api/endpoints/test_organization_metrics_query.py#L110

Concerns:
* Do I need to run all of sentry CI test against the new sdk before i deploy?
* IDK what to do after merging this to SDK