### PR TITLE
feat: new BaseQuery, DeleteQuery which will be used to make delete queries

### DIFF
--- a/snuba_sdk/delete_query.py
+++ b/snuba_sdk/delete_query.py
@@ -1,0 +1,46 @@
+import json
+from dataclasses import dataclass
+from typing import Any, Dict, List, Union
+
+from snuba_sdk.query import BaseQuery
+
+
+@dataclass(frozen=True)
+class DeleteQuery(BaseQuery):
+    """
+    This represents a snuba delete query.
+    Inputs:
+        storage - the storage to delete from
+        columnConditions - a mapping from column-name to a list of column values
+            that defines the delete conditions. ex:
+            {
+                "id": [1, 2, 3]
+                "status": ["failed"]
+            }
+            represents
+            DELETE FROM ... WHERE id in (1,2,3) AND status='failed'
+    Deletes all rows in the given storage, that satisfy the conditions
+    defined in 'columnConditions'.
+    """
+
+    storage_name: str
+    column_conditions: Dict[str, List[Any]]
+
+    def validate(self) -> None:
+        """
+        i dont think we need to do any input validation at the sdk
+        level bc inputs will be validated at the endpoint and the proper
+        response code returned.
+        """
+        return
+
+    def serialize(self) -> Union[str, Dict[str, Any]]:
+        # the body of the request
+        self.validate()
+        return json.dumps({"columns": self.column_conditions})
+
+    def print(self) -> str:
+        return repr(self)
+
+    def __repr__(self) -> str:
+        return f"DeleteQuery(storage_name={repr(self.storage_name)}, columnsConditions={repr(self.column_conditions)})"

--- a/snuba_sdk/delete_query.py
+++ b/snuba_sdk/delete_query.py
@@ -31,12 +31,14 @@ class DeleteQuery(BaseQuery):
     column_conditions: Dict[str, List[Union[str, int]]]
 
     def validate(self) -> None:
-        if "project_id" not in self.column_conditions:
-            raise InvalidDeleteQueryError(
-                "missing required column condition on 'project_id'"
-            )
-        elif len(self.column_conditions["project_id"]) == 0:
-            raise InvalidDeleteQueryError("column condition on 'project_id' is empty")
+        if self.column_conditions == {}:
+            raise InvalidDeleteQueryError("column conditions cannot be empty")
+
+        for col, values in self.column_conditions.items():
+            if len(values) == 0:
+                raise InvalidDeleteQueryError(
+                    f"column condition '{col}' cannot be empty"
+                )
 
     def serialize(self) -> Union[str, Dict[str, Any]]:
         # the body of the request

--- a/snuba_sdk/delete_query.py
+++ b/snuba_sdk/delete_query.py
@@ -5,6 +5,10 @@ from typing import Any, Dict, List, Union
 from snuba_sdk.query import BaseQuery
 
 
+class InvalidDeleteQueryError(Exception):
+    pass
+
+
 @dataclass(frozen=True)
 class DeleteQuery(BaseQuery):
     """
@@ -24,15 +28,15 @@ class DeleteQuery(BaseQuery):
     """
 
     storage_name: str
-    column_conditions: Dict[str, List[Any]]
+    column_conditions: Dict[str, List[Union[str, int]]]
 
     def validate(self) -> None:
-        """
-        i dont think we need to do any input validation at the sdk
-        level bc inputs will be validated at the endpoint and the proper
-        response code returned.
-        """
-        return
+        if "project_id" not in self.column_conditions:
+            raise InvalidDeleteQueryError(
+                "missing required column condition on 'project_id'"
+            )
+        elif len(self.column_conditions["project_id"]) == 0:
+            raise InvalidDeleteQueryError("column condition on 'project_id' is empty")
 
     def serialize(self) -> Union[str, Dict[str, Any]]:
         # the body of the request

