### PR TITLE
fix: DeleteQuery, send query as a dict

### DIFF
--- a/snuba_sdk/delete_query.py
+++ b/snuba_sdk/delete_query.py
@@ -1,4 +1,3 @@
-import json
 from dataclasses import dataclass
 from typing import Any, Dict, List, Union
 

--- a/snuba_sdk/delete_query.py
+++ b/snuba_sdk/delete_query.py
@@ -43,7 +43,7 @@ class DeleteQuery(BaseQuery):
     def serialize(self) -> Union[str, Dict[str, Any]]:
         # the body of the request
         self.validate()
-        return json.dumps({"columns": self.column_conditions})
+        return {"columns": self.column_conditions}
 
     def print(self) -> str:
         return repr(self)

--- a/snuba_sdk/request.py
+++ b/snuba_sdk/request.py
@@ -84,6 +84,10 @@ class Request:
             mql_context = serialized_mql["mql_context"]
             query = str(serialized_mql["mql"])
         elif isinstance(self.query, DeleteQuery):
+            """
+            for a DeleteQuery, the query is not a snql/mql string,
+            it is a dict
+            """
             return {
                 **flags,
                 "query": self.query.serialize(),

--- a/snuba_sdk/request.py
+++ b/snuba_sdk/request.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 import re
 from dataclasses import asdict, dataclass, field, fields
-from typing import Mapping
+from typing import Any, Dict, Mapping, Union
 
 from snuba_sdk.metrics_query import MetricsQuery
 from snuba_sdk.query import BaseQuery
@@ -81,9 +81,9 @@ class Request:
             serialized_mql = self.query.serialize()
             assert isinstance(serialized_mql, dict)  # mypy
             mql_context = serialized_mql["mql_context"]
-            query = str(serialized_mql["mql"])
+            query: Union[str, Dict[str, Any]] = str(serialized_mql["mql"])
         else:
-            query = str(self.query.serialize())
+            query = self.query.serialize()
 
         ret: dict[str, object] = {
             **flags,

--- a/snuba_sdk/request.py
+++ b/snuba_sdk/request.py
@@ -5,6 +5,7 @@ import re
 from dataclasses import asdict, dataclass, field, fields
 from typing import Any, Dict, Mapping, Union
 
+from snuba_sdk.delete_query import DeleteQuery
 from snuba_sdk.metrics_query import MetricsQuery
 from snuba_sdk.query import BaseQuery
 
@@ -82,8 +83,16 @@ class Request:
             assert isinstance(serialized_mql, dict)  # mypy
             mql_context = serialized_mql["mql_context"]
             query: Union[str, Dict[str, Any]] = str(serialized_mql["mql"])
+        elif isinstance(self.query, DeleteQuery):
+            return {
+                **flags,
+                "query": self.query.serialize(),
+                "app_id": self.app_id,
+                "tenant_ids": self.tenant_ids,
+                "parent_api": self.parent_api,
+            }
         else:
-            query = self.query.serialize()
+            query = str(self.query.serialize())
 
         ret: dict[str, object] = {
             **flags,

--- a/snuba_sdk/request.py
+++ b/snuba_sdk/request.py
@@ -82,7 +82,7 @@ class Request:
             serialized_mql = self.query.serialize()
             assert isinstance(serialized_mql, dict)  # mypy
             mql_context = serialized_mql["mql_context"]
-            query: Union[str, Dict[str, Any]] = str(serialized_mql["mql"])
+            query = str(serialized_mql["mql"])
         elif isinstance(self.query, DeleteQuery):
             return {
                 **flags,

--- a/snuba_sdk/request.py
+++ b/snuba_sdk/request.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 import re
 from dataclasses import asdict, dataclass, field, fields
-from typing import Any, Dict, Mapping, Union
+from typing import Mapping
 
 from snuba_sdk.delete_query import DeleteQuery
 from snuba_sdk.metrics_query import MetricsQuery

--- a/tests/test_delete_query.py
+++ b/tests/test_delete_query.py
@@ -28,7 +28,6 @@ def test_serialize_request() -> None:
     )
     expected = {
         "query": {"columns": {"project_id": [1], "occurrence_id": ["1234"]}},
-        "dataset": "search_issues",
         "app_id": "myapp",
         "tenant_ids": {},
         "parent_api": "<unknown>",

--- a/tests/test_delete_query.py
+++ b/tests/test_delete_query.py
@@ -3,6 +3,7 @@ import json
 import pytest
 
 from snuba_sdk.delete_query import DeleteQuery, InvalidDeleteQueryError
+from snuba_sdk.request import Request
 
 
 def test_serialize() -> None:
@@ -11,11 +12,28 @@ def test_serialize() -> None:
         storage_name="non-real-storage",
         column_conditions={"project_id": [1], "occurrence_id": ["1234"]},
     )
-    expected = '{"columns":{"project_id": [1], "occurrence_id": ["1234"]}}'
+    expected = {"columns": {"project_id": [1], "occurrence_id": ["1234"]}}
     serialize = query.serialize()
-    assert isinstance(serialize, str)
-    # json.loads is so whitespace and stuff is ignored
-    assert json.loads(serialize) == json.loads(expected)
+    assert serialize == expected
+
+
+def test_serialize_request() -> None:
+    req = Request(
+        dataset="search_issues",
+        app_id="myapp",
+        query=DeleteQuery(
+            storage_name="search_issues",
+            column_conditions={"project_id": [1], "occurrence_id": ["1234"]},
+        ),
+    )
+    expected = {
+        "query": {"columns": {"project_id": [1], "occurrence_id": ["1234"]}},
+        "dataset": "search_issues",
+        "app_id": "myapp",
+        "tenant_ids": {},
+        "parent_api": "<unknown>",
+    }
+    assert json.loads(req.serialize()) == expected
 
 
 def test_empty_column_conditions() -> None:


### PR DESCRIPTION
The SDK was used to connect sentry to a delete endpoint in snuba. We ran into an issue however where the SDK was serializing the body of the request into a str when our data is actually a dict. This change makes it send the object as a dict now instead of a str.

Additionally we want to not send the dataset since its not required for this endpoint.