### PR TITLE
feat(replay): add replays required timestamp col to ENTITY_TIME_COLUMNS

### DIFF
--- a/snuba_sdk/entity.py
+++ b/snuba_sdk/entity.py
@@ -47,17 +47,17 @@ class Entity(Expression):
 # TODO: This should be handled by the users of the SDK, not the SDK itself.
 ENTITY_TIME_COLUMNS = {
     "discover": "timestamp",
+    "discover_events": "timestamp",
+    "discover_transactions": "finish_ts",
     "errors": "timestamp",
     "events": "timestamp",
-    "discover_events": "timestamp",
     "outcomes": "timestamp",
     "outcomes_raw": "timestamp",
-    "sessions": "started",
-    "transactions": "finish_ts",
-    "discover_transactions": "finish_ts",
-    "discover_events": "timestamp",
-    "spans": "finish_ts",
+    "replays": "timestamp",
     "search_issues": "timestamp",
+    "sessions": "started",
+    "spans": "finish_ts",
+    "transactions": "finish_ts",
 }
 
 


### PR DESCRIPTION
We need this for [this query](https://github.com/getsentry/sentry/blob/a49edf8ae43666338ccb0d9992fd4e7148c8fb13/src/sentry/tagstore/snuba/backend.py#L318) in Sentry's tagstore backend. Currently the `replays` entity does not support auto-filling the timestamp conditions, and we get 400 bad request, `"detail": "Missing >= condition with a datetime literal on column timestamp for entity replays. Example: timestamp >= toDateTime('2023-05-16 00:00')"`.

(The autofilling is done in snuba_sdk's `json_to_snql` function.)

Impact: we can't search for custom tags in the replays dataset until we release this, and bump sentry's snuba-sdk version.