### PR TITLE
feat(ddm): Add lenient MRI regex

### DIFF
--- a/snuba_sdk/mql/mql.py
+++ b/snuba_sdk/mql/mql.py
@@ -77,7 +77,8 @@ group_by_name_tuple = open_paren _ group_by_name (_ comma _ group_by_name)* _ cl
 
 inner_filter = metric (open_brace (_ filter_expr _)? close_brace)? (group_by)?
 metric = quoted_mri / unquoted_mri / quoted_public_name / unquoted_public_name
-quoted_mri = backtick unquoted_mri backtick
+quoted_mri = backtick lenient_mri backtick
+lenient_mri = ~r'[^:`]+:[^/`]+/[^@,`]+@[^`]+'
 unquoted_mri = ~r'[^:\(\){}\[\]"`,]+:[^/\(\){}\[\]"`,]+/[^@\(\){}\[\]"`,]+@[^\(\){}\[\]"`,]+'
 quoted_public_name = backtick unquoted_public_name backtick
 unquoted_public_name = ~r"([a-z_]+(?:\.[a-z_]+)*)"
@@ -526,6 +527,9 @@ class MQLVisitor(NodeVisitor):  # type: ignore
 
     def visit_quoted_mri(self, node: Node, children: Sequence[Any]) -> Metric:
         return Metric(mri=str(node.text[1:-1]))
+
+    def visit_lenient_mri(self, node: Node, children: Sequence[Any]) -> Metric:
+        return Metric(mri=str(node.text))
 
     def visit_unquoted_mri(self, node: Node, children: Sequence[Any]) -> Metric:
         return Metric(mri=str(node.text))

