### PR TITLE
bug(mql): Update rollup totals validation

### DIFF
--- a/snuba_sdk/timeseries.py
+++ b/snuba_sdk/timeseries.py
@@ -199,7 +199,7 @@ class Rollup:
             if not isinstance(self.totals, bool):
                 raise InvalidExpressionError("totals must be a boolean")
 
-        if self.interval is None and self.totals is None:
+        if self.interval is None and self.totals in (None, False):
             raise InvalidExpressionError(
                 "Rollup must have at least one of interval or totals"
             )

--- a/tests/test_metrics_expressions.py
+++ b/tests/test_metrics_expressions.py
@@ -40,6 +40,15 @@ rollup_tests = [
     ),
     pytest.param(
         None,
+        False,
+        None,
+        60,
+        None,
+        InvalidExpressionError("Rollup must have at least one of interval or totals"),
+        id="3",
+    ),
+    pytest.param(
+        None,
         True,
         Direction.ASC,
         60,


### PR DESCRIPTION
A Rollup object should be invalid if `interval=None` and `totals=None | False`. Since in MQL, a False or None rollup query mean the same thing.