--- a/tests/test_delete_query.py
+++ b/tests/test_delete_query.py
@@ -8,7 +8,7 @@ from snuba_sdk.delete_query import DeleteQuery, InvalidDeleteQueryError
 def test_serialize() -> None:
     # im doing the json.loads to ignore things like formatting
     query = DeleteQuery(
-        storage_name="search_issues",
+        storage_name="non-real-storage",
         column_conditions={"project_id": [1], "occurrence_id": ["1234"]},
     )
     expected = '{"columns":{"project_id": [1], "occurrence_id": ["1234"]}}'
@@ -18,24 +18,24 @@ def test_serialize() -> None:
     assert json.loads(serialize) == json.loads(expected)
 
 
-def test_missing_project_id() -> None:
+def test_empty_column_conditions() -> None:
     query = DeleteQuery(
-        storage_name="non-real-storage",
+        storage_name="search_issues",
         column_conditions={},
     )
     with pytest.raises(
         InvalidDeleteQueryError,
-        match="missing required column condition on 'project_id'",
+        match="column conditions cannot be empty",
     ):
         query.serialize()
 
 
-def test_empty_project_id() -> None:
+def test_single_empty_column_condition() -> None:
     query = DeleteQuery(
         storage_name="search_issues",
         column_conditions={"project_id": []},
     )
     with pytest.raises(
-        InvalidDeleteQueryError, match="column condition on 'project_id' is empty"
+        InvalidDeleteQueryError, match="column condition 'project_id' cannot be empty"
     ):
         query.serialize()

--- a/tests/test_delete_query.py
+++ b/tests/test_delete_query.py
@@ -23,9 +23,11 @@ def test_missing_project_id() -> None:
         storage_name="non-real-storage",
         column_conditions={},
     )
-    with pytest.raises(InvalidDeleteQueryError) as e:
+    with pytest.raises(
+        InvalidDeleteQueryError,
+        match="missing required column condition on 'project_id'",
+    ):
         query.serialize()
-        assert e.value == "missing required column condition on 'project_id'"
 
 
 def test_empty_project_id() -> None:
@@ -33,6 +35,7 @@ def test_empty_project_id() -> None:
         storage_name="search_issues",
         column_conditions={"project_id": []},
     )
-    with pytest.raises(InvalidDeleteQueryError) as e:
+    with pytest.raises(
+        InvalidDeleteQueryError, match="column condition on 'project_id' is empty"
+    ):
         query.serialize()
-        assert e.value == "column condition on 'project_id' is empty"

--- a/tests/test_delete_query.py
+++ b/tests/test_delete_query.py
@@ -1,0 +1,31 @@
+import json
+
+import pytest
+
+from snuba_sdk.delete_query import DeleteQuery
+
+queries = [
+    pytest.param(
+        DeleteQuery(
+            storage_name="search_issues",
+            column_conditions={"project_id": [1], "occurrence_id": ["1234"]},
+        ),
+        '{"columns":{"project_id": [1], "occurrence_id": ["1234"]}}',
+    ),
+    pytest.param(
+        DeleteQuery(
+            storage_name="non-real-storage",
+            column_conditions={},
+        ),
+        '{"columns":{}}',
+    ),
+]
+
+
+@pytest.mark.parametrize("query, expected", queries)
+def test_serializes_properly(query: DeleteQuery, expected: str) -> None:
+    # im doing the json.loads to ignore things like formatting
+    actual = query.serialize()
+    if not isinstance(actual, str):
+        actual = json.dumps(actual)
+    assert json.loads(actual) == json.loads(expected)


### PR DESCRIPTION
This PR adds a new subclass of `BaseQuery`, called `DeleteQuery`. This will be used inside a `Request` object for sdk users to create delete queries to send to snuba. Like this:

```
# create a snuba-sdk request object, query type DeleteQuery
request = Request(
    dataset = "search_issues",
    app_id = "myappid",
    tenant_ids = {"referrer": "my_referrer", "organization_id": 1234}
    query = DeleteQuery(
		    storage="search_issues"
		    columnConditions={
			    "project_id": [1],
			    "occurrence_id": UUID
		    }
    )
)

# use a function like raw_snql_query to send the request object to snuba
raw_snql_query(request, ...)
```

Next Steps: 
* change `raw_snql_query` to know what to do when the query type of a request is DeleteQuery
* update snuba to the new sdk