--- a/snuba_sdk/mql/mql.py
+++ b/snuba_sdk/mql/mql.py
@@ -23,7 +23,7 @@ class InvalidMQLQueryError(Exception):
 AGGREGATE_PLACEHOLDER_NAME = "AGGREGATE_PLACEHOLDER"
 
 MQL_GRAMMAR = Grammar(
-    rf"""
+    r"""
 expression = term (_ expr_op _ term)*
 expr_op = "+" / "-"
 

--- a/snuba_sdk/mql/mql.py
+++ b/snuba_sdk/mql/mql.py
@@ -78,7 +78,7 @@ group_by_name_tuple = open_paren _ group_by_name (_ comma _ group_by_name)* _ cl
 inner_filter = metric (open_brace (_ filter_expr _)? close_brace)? (group_by)?
 metric = quoted_mri / unquoted_mri / quoted_public_name / unquoted_public_name
 quoted_mri = backtick unquoted_mri backtick
-unquoted_mri = ~r'[^:\(\){{}}\[\]"`]+:[^/\(\){{}}\[\]"`]+/[^@\(\){{}}\[\]"`]+@[^\(\){{}}\[\]"`]+'
+unquoted_mri = ~r'[^:\(\){{}}\[\]"`,]+:[^/\(\){{}}\[\]"`,]+/[^@\(\){{}}\[\]"`,]+@[^\(\){{}}\[\]"`,]+'
 quoted_public_name = backtick unquoted_public_name backtick
 unquoted_public_name = ~r"([a-z_]+(?:\.[a-z_]+)*)"
 

--- a/snuba_sdk/mql/mql.py
+++ b/snuba_sdk/mql/mql.py
@@ -78,7 +78,7 @@ group_by_name_tuple = open_paren _ group_by_name (_ comma _ group_by_name)* _ cl
 inner_filter = metric (open_brace (_ filter_expr _)? close_brace)? (group_by)?
 metric = quoted_mri / unquoted_mri / quoted_public_name / unquoted_public_name
 quoted_mri = backtick unquoted_mri backtick
-unquoted_mri = ~r"[^:(){{}}`]+:[^/(){{}}`]+/[^@(){{}}`]+@[^(){{}}`]+"
+unquoted_mri = ~r'[^:\(\){{}}\[\]"`]+:[^/\(\){{}}\[\]"`]+/[^@\(\){{}}\[\]"`]+@[^\(\){{}}\[\]"`]+'
 quoted_public_name = backtick unquoted_public_name backtick
 unquoted_public_name = ~r"([a-z_]+(?:\.[a-z_]+)*)"
 

--- a/snuba_sdk/mql/mql.py
+++ b/snuba_sdk/mql/mql.py
@@ -50,7 +50,7 @@ tag_key = ~r"[a-zA-Z0-9_.]+"
 tag_value = quoted_string / unquoted_string / string_tuple / variable
 
 quoted_string = ~r'"([^"\\]*(?:\\.[^"\\]*)*)"'
-unquoted_string = ~r'[^,\[\]\"}}{{\(\)\s]+'
+unquoted_string = ~r'[^,\[\]\"}{\(\)\s]+'
 string_tuple = open_square_bracket _ (quoted_string / unquoted_string) (_ comma _ (quoted_string / unquoted_string))* _ close_square_bracket
 
 target = variable / nested_expression / function / metric
@@ -78,7 +78,7 @@ group_by_name_tuple = open_paren _ group_by_name (_ comma _ group_by_name)* _ cl
 inner_filter = metric (open_brace (_ filter_expr _)? close_brace)? (group_by)?
 metric = quoted_mri / unquoted_mri / quoted_public_name / unquoted_public_name
 quoted_mri = backtick unquoted_mri backtick
-unquoted_mri = ~r'[^:\(\){{}}\[\]"`,]+:[^/\(\){{}}\[\]"`,]+/[^@\(\){{}}\[\]"`,]+@[^\(\){{}}\[\]"`,]+'
+unquoted_mri = ~r'[^:\(\){}\[\]"`,]+:[^/\(\){}\[\]"`,]+/[^@\(\){}\[\]"`,]+@[^\(\){}\[\]"`,]+'
 quoted_public_name = backtick unquoted_public_name backtick
 unquoted_public_name = ~r"([a-z_]+(?:\.[a-z_]+)*)"
 
@@ -86,8 +86,8 @@ open_paren = "("
 close_paren = ")"
 open_square_bracket = "["
 close_square_bracket = "]"
-open_brace = "{{"
-close_brace = "}}"
+open_brace = "{"
+close_brace = "}"
 comma = ","
 backtick = "`"
 colon = ":"

--- a/snuba_sdk/mql/mql.py
+++ b/snuba_sdk/mql/mql.py
@@ -22,11 +22,6 @@ class InvalidMQLQueryError(Exception):
 
 AGGREGATE_PLACEHOLDER_NAME = "AGGREGATE_PLACEHOLDER"
 
-METRIC_TYPE_REGEX = r"(c|s|d|g|e)"
-METRIC_NAMESPACE_REGEX = r"[a-zA-Z0-9_]+"
-METRIC_NAME_REGEX = r"([a-zA-Z0-9_]+(?:\.[a-zA-Z0-9_]+)*)"
-METRIC_UNIT_REGEX = r"([\w.]*)"
-
 MQL_GRAMMAR = Grammar(
     rf"""
 expression = term (_ expr_op _ term)*
@@ -83,7 +78,7 @@ group_by_name_tuple = open_paren _ group_by_name (_ comma _ group_by_name)* _ cl
 inner_filter = metric (open_brace (_ filter_expr _)? close_brace)? (group_by)?
 metric = quoted_mri / unquoted_mri / quoted_public_name / unquoted_public_name
 quoted_mri = backtick unquoted_mri backtick
-unquoted_mri = ~r"{METRIC_TYPE_REGEX}:{METRIC_NAMESPACE_REGEX}/{METRIC_NAME_REGEX}@{METRIC_UNIT_REGEX}"
+unquoted_mri = ~r"[^:(){{}}`]+:[^/(){{}}`]+/[^@(){{}}`]+@[^(){{}}`]+"
 quoted_public_name = backtick unquoted_public_name backtick
 unquoted_public_name = ~r"([a-z_]+(?:\.[a-z_]+)*)"
 

--- a/tests/test_mql.py
+++ b/tests/test_mql.py
@@ -26,6 +26,14 @@ base_tests = [
         id="test unquoted mri name",
     ),
     pytest.param(
+        "sum(`avg(d:transactions/Duration.Metric@{millisecond})`)",
+        Timeseries(
+            metric=Metric(mri="avg(d:transactions/Duration.Metric@{millisecond})"),
+            aggregate="sum",
+        ),
+        id="test weird mri name",
+    ),
+    pytest.param(
         "sum(`transactions.duration`)",
         Timeseries(metric=Metric(public_name="transactions.duration"), aggregate="sum"),
         id="test quoted public name 1",

--- a/tests/test_mql.py
+++ b/tests/test_mql.py
@@ -10,17 +10,17 @@ from snuba_sdk.timeseries import Metric, Timeseries
 
 base_tests = [
     pytest.param(
-        "sum(`d:transactions/Duration.Metric@millisecond`)",
+        "sum(`d:transactions/Duration.Metric@{millisecond}`)",
         Timeseries(
-            metric=Metric(mri="d:transactions/Duration.Metric@millisecond"),
+            metric=Metric(mri="d:transactions/Duration.Metric@{millisecond}"),
             aggregate="sum",
         ),
         id="test quoted mri name",
     ),
     pytest.param(
-        "sum(d:transactions/Duration@millisecond)",
+        "sum(d:transactions/organizations.api.v1@millisecond)",
         Timeseries(
-            metric=Metric(mri="d:transactions/Duration@millisecond"),
+            metric=Metric(mri="d:transactions/organizations.api.v1@millisecond"),
             aggregate="sum",
         ),
         id="test unquoted mri name",


### PR DESCRIPTION
This PR adds a more lenient MRI regex to relax the definition, as done in the backend: https://github.com/getsentry/sentry/pull/68175.

The definition of the unquoted MRI is slightly different than the one in the backend since we have to disambiguate certain strings which make the parser confused. The divergence of MRI regexes might cause problems in case some ill-defined metrics are accepted by Relay, the backend, and not by MQL. This however should not happen, but it is a possibility.

In the case of a quoted MRI, an even more lenient version is permitted, since we use backticks to disambiguate and we can therefore afford to put more accepted characters.